### PR TITLE
Align table Head and Body

### DIFF
--- a/console-frontend/src/app/resources/curations/list.js
+++ b/console-frontend/src/app/resources/curations/list.js
@@ -1,9 +1,8 @@
-import Avatar from '@material-ui/core/Avatar'
 import enhanceList from 'ext/recompose/enhance-list'
 import React from 'react'
 import routes from 'app/routes'
-import TableCell from '@material-ui/core/TableCell'
 import { apiCurationDestroy, apiCurationList } from 'utils'
+import { Avatar, TableCell } from 'shared/table-elements'
 import { compose } from 'recompose'
 
 const columns = [
@@ -13,12 +12,10 @@ const columns = [
 
 const CurationsRow = ({ record }) => (
   <React.Fragment>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '20%' }}>
+    <TableCell width="20%">
       <Avatar alt="" src={record.persona.profilePicUrl} />
     </TableCell>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '80%' }}>
-      {record.name}
-    </TableCell>
+    <TableCell width="80%">{record.name}</TableCell>
   </React.Fragment>
 )
 

--- a/console-frontend/src/app/resources/outros/list.js
+++ b/console-frontend/src/app/resources/outros/list.js
@@ -1,9 +1,8 @@
-import Avatar from '@material-ui/core/Avatar'
 import enhanceList from 'ext/recompose/enhance-list'
 import React from 'react'
 import routes from 'app/routes'
-import TableCell from '@material-ui/core/TableCell'
 import { apiOutroDestroy, apiOutroList } from 'utils'
+import { Avatar, TableCell } from 'shared/table-elements'
 import { compose } from 'recompose'
 
 const columns = [
@@ -13,12 +12,10 @@ const columns = [
 
 const OutrosRow = ({ record }) => (
   <React.Fragment>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '20%' }}>
+    <TableCell width="20%">
       <Avatar alt="" src={record.persona.profilePicUrl} />
     </TableCell>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '80%' }}>
-      {record.name}
-    </TableCell>
+    <TableCell width="80%">{record.name}</TableCell>
   </React.Fragment>
 )
 

--- a/console-frontend/src/app/resources/personas/list.js
+++ b/console-frontend/src/app/resources/personas/list.js
@@ -1,8 +1,8 @@
-import Avatar from '@material-ui/core/Avatar'
+import Avatar from 'shared/table-elements/avatar'
 import enhanceList from 'ext/recompose/enhance-list'
 import React from 'react'
 import routes from 'app/routes'
-import TableCell from '@material-ui/core/TableCell'
+import TableCell from 'shared/table-elements/table-cell'
 import { apiPersonaDestroy, apiPersonaList } from 'utils'
 import { compose } from 'recompose'
 
@@ -14,15 +14,11 @@ const columns = [
 
 const PersonasRow = ({ record }) => (
   <React.Fragment>
-    <TableCell component="th" padding="none" scope="row">
+    <TableCell>
       <Avatar alt={record.name} src={record.profilePicUrl} />
     </TableCell>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '30%' }}>
-      {record.name}
-    </TableCell>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '70%' }}>
-      {record.description}
-    </TableCell>
+    <TableCell width="20%">{record.name}</TableCell>
+    <TableCell width="80%">{record.description}</TableCell>
   </React.Fragment>
 )
 

--- a/console-frontend/src/app/resources/scripted-chats/list.js
+++ b/console-frontend/src/app/resources/scripted-chats/list.js
@@ -1,9 +1,8 @@
-import Avatar from '@material-ui/core/Avatar'
 import enhanceList from 'ext/recompose/enhance-list'
 import React from 'react'
 import routes from 'app/routes'
-import TableCell from '@material-ui/core/TableCell'
 import { apiScriptedChatDestroy, apiScriptedChatList } from 'utils'
+import { Avatar, TableCell } from 'shared/table-elements'
 import { compose } from 'recompose'
 
 const columns = [
@@ -13,12 +12,10 @@ const columns = [
 
 const ScriptedChatsRow = ({ record }) => (
   <React.Fragment>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '20%' }}>
+    <TableCell width="20%">
       <Avatar alt="" src={record.persona.profilePicUrl} />
     </TableCell>
-    <TableCell component="th" padding="none" scope="row" style={{ width: '80%' }}>
-      {record.name}
-    </TableCell>
+    <TableCell width="80%">{record.name}</TableCell>
   </React.Fragment>
 )
 

--- a/console-frontend/src/app/resources/triggers/list.js
+++ b/console-frontend/src/app/resources/triggers/list.js
@@ -13,7 +13,6 @@ import routes from 'app/routes'
 import styled from 'styled-components'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
-import TableCell from '@material-ui/core/TableCell'
 import TableRow from '@material-ui/core/TableRow'
 import TableSortLabel from '@material-ui/core/TableSortLabel'
 import Tooltip from '@material-ui/core/Tooltip'
