### PR TITLE
Add coloured states in index and show views

### DIFF
--- a/console-frontend/src/app/resources/expositions.js
+++ b/console-frontend/src/app/resources/expositions.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import StatusField from './status-field'
 import {
   Create,
   Datagrid,
@@ -20,10 +21,10 @@ export const ExpositionShow = props => (
     <SimpleShowLayout>
       <TextField source="id" />
       <TextField source="description" />
-      <TextField source="status" />
       <TextField source="ctaText" />
       <TextField source="ctaUrl" />
       <TextField source="domain" />
+      <StatusField source="status" />
     </SimpleShowLayout>
   </Show>
 )
@@ -33,7 +34,7 @@ export const ExpositionsList = ({ ...props }) => (
     <Datagrid>
       <TextField source="id" />
       <TextField source="description" />
-      <TextField source="status" />
+      <StatusField source="status" />
       <TextField source="ctaText" />
       <TextField source="ctaUrl" />
       <TextField source="domain" />

--- a/console-frontend/src/app/resources/status-field.js
+++ b/console-frontend/src/app/resources/status-field.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { ChipField } from 'react-admin'
+
+var statusStyles = {
+  DRAFT: {
+    background: '#4a90e2',
+    color: '#fff',
+  },
+  PUBLISHED: {
+    background: '#04fb50',
+    color: '#fff',
+  },
+  ARCHIVED: {
+    background: '#fb7604',
+    color: '#fff',
+  },
+}
+
+const StatusField = ({ source, record = {} }) => {
+  return <ChipField record={record} source={source} style={statusStyles[record.status]} />
+}
+
+export default StatusField


### PR DESCRIPTION
Added coloured Chips as a status indicator in Index and Show views of expositions.
Done by adding a custom component (statusField.js) to the resources folder.