### PR TITLE
Remove title and subtitle from websites

### DIFF
--- a/backend/app/controllers/websites_controller.rb
+++ b/backend/app/controllers/websites_controller.rb
@@ -21,6 +21,6 @@ class WebsitesController < ApplicationController
   private
 
   def website_params
-    params.require(:website).permit(:name, :title, :subtitle, hostnames: [])
+    params.require(:website).permit(:name, hostnames: [])
   end
 end

--- a/backend/app/graphql/types/website_type.rb
+++ b/backend/app/graphql/types/website_type.rb
@@ -4,6 +4,4 @@ Types::WebsiteType = GraphQL::ObjectType.define do
   field :id, !types.ID
   # field :status, Types::StatusType
   field :name, types.String
-  field :title, types.String
-  field :subtitle, types.String
 end

--- a/backend/app/models/website.rb
+++ b/backend/app/models/website.rb
@@ -4,7 +4,6 @@ class Website < ApplicationRecord
   belongs_to :account
 
   validates :name, presence: true, uniqueness: true
-  validates :title, presence: true
   validates :hostnames, presence: true
   validate :hostnames_cannot_be_blank
   validate :hostnames_cannot_be_repeated

--- a/backend/db/migrate/20181119142143_remove_title_and_subtitle_from_websites.rb
+++ b/backend/db/migrate/20181119142143_remove_title_and_subtitle_from_websites.rb
@@ -1,0 +1,6 @@
+class RemoveTitleAndSubtitleFromWebsites < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :websites, :title, :string
+    remove_column :websites, :subtitle, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181119124758) do
+ActiveRecord::Schema.define(version: 20181119142143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,8 +122,6 @@ ActiveRecord::Schema.define(version: 20181119124758) do
 
   create_table "websites", force: :cascade do |t|
     t.string "name", null: false
-    t.string "title", null: false
-    t.string "subtitle"
     t.string "hostnames", null: false, array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Removed `title` and `subtitle` from `websites` table.

- Removed from controllers, models, and types also.