@@ -25,6 +24,7 @@ import { branch, compose, lifecycle, renderComponent, withHandlers, withState } 
 import { BulkActions } from 'shared/list-actions'
 import { createGlobalStyle } from 'styled-components'
 import { Link } from 'react-router-dom'
+import { TableCell } from 'shared/table-elements'
 
 const CheckBoxIcon = styled(MUICheckBoxIcon)`
   color: blue;
@@ -57,10 +57,10 @@ const Actions = () => (
 )
 
 const columns = [
-  { name: 'name', numeric: true, disablePadding: false, label: 'name' },
-  { name: 'flowType', numeric: false, disablePadding: false, label: 'flow type' },
-  { name: 'flowId', numeric: false, disablePadding: true, label: 'flow id' },
-  { name: 'urlMatchers', numeric: false, disablePadding: true, label: 'Url Matchers' },
+  { name: 'name', label: 'name' },
+  { name: 'flowType', label: 'flow type' },
+  { name: 'flowId', label: 'flow id' },
+  { name: 'urlMatchers', disablePadding: true, label: 'Url Matchers' },
 ]
 
 const Title = styled.div`
@@ -101,20 +101,21 @@ const StyledTableHead = styled(MUITableHead)`
 
 const StyledChip = styled(Chip)`
   margin: 0.25rem;
