### PR TITLE
Rename Chat to ScriptedChat; rename foreign key; remove path column

### DIFF
--- a/backend/app/models/chat.rb
+++ b/backend/app/models/chat.rb
@@ -1,6 +1,0 @@
-class Chat < ApplicationRecord
-  has_one :first_chat_step, foreign_key: "chat_id", class_name: "ChatStep"
-
-  validates :path, presence: true
-  validates :title, presence: true
-end

--- a/backend/app/models/chat_step.rb
+++ b/backend/app/models/chat_step.rb
@@ -1,6 +1,5 @@
 class ChatStep < ApplicationRecord
-  belongs_to :chat
-  belongs_to :chat_option
+  belongs_to :scripted_chat
   has_many :chat_messages
   has_many :chat_options
   has_many :refering_chat_options, foreign_key: "destinaton_chat_step_id", class_name: "ChatOption"

--- a/backend/app/models/scripted_chat.rb
+++ b/backend/app/models/scripted_chat.rb
@@ -1,0 +1,6 @@
+class ScriptedChat < ApplicationRecord
+  has_one :first_chat_step, foreign_key: "scripted_chat_id", class_name: "ChatStep"
+
+  validates :path, presence: true
+  validates :title, presence: true
+end

--- a/backend/db/migrate/20181119143154_change_chats_to_scripted_chats.rb
+++ b/backend/db/migrate/20181119143154_change_chats_to_scripted_chats.rb
@@ -1,0 +1,5 @@
+class ChangeChatsToScriptedChats < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :chats, :scripted_chats
+  end
+end

--- a/backend/db/migrate/20181119144026_change_chat_foreign_key_for_chat_steps.rb
+++ b/backend/db/migrate/20181119144026_change_chat_foreign_key_for_chat_steps.rb
@@ -1,0 +1,5 @@
+class ChangeChatForeignKeyForChatSteps < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :chat_steps, :chat_id, :scripted_chat_id
+  end
+end

--- a/backend/db/migrate/20181119152010_remove_path_from_scripted_chats.rb
+++ b/backend/db/migrate/20181119152010_remove_path_from_scripted_chats.rb
@@ -1,0 +1,5 @@
+class RemovePathFromScriptedChats < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :scripted_chats, :path, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181119142143) do
+ActiveRecord::Schema.define(version: 20181119152010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,25 +59,14 @@ ActiveRecord::Schema.define(version: 20181119142143) do
   create_table "chat_steps", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "chat_id"
+    t.bigint "scripted_chat_id"
     t.bigint "account_id"
     t.bigint "chat_option_id"
     t.bigint "refering_chat_option_id"
     t.index ["account_id"], name: "index_chat_steps_on_account_id"
-    t.index ["chat_id"], name: "index_chat_steps_on_chat_id"
     t.index ["chat_option_id"], name: "index_chat_steps_on_chat_option_id"
     t.index ["refering_chat_option_id"], name: "index_chat_steps_on_refering_chat_option_id"
-  end
-
-  create_table "chats", force: :cascade do |t|
-    t.string "path", null: false
-    t.string "title", null: false
-    t.bigint "influencer_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "account_id"
-    t.index ["account_id"], name: "index_chats_on_account_id"
-    t.index ["influencer_id"], name: "index_chats_on_influencer_id"
+    t.index ["scripted_chat_id"], name: "index_chat_steps_on_scripted_chat_id"
   end
 
   create_table "influencers", force: :cascade do |t|
@@ -88,6 +77,16 @@ ActiveRecord::Schema.define(version: 20181119142143) do
     t.datetime "updated_at", null: false
     t.bigint "account_id", null: false
     t.index ["account_id"], name: "index_influencers_on_account_id"
+  end
+
+  create_table "scripted_chats", force: :cascade do |t|
+    t.string "title", null: false
+    t.bigint "influencer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id"
+    t.index ["account_id"], name: "index_scripted_chats_on_account_id"
+    t.index ["influencer_id"], name: "index_scripted_chats_on_influencer_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -139,10 +138,10 @@ ActiveRecord::Schema.define(version: 20181119142143) do
   add_foreign_key "chat_steps", "accounts"
   add_foreign_key "chat_steps", "chat_options"
   add_foreign_key "chat_steps", "chat_options", column: "refering_chat_option_id"
-  add_foreign_key "chat_steps", "chats"
-  add_foreign_key "chats", "accounts"
-  add_foreign_key "chats", "influencers"
+  add_foreign_key "chat_steps", "scripted_chats"
   add_foreign_key "influencers", "accounts"
+  add_foreign_key "scripted_chats", "accounts"
+  add_foreign_key "scripted_chats", "influencers"
   add_foreign_key "users", "accounts"
   add_foreign_key "websites", "accounts"
 end


### PR DESCRIPTION
- Renamed chats table to scripted_chats
- Rename chat_id foreign key in chat_steps table to scripted_chat_id
- Remove path:string column from scripted_chats table

https://trello.com/c/WNaMX9hg/425-rename-chat-to-scriptedchat-remove-path-field-and-website-reference-from-it