### PR TITLE
Style list's table headers

### DIFF
--- a/console-frontend/src/app/resources/personas/list.js
+++ b/console-frontend/src/app/resources/personas/list.js
@@ -81,8 +81,18 @@ const EnhancedToolbar = ({ selectedIds, deletePersonas }) => (
   </Toolbar>
 )
 
+const StyledTableHead = styled(MUITableHead)`
+  background-color: #fafafa;
+  border-top: 1px solid #dfe0df;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 1.3px;
+  color: #555;
+  text-transform: uppercase;
+`
+
 const TableHead = ({ handleSelectAll, isSelectAll }) => (
-  <MUITableHead>
+  <StyledTableHead>
     <TableRow>
       <TableCell padding="checkbox">
         <Checkbox checked={isSelectAll} checkedIcon={<CheckBoxIcon />} onClick={handleSelectAll} />
@@ -98,7 +108,7 @@ const TableHead = ({ handleSelectAll, isSelectAll }) => (
       })}
       <TableCell key="actions" />
     </TableRow>
-  </MUITableHead>
+  </StyledTableHead>
 )
 
 const PersonaRow = compose(


### PR DESCRIPTION
https://trello.com/c/cG96jhMP/364-style-the-table-ui

- Restored table headers styling according to [#122](https://github.com/trendiamo/core/pull/122)

**Before:**
<img width="1274" alt="captura de ecra 2018-11-22 as 11 36 54" src="https://user-images.githubusercontent.com/35154956/48910594-45365c00-ee68-11e8-8275-3c4341b75e2b.png">

**After:**
<img width="1275" alt="styled_index_table_headers" src="https://user-images.githubusercontent.com/35154956/48910601-4b2c3d00-ee68-11e8-83bd-aa02bbba792f.png">