+  margin-left: 0;
 `
 
 const TableHead = ({ handleSelectAll, isSelectAll }) => (
   <StyledTableHead>
     <TableRow>
-      <TableCell padding="checkbox">
+      <TableCell>
         <ReorderIcon />
       </TableCell>
-      <TableCell padding="checkbox">
+      <TableCell>
         <Checkbox checked={isSelectAll} checkedIcon={<CheckBoxIcon />} onClick={handleSelectAll} />
       </TableCell>
       {columns.map(row => {
         return (
-          <TableCell key={row.name} numeric={row.numeric} padding={row.disablePadding ? 'none' : 'default'}>
+          <TableCell key={row.name} numeric={row.numeric}>
             <Tooltip enterDelay={300} placement={row.numeric ? 'bottom-end' : 'bottom-start'} title="Sort">
               <TableSortLabel value={row.name}>{row.label}</TableSortLabel>
             </Tooltip>
@@ -142,28 +143,22 @@ const TriggerRow = compose(
   })
 )(({ trigger, handleSelect, selectedIds }) => (
   <TableRow hover role="checkbox" tabIndex={-1}>
-    <TableCell padding="checkbox">
+    <TableCell>
       <DragHandle />
     </TableCell>
-    <TableCell padding="checkbox">
+    <TableCell>
       <Checkbox checked={selectedIds.includes(trigger.id)} checkedIcon={<CheckBoxIcon />} onChange={handleSelect} />
     </TableCell>
-    <TableCell component="th" padding="none" scope="row">
-      {trigger.name}
-    </TableCell>
-    <TableCell component="th" padding="none" scope="row">
-      {trigger.flowType}
-    </TableCell>
-    <TableCell component="th" padding="none" scope="row">
-      {trigger.flowId}
-    </TableCell>
-    <TableCell component="th" padding="none" scope="row">
+    <TableCell>{trigger.name}</TableCell>
+    <TableCell>{trigger.flowType}</TableCell>
+    <TableCell>{trigger.flowId}</TableCell>
+    <TableCell>
       {trigger.urlMatchers.map((url, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <StyledChip key={`url${index}`} label={url} />
       ))}
     </TableCell>
-    <TableCell component="th" padding="none" scope="row">
+    <TableCell>
       <Button color="primary" component={Link} to={routes.triggerEdit(trigger.id)}>
         <EditIcon />
       </Button>

--- a/console-frontend/src/shared/table-elements/avatar.js
+++ b/console-frontend/src/shared/table-elements/avatar.js
@@ -1,0 +1,7 @@
+import Avatar from '@material-ui/core/Avatar'
+import styled from 'styled-components'
+
+export default styled(Avatar)`
+  display: inline-block;
+  vertical-align: middle;
+`

--- a/console-frontend/src/shared/table-elements/index.js
+++ b/console-frontend/src/shared/table-elements/index.js
@@ -1,5 +1,7 @@
+import Avatar from './avatar'
+import TableCell from './table-cell'
 import TableHead from './table-head'
 import TableRow from './table-row'
 import TableToolbar from './table-toolbar'
 
-export { TableHead, TableRow, TableToolbar }
+export { TableHead, TableRow, TableToolbar, TableCell, Avatar }

--- a/console-frontend/src/shared/table-elements/table-cell.js
+++ b/console-frontend/src/shared/table-elements/table-cell.js
@@ -1,0 +1,13 @@
+import MuiTableCell from '@material-ui/core/TableCell'
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledCell = styled(MuiTableCell)`
+  width: ${({ width }) => width};
+  text-align: ${({ align }) => align};
+  padding: 0 5px;
+`
+
+const TableCell = ({ ...props }) => <StyledCell {...props} scope="row" />
+
+export default TableCell

--- a/console-frontend/src/shared/table-elements/table-head.js
+++ b/console-frontend/src/shared/table-elements/table-head.js
@@ -4,7 +4,7 @@ import MUITableHead from '@material-ui/core/TableHead'
 import MUITableSortLabel from '@material-ui/core/TableSortLabel'
 import React from 'react'
 import styled from 'styled-components'
-import TableCell from '@material-ui/core/TableCell'
+import TableCell from './table-cell'
 import TableRow from '@material-ui/core/TableRow'
 import Tooltip from '@material-ui/core/Tooltip'
 import { compose, withHandlers } from 'recompose'
@@ -34,18 +34,26 @@ const TableSortLabel = compose(
 const TableHead = ({ handleSelectAll, handleRequestSort, isSelectAll, orderBy, orderDirection, columns }) => (
   <StyledTableHead>
     <TableRow>
-      <TableCell padding="checkbox">
+      <TableCell width="72px">
         <Checkbox checked={isSelectAll} checkedIcon={<CheckBoxIcon />} onClick={handleSelectAll} />
       </TableCell>
       {columns.map(column => {
         return (
-          <TableCell key={column.name} numeric={column.numeric} padding={column.padding || 'default'}>
+          <TableCell
+            align={column.align}
+            component="th"
+            key={column.name}
+            numeric={column.numeric}
+            padding={column.padding}
+          >
             {column.sortable ? (
               <Tooltip enterDelay={50} placement={column.numeric ? 'bottom-end' : 'bottom-start'} title="Sort">
                 <TableSortLabel
                   active={orderBy === column.name}
                   direction={orderDirection}
+                  hideSortIcon
                   onClick={handleRequestSort}
+                  style={{ verticalAlign: 'baseline' }}
                   value={column.name}
                 >
                   {column.label}

--- a/console-frontend/src/shared/table-elements/table-row.js
+++ b/console-frontend/src/shared/table-elements/table-row.js
@@ -5,7 +5,7 @@ import MUICheckBoxIcon from '@material-ui/icons/CheckBox'
 import MUITableRow from '@material-ui/core/TableRow'
 import React from 'react'
 import styled from 'styled-components'
-import TableCell from '@material-ui/core/TableCell'
+import TableCell from './table-cell'
 import { compose, withHandlers } from 'recompose'
 import { Link } from 'react-router-dom'
 
@@ -27,14 +27,11 @@ const TableRow = compose(
   })
 )(({ resource, handleSelect, selectedIds, resourceEditPath, children }) => (
   <MUITableRow hover role="checkbox" tabIndex={-1}>
-    <TableCell padding="checkbox">
+    <TableCell>
       <Checkbox checked={selectedIds.includes(resource.id)} checkedIcon={<CheckBoxIcon />} onChange={handleSelect} />
     </TableCell>
     {children}
     <TableCell
-      component="th"
-      padding="none"
-      scope="row"
       style={{
         whiteSpace: 'nowrap',
       }}


### PR DESCRIPTION
Features
----
- Align cells by simply providing `align` attribute (`left`,`center`,`right`) to the `TableCell`;
- Head and Body are on the same line now;
- Width of the cell can simply be provided by adding `width` attribute.

Code Changes
----
- Created `TableCell` component in order to remove repetitions in views;
- Created `Avatar` component (only for tables) which has a different configuration to allow alignment;
- Checkbox width is set to fixed `72px` in order to avoid excessive padding;
- Cell padding is `5px` from the left and right instead of MUI `24px-42px`;
- Sortable columns `vertical-align: baseline` was set due to a slight shift in positioning;

Screenshots
----
Left:
![screenshot from 2018-12-03 16-53-34](https://user-images.githubusercontent.com/32452032/49389492-5dd32b80-f71e-11e8-8dad-7631e7114e1d.png)
Center:
![screenshot from 2018-12-03 16-54-18](https://user-images.githubusercontent.com/32452032/49389532-78a5a000-f71e-11e8-935c-d011cc531ef9.png)
Right:
![screenshot from 2018-12-03 16-54-47](https://user-images.githubusercontent.com/32452032/49389547-82c79e80-f71e-11e8-8356-f5301b6a244d.png)
Sortable:
![screenshot from 2018-12-03 16-54-30](https://user-images.githubusercontent.com/32452032/49389637-b9051e00-f71e-11e8-9d7b-0b6314e1b497.png)

