### PR TITLE
Fix sidebar bug

### DIFF
--- a/console-frontend/src/app/layout/layout-styles.js
+++ b/console-frontend/src/app/layout/layout-styles.js
@@ -92,7 +92,8 @@ export const styles = theme => ({
   },
   drawerGhost: {
     width: drawerWidth,
-    [theme.breakpoints.down('xs')]: {
+    flexShrink: 0,
+    [theme.breakpoints.down('sm')]: {
       width: 0,
     },
     transition: createTransition(theme, ['width']),


### PR DESCRIPTION
Sidebar overflow bug
----
- Added `flex-shrink: 0` to the `drawer-ghost` element;
- Fixed breakpoint bug with `sm` instead `xs`;
![screenshot from 2018-12-04 10-42-17](https://user-images.githubusercontent.com/32452032/49436540-4d1fc580-f7b1-11e8-9189-42fbbba1fe6e.png)
Breakpoint bug:
![screenshot from 2018-12-04 10-43-33](https://user-images.githubusercontent.com/32452032/49436623-78a2b000-f7b1-11e8-9812-a486b1789b95.png)
Fix:
![screenshot from 2018-12-04 10-42-47](https://user-images.githubusercontent.com/32452032/49436581-6294ef80-f7b1-11e8-82ff-5c79ba3e44ef.png)
