### PR TITLE
Fix ImageCropper aspect ratio issue on small screens

### DIFF
--- a/console-frontend/src/shared/picture-uploader.js
+++ b/console-frontend/src/shared/picture-uploader.js
@@ -180,6 +180,7 @@ const BarebonesPictureUploader = ({
         <HiddenImg alt="" ref={setImagePreviewRef} src={image.preview} />
         <StyledReactCrop
           crop={crop}
+          imageStyle={{ maxHeight: 'initial' }}
           keepSelection
           minHeight={20}
           minWidth={20}


### PR DESCRIPTION
https://trello.com/c/6lIcHYn4/402-imagecropper-try-it-with-very-small-window-height

**Fixed:** 
<img width="643" alt="captura de ecra 2018-11-13 as 10 18 19" src="https://user-images.githubusercontent.com/35154956/48406880-81154700-e72d-11e8-9e96-76433bead4d8.png">
