### PR TITLE
Use router in console-frontend

### DIFF
--- a/console-frontend/src/app/index.js
+++ b/console-frontend/src/app/index.js
@@ -8,6 +8,7 @@ import PasswordReset from 'app/screens/password-reset'
 import React from 'react'
 import RequestPasswordReset from 'app/screens/password-reset/request-password-reset'
 import { Route } from 'react-router-dom'
+import routes from './routes'
 import WebsiteEdit from './resources/websites'
 import { Admin, Resource } from 'react-admin'
 import auth, { authProvider } from 'app/auth'
@@ -21,13 +22,13 @@ const jss = create({
   insertionPoint: document.getElementById('jss-insertion-point'),
 })
 
-const routes = [
-  <Route component={RequestPasswordReset} exact key="passwordReset" noLayout path="/request_password_reset" />,
-  <Route component={PasswordReset} exact key="passwordReset" noLayout path="/password_reset" />,
+const customRoutes = [
+  <Route component={RequestPasswordReset} exact key="passwordReset" noLayout path={routes.requestPasswordReset()} />,
+  <Route component={PasswordReset} exact key="passwordReset" noLayout path={routes.passwordReset()} />,
   <Route
     exact
     key="account"
-    path="/account"
+    path={routes.account()}
     render={() => (
       <WebsiteEdit basePath="/Website" id={auth.getUser().websiteRef} location={{}} match={{}} resource="Website" />
     )}
@@ -40,7 +41,7 @@ const App = ({ dataProvider, history }) => (
       appLayout={Layout}
       authProvider={authProvider}
       catchAll={NotFound}
-      customRoutes={routes}
+      customRoutes={customRoutes}
       dataProvider={dataProvider.dataProvider}
       history={history}
       loginPage={LoginPage}

--- a/console-frontend/src/app/layout/user-menu.js
+++ b/console-frontend/src/app/layout/user-menu.js
@@ -4,6 +4,7 @@ import auth from 'app/auth'
 import Avatar from '@material-ui/core/Avatar'
 import ExitIcon from '@material-ui/icons/PowerSettingsNew'
 import IconButton from '@material-ui/core/IconButton'
+import Link from 'shared/link'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import React from 'react'
@@ -11,7 +12,7 @@ import routes from 'app/routes'
 import SettingsIcon from '@material-ui/icons/Settings'
 import { compose, withHandlers, withProps, withState } from 'recompose'
 
-const UserMenu = ({ onAccountButtonClick, initials, onLogoutButtonClick, anchorEl, handleMenu, handleClose, open }) => (
+const UserMenu = ({ initials, onLogoutButtonClick, anchorEl, handleMenu, handleClose, open }) => (
   <React.Fragment>
     <IconButton aria-haspopup="true" aria-owns={open ? 'menu-appbar' : null} color="inherit" onClick={handleMenu}>
       {initials ? <Avatar>{initials}</Avatar> : <AccountCircle />}
@@ -31,10 +32,12 @@ const UserMenu = ({ onAccountButtonClick, initials, onLogoutButtonClick, anchorE
       }}
     >
       <MenuItem disabled>{auth.getDisplayName() || auth.getEmail()}</MenuItem>
-      <MenuItem onClick={onAccountButtonClick}>
-        <SettingsIcon style={{ marginRight: '0.5rem' }} />
-        {'Account'}
-      </MenuItem>
+      <Link to={routes.account()}>
+        <MenuItem>
+          <SettingsIcon style={{ marginRight: '0.5rem' }} />
+          {'Account'}
+        </MenuItem>
+      </Link>
       <MenuItem onClick={onLogoutButtonClick}>
         <ExitIcon style={{ marginRight: '0.5rem' }} /> {'Logout'}
       </MenuItem>
@@ -56,10 +59,6 @@ export default compose(
     handleMenu: ({ setAnchorEl }) => event => {
       event.preventDefault()
       setAnchorEl(event.currentTarget)
-    },
-    onAccountButtonClick: () => event => {
-      event.preventDefault()
-      window.location.href = routes.account()
     },
     onLogoutButtonClick: () => async event => {
       event.preventDefault()

--- a/console-frontend/src/shared/link.js
+++ b/console-frontend/src/shared/link.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Link as RouteLink } from 'react-router-dom'
+
+const Link = ({ to = '/', children }) => {
+  return (
+    <RouteLink style={{ textDecoration: 'none' }} to={to}>
+      {children}
+    </RouteLink>
+  )
+}
+
+export default Link


### PR DESCRIPTION
Replaced the default link by the Link component from the Router. So when you click on that link it doesn't makes refresh on the browser, it uses Router instead and stays on the same page.