### PR TITLE
Refactor Forms

### DIFF
--- a/console-frontend/src/app/resources/curations/form/index.js
+++ b/console-frontend/src/app/resources/curations/form/index.js
@@ -1,19 +1,15 @@
-import AddCircleOutline from '@material-ui/icons/AddCircleOutline'
-import Cancel from './shared/cancel'
 import CircularProgress from 'shared/circular-progress'
-import Notification from 'shared/notification'
 import PaperContainer from 'app/layout/paper-container'
 import React from 'react'
 import routes from 'app/routes'
-import SaveIcon from '@material-ui/icons/Save'
 import Spotlight from './spotlight'
 import styled from 'styled-components'
 import withAppBarContent from 'ext/recompose/with-app-bar-content'
 import withForm from 'ext/recompose/with-form'
+import { Actions, AddItemButton, Cancel, Form } from 'shared/form-elements'
 import { apiPersonaSimpleList } from 'utils'
 import {
   Avatar,
-  Button,
   Card,
   CardContent,
   FormControl,
@@ -26,7 +22,7 @@ import {
   Typography,
 } from '@material-ui/core'
 import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
-import { Prompt, withRouter } from 'react-router'
+import { withRouter } from 'react-router'
 
 const StyledAvatar = styled(Avatar)`
   display: inline-block;
@@ -41,24 +37,6 @@ const Item = styled.div`
   display: flex;
   align-items: center;
 `
-
-const Actions = ({ isFormLoading, onFormSubmit }) => (
-  <Button color="primary" disabled={isFormLoading} onClick={onFormSubmit} type="submit" variant="contained">
-    <SaveIcon />
-    {'Save'}
-  </Button>
-)
-
-const StyledAddCircleOutline = styled(AddCircleOutline)`
-  color: #6c6c6c;
-`
-
-const AddSpotlightButton = ({ disabled, addSpotlight }) => (
-  <Button disabled={disabled} onClick={addSpotlight} size="small">
-    <StyledAddCircleOutline />
-    <StyledTypography>{'Add Another Spotlight'}</StyledTypography>
-  </Button>
-)
 
 const selectValue = (form, personas) => {
   if (form.personaId === '') return ''
@@ -84,9 +62,7 @@ const CurationForm = ({
 }) => (
   <PaperContainer>
     <Typography variant="subtitle1">{title}</Typography>
-    <form onSubmit={onFormSubmit} ref={formRef}>
-      <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
-      <Notification data={errors} />
+    <Form errors={errors} formRef={formRef} isFormPristine={isFormPristine} onSubmit={onFormSubmit}>
       <TextField
         autoFocus
         disabled={isFormLoading}
@@ -163,9 +139,9 @@ const CurationForm = ({
             </Card>
           </div>
         ))}
-        <AddSpotlightButton addSpotlight={addSpotlight} disabled={isFormLoading} />{' '}
+        <AddItemButton disabled={isFormLoading} message="Add another spotlight" onClick={addSpotlight} />{' '}
       </div>
-    </form>
+    </Form>
   </PaperContainer>
 )
 
@@ -253,7 +229,7 @@ export default compose(
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
   withAppBarContent(({ breadcrumbs, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions isFormLoading={isFormLoading} onFormSubmit={onFormSubmit} />,
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormLoading} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/app/resources/curations/form/spotlight.js
+++ b/console-frontend/src/app/resources/curations/form/spotlight.js
@@ -1,11 +1,9 @@
-import AddCircleOutline from '@material-ui/icons/AddCircleOutline'
-import Cancel from './shared/cancel'
 import ProductPick from './product-pick'
 import React from 'react'
 import styled from 'styled-components'
+import { AddItemButton, Cancel } from 'shared/form-elements'
 import {
   Avatar,
-  Button,
   Card,
   CardContent,
   FormControl,
@@ -32,17 +30,6 @@ const Item = styled.div`
   display: flex;
   align-items: center;
 `
-
-const StyledAddCircleOutline = styled(AddCircleOutline)`
-  color: #6c6c6c;
-`
-
-const AddProductPickButton = ({ disabled, addProductPick }) => (
-  <Button disabled={disabled} onClick={addProductPick} size="small">
-    <StyledAddCircleOutline />
-    <StyledTypography>{'Add Another Product Pick'}</StyledTypography>
-  </Button>
-)
 
 const Spotlight = ({
   personas,
@@ -108,7 +95,12 @@ const Spotlight = ({
           </Card>
         </div>
       ))}
-      <AddProductPickButton addProductPick={addProductPick} disabled={isFormLoading} index={index} />{' '}
+      <AddItemButton
+        disabled={isFormLoading}
+        index={index}
+        message="Add Another Product Pick"
+        onClick={addProductPick}
+      />{' '}
     </div>
   </React.Fragment>
 )

--- a/console-frontend/src/app/resources/outros/form.js
+++ b/console-frontend/src/app/resources/outros/form.js
@@ -1,23 +1,20 @@
 import Avatar from '@material-ui/core/Avatar'
-import Button from '@material-ui/core/Button'
 import CircularProgress from 'shared/circular-progress'
 import FormControl from '@material-ui/core/FormControl'
 import Input from '@material-ui/core/Input'
 import InputLabel from '@material-ui/core/InputLabel'
 import MenuItem from '@material-ui/core/MenuItem'
-import Notification from 'shared/notification'
 import PaperContainer from 'app/layout/paper-container'
 import React from 'react'
 import routes from 'app/routes'
-import SaveIcon from '@material-ui/icons/Save'
 import Select from '@material-ui/core/Select'
 import styled from 'styled-components'
 import Typography from '@material-ui/core/Typography'
 import withAppBarContent from 'ext/recompose/with-app-bar-content'
 import withForm from 'ext/recompose/with-form'
+import { Actions, Form } from 'shared/form-elements'
 import { apiPersonaSimpleList } from 'utils'
 import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
-import { Prompt } from 'react-router'
 import { TextField } from '@material-ui/core'
 import { withRouter } from 'react-router'
 
@@ -34,13 +31,6 @@ const Item = styled.div`
   display: flex;
   align-items: center;
 `
-
-const Actions = ({ isFormLoading, onFormSubmit }) => (
-  <Button color="primary" disabled={isFormLoading} onClick={onFormSubmit} type="submit" variant="contained">
-    <SaveIcon />
-    {'Save'}
-  </Button>
-)
 
 const selectValue = (form, personas) => {
   if (form.personaId === '') return ''
@@ -62,9 +52,7 @@ const OutroForm = ({
 }) => (
   <PaperContainer>
     <Typography variant="subtitle1">{title}</Typography>
-    <form onSubmit={onFormSubmit} ref={formRef}>
-      <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
-      <Notification data={errors} />
+    <Form errors={errors} formRef={formRef} isFormPristine={isFormPristine} onSubmit={onFormSubmit}>
       <TextField
         autoFocus
         disabled={isFormLoading}
@@ -97,7 +85,7 @@ const OutroForm = ({
           ))}
         </Select>
       </FormControl>
-    </form>
+    </Form>
   </PaperContainer>
 )
 
@@ -136,7 +124,7 @@ export default compose(
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
   withAppBarContent(({ breadcrumbs, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions isFormLoading={isFormLoading} onFormSubmit={onFormSubmit} />,
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormLoading} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/app/resources/personas/form.js
+++ b/console-frontend/src/app/resources/personas/form.js
@@ -1,30 +1,15 @@
-import Button from '@material-ui/core/Button'
 import CircularProgress from 'shared/circular-progress'
 import Label from 'shared/label'
-import Notification from 'shared/notification'
 import PaperContainer from 'app/layout/paper-container'
 import PictureUploader, { ProgressBar } from 'shared/picture-uploader'
 import React from 'react'
 import routes from 'app/routes'
-import SaveIcon from '@material-ui/icons/Save'
 import TextField from '@material-ui/core/TextField'
 import withAppBarContent from 'ext/recompose/with-app-bar-content'
 import withForm from 'ext/recompose/with-form'
+import { Actions, Form } from 'shared/form-elements'
 import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
-import { Prompt, withRouter } from 'react-router'
-
-const Actions = ({ isCropping, isFormLoading, onFormSubmit }) => (
-  <Button
-    color="primary"
-    disabled={isFormLoading || isCropping}
-    onClick={onFormSubmit}
-    type="submit"
-    variant="contained"
-  >
-    <SaveIcon />
-    {'Save'}
-  </Button>
-)
+import { withRouter } from 'react-router'
 
 const PersonaForm = ({
   form,
@@ -41,9 +26,7 @@ const PersonaForm = ({
   setProfilePicUrl,
 }) => (
   <PaperContainer>
-    <form onSubmit={onFormSubmit} ref={formRef}>
-      <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
-      <Notification data={errors} />
+    <Form errors={errors} formRef={formRef} isFormPristine={isFormPristine} onSubmit={onFormSubmit}>
       <Label>{'Picture'}</Label>
       <PictureUploader
         disabled={isCropping}
@@ -74,7 +57,7 @@ const PersonaForm = ({
         value={form.description}
       />
       {progress && <ProgressBar progress={progress} />}
-    </form>
+    </Form>
   </PaperContainer>
 )
 
@@ -111,7 +94,7 @@ export default compose(
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
   withAppBarContent(({ breadcrumbs, isCropping, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions isCropping={isCropping} isFormLoading={isFormLoading} onFormSubmit={onFormSubmit} />,
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormLoading || isCropping} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/app/resources/triggers/form.js
+++ b/console-frontend/src/app/resources/triggers/form.js
@@ -1,35 +1,22 @@
-import AddCircleOutline from '@material-ui/icons/AddCircleOutline'
-import Button from '@material-ui/core/Button'
 import CircularProgress from 'shared/circular-progress'
 import FormControl from '@material-ui/core/FormControl'
 import IconButton from '@material-ui/core/IconButton'
 import Input from '@material-ui/core/Input'
 import InputLabel from '@material-ui/core/InputLabel'
 import MenuItem from '@material-ui/core/MenuItem'
-import MuiCancel from '@material-ui/icons/Cancel'
-import Notification from 'shared/notification'
 import PaperContainer from 'app/layout/paper-container'
 import React from 'react'
 import routes from 'app/routes'
-import SaveIcon from '@material-ui/icons/Save'
 import Select from '@material-ui/core/Select'
 import styled from 'styled-components'
 import TextField from '@material-ui/core/TextField'
-import Typography from '@material-ui/core/Typography'
 import withAppBarContent from 'ext/recompose/with-app-bar-content'
 import withForm from 'ext/recompose/with-form'
+import { Actions, AddItemButton, Cancel, Form } from 'shared/form-elements'
 import { apiFlowsList } from 'utils'
 import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
 import { camelize, singularize } from 'inflected'
-import { Prompt } from 'react-router'
 import { withRouter } from 'react-router'
-
-const Actions = ({ isFormLoading, onFormSubmit }) => (
-  <Button color="primary" disabled={isFormLoading} onClick={onFormSubmit} type="submit" variant="contained">
-    <SaveIcon />
-    {'Save'}
-  </Button>
-)
 
 const LabelContainer = styled.div`
   margin-top: 1rem;
@@ -52,19 +39,6 @@ const StyledUrlTextField = styled(UrlTextField)`
   flex: 1;
   margin: 8px 0;
 `
-const StyledAddCircleOutline = styled(AddCircleOutline)`
-  color: #6c6c6c;
-`
-const StyledTypography = styled(Typography)`
-  margin-left: 10px;
-`
-
-const AddUrlButton = ({ disabled, addUrlSelect }) => (
-  <Button disabled={disabled} onClick={addUrlSelect} size="small">
-    <StyledAddCircleOutline />
-    <StyledTypography>{'Add Another Url'}</StyledTypography>
-  </Button>
-)
 
 const selectValue = (form, flows) => {
   if (form.flowType === '') return ''
@@ -75,14 +49,6 @@ const selectValue = (form, flows) => {
   if (form.flowType === 'curations' || form.flowType === 'Curation')
     return `Curation: ${flows['curations'].find(curation => curation.id === form.flowId).id}`
 }
-
-const Cancel = compose(
-  withHandlers({
-    deleteUrlMatcher: ({ index, onClick }) => () => {
-      onClick(index)
-    },
-  })
-)(({ deleteUrlMatcher, ...props }) => <MuiCancel {...props} onClick={deleteUrlMatcher} />)
 
 const TriggerForm = ({
   addUrlSelect,
@@ -98,9 +64,7 @@ const TriggerForm = ({
   selectFlow,
 }) => (
   <PaperContainer>
-    <form onSubmit={onFormSubmit} ref={formRef}>
-      <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
-      <Notification data={errors} />
+    <Form errors={errors} formRef={formRef} isFormPristine={isFormPristine} onSubmit={onFormSubmit}>
       <FormControl disabled={isFormLoading} fullWidth>
         <InputLabel htmlFor="flow-label-placeholder" shrink>
           {'Flow'}
@@ -161,9 +125,9 @@ const TriggerForm = ({
             </FlexDiv>
           ))
         )}
-        <AddUrlButton addUrlSelect={addUrlSelect} disabled={isFormLoading} />{' '}
+        <AddItemButton disabled={isFormLoading} message="Add Another Url" onClick={addUrlSelect} />{' '}
       </div>
-    </form>
+    </Form>
   </PaperContainer>
 )
 
@@ -219,7 +183,7 @@ export default compose(
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
   withAppBarContent(({ breadcrumbs, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions isFormLoading={isFormLoading} onFormSubmit={onFormSubmit} />,
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormLoading} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/shared/form-elements/actions.js
+++ b/console-frontend/src/shared/form-elements/actions.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import SaveButton from './save-button'
+
+const Actions = ({ onFormSubmit, saveDisabled }) => (
+  <React.Fragment>
+    <SaveButton disabled={saveDisabled} onClick={onFormSubmit} />
+  </React.Fragment>
+)
+
+export default Actions

--- a/console-frontend/src/shared/form-elements/add-item-button.js
+++ b/console-frontend/src/shared/form-elements/add-item-button.js
@@ -1,0 +1,18 @@
+import AddCircleOutline from '@material-ui/icons/AddCircleOutline'
+import InlineTypography from './inline-typography'
+import React from 'react'
+import styled from 'styled-components'
+import { Button } from '@material-ui/core'
+
+const CircleIcon = styled(AddCircleOutline)`
+  color: #6c6c6c;
+`
+
+const AddItemButton = ({ message, ...props }) => (
+  <Button size="small" {...props}>
+    <CircleIcon />
+    <InlineTypography>{message}</InlineTypography>
+  </Button>
+)
+
+export default AddItemButton

--- a/console-frontend/src/shared/form-elements/cancel.js
+++ b/console-frontend/src/shared/form-elements/cancel.js
@@ -2,11 +2,11 @@ import MuiCancel from '@material-ui/icons/Cancel'
 import React from 'react'
 import { compose, withHandlers } from 'recompose'
 
-const Cancel = ({ deleteResource, ...props }) => <MuiCancel {...props} onClick={deleteResource} />
+const Cancel = ({ onClick, ...props }) => <MuiCancel {...props} onClick={onClick} />
 
 export default compose(
   withHandlers({
-    deleteResource: ({ index, onClick, disabled }) => () => {
+    onClick: ({ index, onClick, disabled }) => () => {
       if (!disabled) onClick(index)
     },
   })

--- a/console-frontend/src/shared/form-elements/form.js
+++ b/console-frontend/src/shared/form-elements/form.js
@@ -1,0 +1,15 @@
+import Notification from 'shared/notification'
+import Prompt from './prompt'
+import React from 'react'
+
+const Form = ({ children, promptMessage, isFormPristine, errors, formRef, ...props }) => (
+  <React.Fragment>
+    <form action="" ref={formRef} {...props}>
+      <Prompt message={promptMessage} when={!isFormPristine} />
+      <Notification data={errors} />
+      {children}
+    </form>
+  </React.Fragment>
+)
+
+export default Form

--- a/console-frontend/src/shared/form-elements/index.js
+++ b/console-frontend/src/shared/form-elements/index.js
@@ -1,0 +1,9 @@
+import Actions from './actions'
+import AddItemButton from './add-item-button'
+import Cancel from './cancel'
+import Form from './form'
+import InlineTypography from './inline-typography'
+import Prompt from './prompt'
+import SaveButton from './save-button'
+
+export { Actions, AddItemButton, Cancel, InlineTypography, Prompt, SaveButton, Form }

--- a/console-frontend/src/shared/form-elements/inline-typography.js
+++ b/console-frontend/src/shared/form-elements/inline-typography.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { Typography } from '@material-ui/core'
+
+const InlineTypography = styled(Typography)`
+  display: inline-block;
+  padding-left: 20px;
+`
+
+export default InlineTypography

--- a/console-frontend/src/shared/form-elements/prompt.js
+++ b/console-frontend/src/shared/form-elements/prompt.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Prompt as RouterPrompt } from 'react-router'
+
+const defaultMessage = 'You have unsaved changes, are you sure you want to leave?'
+
+const Prompt = ({ message, ...props }) => <RouterPrompt message={message ? message : defaultMessage} {...props} />
+
+export default Prompt

--- a/console-frontend/src/shared/form-elements/save-button.js
+++ b/console-frontend/src/shared/form-elements/save-button.js
@@ -1,0 +1,14 @@
+import MuiButton from '@material-ui/core/Button'
+import React from 'react'
+import SaveIcon from '@material-ui/icons/Save'
+
+const defaultMessage = 'Save'
+
+const Button = ({ message, ...props }) => (
+  <MuiButton {...props} color="primary" type="submit" variant="contained">
+    <SaveIcon />
+    {message ? 'Save' : defaultMessage}
+  </MuiButton>
+)
+
+export default Button


### PR DESCRIPTION
### Partial refactor of Form components
- Removed some of the self-repeating components;
- Created `shared/form-elements` folder in order to import shared components;

### Changes in detail
- `<form>` was replaced by `Form` which already contains `Notifications` and `Prompt` with a default message;
- `Actions` was replaced in order to avoid repeating itself and handle cases of adding new buttons ( e.g.: `Cancel` ) in future;
- Button which creates sub-elements (e.g: `AddSpotlightButton`) was replaced by `AddItemButton`. It also uses a custom styling, which was repeated in all of the forms;
- `StyledTypography` is replaced by `InlineTypography`.