### PR TITLE
Use single component for notifications in console-frontend

### DIFF
--- a/console-frontend/src/app/screens/change-password/index.js
+++ b/console-frontend/src/app/screens/change-password/index.js
@@ -6,20 +6,15 @@ import Input from '@material-ui/core/Input'
 import InputLabel from '@material-ui/core/InputLabel'
 import React from 'react'
 import routes from 'app/routes'
-import Typography from '@material-ui/core/Typography'
 import { withRouter } from 'react-router'
 import { compose, withHandlers, withState } from 'recompose'
-import { StyledButton, StyledForm } from '../shared'
+import { Notification, StyledButton, StyledForm } from '../shared'
 
-const ChangePassword = ({ errors, passwordForm, passwordResetSubmit, setFieldValue, location }) => (
+const ChangePassword = ({ info, passwordForm, passwordResetSubmit, setFieldValue, location }) => (
   <Authenticated location={location}>
     <AuthLayout title="Change Password">
       <StyledForm onSubmit={passwordResetSubmit}>
-        {errors && (
-          <Typography align="center" color="error" variant="body2">
-            {errors}
-          </Typography>
-        )}
+        <Notification data={info} />
         <FormControl fullWidth margin="normal" required>
           <InputLabel htmlFor="currentPassword">{'Current Password'}</InputLabel>
           <Input
@@ -59,10 +54,10 @@ export default compose(
     password: '',
     passwordConfirmation: '',
   }),
-  withState('errors', 'setErrors', null),
+  withState('info', 'setInfo', null),
   withRouter,
   withHandlers({
-    passwordResetSubmit: ({ passwordForm, setErrors, history }) => async event => {
+    passwordResetSubmit: ({ passwordForm, setInfo, history }) => async event => {
       event.preventDefault()
       if (passwordForm.password === passwordForm.passwordConfirmation) {
         const success = await apiPasswordChange(
@@ -73,11 +68,11 @@ export default compose(
               password_confirmation: passwordForm.passwordConfirmation,
             },
           },
-          setErrors
+          setInfo
         )
         if (success) history.push(routes.root())
       } else {
-        setErrors("New passwords don't match")
+        setInfo({ message: "New passwords don't match", status: 'error' })
       }
     },
     setFieldValue: ({ setPasswordForm, passwordForm }) => event => {

--- a/console-frontend/src/app/screens/forgot-password/index.js
+++ b/console-frontend/src/app/screens/forgot-password/index.js
@@ -6,19 +6,14 @@ import Input from '@material-ui/core/Input'
 import InputLabel from '@material-ui/core/InputLabel'
 import queryString from 'query-string'
 import React from 'react'
-import Typography from '@material-ui/core/Typography'
 import { compose, withHandlers, withState } from 'recompose'
-import { StyledButton, StyledForm } from '../shared'
+import { Notification, StyledButton, StyledForm } from '../shared'
 
-const PasswordReset = ({ errors, passwordForm, passwordResetSubmit, setFieldValue, location }) => (
+const PasswordReset = ({ info, passwordForm, passwordResetSubmit, setFieldValue, location }) => (
   <Authenticated location={location}>
     <AuthLayout title="Reset Password">
       <StyledForm onSubmit={passwordResetSubmit}>
-        {errors && (
-          <Typography align="center" color="error" variant="body2">
-            {errors}
-          </Typography>
-        )}
+        <Notification data={info} />
         <FormControl fullWidth margin="normal" required>
           <InputLabel htmlFor="email">{'New Password'}</InputLabel>
           <Input
@@ -56,9 +51,9 @@ export default compose(
     fieldOne: '',
     fieldTwo: '',
   }),
-  withState('errors', 'setErrors', null),
+  withState('info', 'setInfo', null),
   withHandlers({
-    passwordResetSubmit: ({ passwordForm, setErrors }) => async event => {
+    passwordResetSubmit: ({ passwordForm, setInfo }) => async event => {
       event.preventDefault()
       const parsedUrl = queryString.parse(window.location.search)
       if (passwordForm.fieldOne === passwordForm.fieldTwo) {
@@ -69,10 +64,10 @@ export default compose(
               reset_password_token: parsedUrl.reset_password_token,
             },
           },
-          setErrors
+          setInfo
         )
       } else {
-        setErrors("Passwords don't match")
+        setInfo("Passwords don't match")
       }
     },
     setFieldValue: ({ setPasswordForm, passwordForm }) => event => {

--- a/console-frontend/src/app/screens/forgot-password/request-password-reset.js
+++ b/console-frontend/src/app/screens/forgot-password/request-password-reset.js
@@ -6,23 +6,13 @@ import InputLabel from '@material-ui/core/InputLabel'
 import Link from 'shared/link'
 import React from 'react'
 import routes from 'app/routes'
-import Typography from '@material-ui/core/Typography'
 import { compose, withHandlers, withState } from 'recompose'
 import { Notification, StyledButton, StyledForm } from '../shared'
 
-const PasswordReset = ({ passwordForm, passwordChangeSubmit, setPasswordFormValue, notification, errors }) => (
+const PasswordReset = ({ passwordForm, passwordChangeSubmit, setPasswordFormValue, info }) => (
   <AuthLayout title="Reset Password">
     <StyledForm onSubmit={passwordChangeSubmit}>
-      {notification && (
-        <Notification align="center" variant="body2">
-          {notification}
-        </Notification>
-      )}
-      {errors && (
-        <Typography align="center" color="error" variant="body2">
-          {errors}
-        </Typography>
-      )}
+      <Notification data={info} />
       <FormControl fullWidth margin="normal" required>
         <InputLabel htmlFor="password">{'Email'}</InputLabel>
         <Input
@@ -48,16 +38,15 @@ const PasswordReset = ({ passwordForm, passwordChangeSubmit, setPasswordFormValu
 
 export default compose(
   withState('passwordForm', 'setPasswordForm', { email: '' }),
-  withState('notification', 'setNotification', null),
-  withState('errors', 'setErrors', null),
+  withState('info', 'setInfo', null),
   withHandlers({
     onBackToLogin: () => event => {
       event.preventDefault()
       window.location.href = routes.login()
     },
-    passwordChangeSubmit: ({ passwordForm, setNotification, setErrors }) => async event => {
+    passwordChangeSubmit: ({ passwordForm, setInfo }) => async event => {
       event.preventDefault()
-      await apiPasswordEmailLink({ user: { email: passwordForm.email } }, setErrors, setNotification)
+      await apiPasswordEmailLink({ user: { email: passwordForm.email } }, setInfo)
     },
     setPasswordFormValue: ({ passwordForm, setPasswordForm }) => event =>
       setPasswordForm({

--- a/console-frontend/src/app/screens/login/index.js
+++ b/console-frontend/src/app/screens/login/index.js
@@ -7,18 +7,13 @@ import InputLabel from '@material-ui/core/InputLabel'
 import Link from 'shared/link'
 import React from 'react'
 import routes from 'app/routes'
-import Typography from '@material-ui/core/Typography'
 import { compose, withHandlers, withState } from 'recompose'
-import { StyledButton, StyledForm } from '../shared'
+import { Notification, StyledButton, StyledForm } from '../shared'
 
-const Login = ({ errors, loginForm, loginSubmit, setLoginValue }) => (
+const Login = ({ info, loginForm, loginSubmit, setLoginValue }) => (
   <AuthLayout title="Log in">
     <StyledForm onSubmit={loginSubmit}>
-      {errors && (
-        <Typography align="center" color="error" variant="body2">
-          {errors}
-        </Typography>
-      )}
+      <Notification data={info} />
       <FormControl fullWidth margin="normal" required>
         <InputLabel htmlFor="email">{'Email Address'}</InputLabel>
         <Input
@@ -56,11 +51,11 @@ const Login = ({ errors, loginForm, loginSubmit, setLoginValue }) => (
 
 export default compose(
   withState('loginForm', 'setLoginForm', { email: '', password: '' }),
-  withState('errors', 'setErrors', null),
+  withState('info', 'setInfo', null),
   withHandlers({
-    loginSubmit: ({ loginForm, setErrors }) => async event => {
+    loginSubmit: ({ loginForm, setInfo }) => async event => {
       event.preventDefault()
-      await apiSignIn({ user: { email: loginForm.email, password: loginForm.password } }, setErrors)
+      await apiSignIn({ user: { email: loginForm.email, password: loginForm.password } }, setInfo)
       if (auth.isLoggedIn()) {
         window.location.href = routes.root()
       }

--- a/console-frontend/src/app/screens/shared.js
+++ b/console-frontend/src/app/screens/shared.js
@@ -1,6 +1,7 @@
 import Avatar from '@material-ui/core/Avatar'
 import Button from '@material-ui/core/Button'
 import Paper from '@material-ui/core/Paper'
+import React from 'react'
 import styled from 'styled-components'
 import Typography from '@material-ui/core/Typography'
 
@@ -26,9 +27,27 @@ const Main = styled.main`
   }
 `
 
-const Notification = styled(Typography)`
-  color: #00ae5f;
-`
+const Notification = ({ data }) => {
+  const commonStyle = {
+    fontWeight: 700,
+  }
+  const styles = {
+    error: {
+      color: '#f44',
+    },
+    success: {
+      color: '#4f7',
+    },
+  }
+  const status = data ? data.status : null
+  const message = data ? data.message : null
+  const currentStyle = { ...commonStyle, ...styles[status] }
+  return (
+    <Typography align="center" style={currentStyle} variant="body2">
+      {message}
+    </Typography>
+  )
+}
 
 const StyledPaper = styled(Paper)`
   align-items: center;


### PR DESCRIPTION
Changed the logic for showing notifications in login, sign-in, password change, password reset forms. Now it uses a single component. That component receives an attribute which in result determines the color of the notification.
Note: changed the order of functions in utils.js to make it more readable.