### PR TITLE
Fix layout rendering without authentication

### DIFF
--- a/console-frontend/src/app/index.js
+++ b/console-frontend/src/app/index.js
@@ -9,7 +9,6 @@ import NotFound from 'app/screens/not-found'
 import React from 'react'
 import RequestPasswordReset from 'auth/forgot-password/request-password-reset'
 import routes from './routes'
-import theme from './theme'
 import { create } from 'jss'
 import { createGenerateClassName, jssPreset } from '@material-ui/core/styles'
 import { PersonaCreate, PersonaEdit, PersonaShow, PersonasList } from './resources/personas'
@@ -64,7 +63,7 @@ const Routes = () => (
 export const App = ({ history }) => (
   <Router history={history}>
     <JssProvider generateClassName={generateClassName} jss={jss}>
-      <Layout isLoggedIn={auth.isLoggedIn()} theme={theme}>
+      <Layout>
         <Routes />
       </Layout>
     </JssProvider>

--- a/console-frontend/src/app/layout/index.js
+++ b/console-frontend/src/app/layout/index.js
@@ -1,9 +1,11 @@
 import AppBar from './app-bar'
+import auth from 'auth'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import Menu from './menu'
 import React from 'react'
 import Sidebar from './sidebar'
-import { branch, compose, renderComponent, withHandlers, withState } from 'recompose'
+import theme from 'app/theme'
+import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
 import { MuiThemeProvider, withStyles } from '@material-ui/core/styles'
 import { styles } from './layout-styles'
 import { withRouter } from 'react-router'
@@ -41,10 +43,13 @@ const EnhancedLayout = compose(
     toggleOpen: ({ open, setOpen }) => () => setOpen(!open),
   }),
   withStyles(styles, { index: 1 }),
+  withProps(() => ({
+    isLoggedIn: auth.isLoggedIn(),
+  })),
   branch(({ isLoggedIn }) => !isLoggedIn, renderComponent(props => <EmptyLayout {...props} />))
 )(Layout)
 
-const LayoutWithTheme = ({ theme, ...rest }) => (
+const LayoutWithTheme = ({ ...rest }) => (
   <MuiThemeProvider theme={theme}>
     <EnhancedLayout {...rest} />
   </MuiThemeProvider>


### PR DESCRIPTION
https://trello.com/c/Zx2Ti4Le/412-replace-react-admin-routing-with-our-own-remove-react-admin

**Fix:**  With 2 tabs opened while user authenticated: if user logs out in one of the tabs and tries to navigate to a different page in the other, he sees the side menu and the login page.

**Before:**
<img width="1276" alt="captura de ecra 2018-11-20 as 16 32 24" src="https://user-images.githubusercontent.com/35154956/48788089-fd85c800-ece1-11e8-8d2a-e0c090e499f2.png">

**After:**
<img width="1261" alt="captura de ecra 2018-11-20 as 16 33 58" src="https://user-images.githubusercontent.com/35154956/48788140-18f0d300-ece2-11e8-8e9f-40b8528abe35.png">

