### PR TITLE
Restyle AppBar

### DIFF
--- a/console-frontend/src/app/layout/app-bar.js
+++ b/console-frontend/src/app/layout/app-bar.js
@@ -23,9 +23,9 @@ const AppBarContent = compose(
     Actions: store.appBarContent.Actions,
     breadcrumbs: store.appBarContent.breadcrumbs,
   }))
-)(({ Actions, breadcrumbs }) => (
+)(({ Actions, breadcrumbs, classes }) => (
   <React.Fragment>
-    <Breadcrumbs breadcrumbs={breadcrumbs} />
+    <Breadcrumbs breadcrumbs={breadcrumbs} classes={classes} />
     {Actions && <ButtonsContainer>{Actions}</ButtonsContainer>}
   </React.Fragment>
 ))
@@ -36,7 +36,7 @@ const AppBar = ({ classes, open, toggleOpen }) => (
       <IconButton aria-label="Open drawer" className={classes.menuButton} color="inherit" onClick={toggleOpen}>
         <MenuIcon />
       </IconButton>
-      <AppBarContent />
+      <AppBarContent classes={classes} />
     </Toolbar>
   </MuiAppBar>
 )

--- a/console-frontend/src/app/layout/layout-styles.js
+++ b/console-frontend/src/app/layout/layout-styles.js
@@ -225,8 +225,16 @@ export const styles = theme => ({
   },
   title: {
     color: '#777',
+    display: 'inline-block',
+    marginRight: '5px',
     [theme.breakpoints.down('sm')]: {
       color: theme.palette.primary.contrastText,
+      fontSize: '16px',
+    },
+  },
+  titleResponsive: {
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
     },
   },
   toolbar: {

--- a/console-frontend/src/shared/breadcrumbs.js
+++ b/console-frontend/src/shared/breadcrumbs.js
@@ -1,27 +1,26 @@
+import classnames from 'classnames'
 import Link from 'shared/link'
 import React from 'react'
 import Typography from '@material-ui/core/Typography'
 
-const Breadcrumbs = ({ breadcrumbs }) => (
+const Title = ({ text, classes, responsive }) => (
+  <Typography className={classnames(classes.title, responsive && classes.titleResponsive)} variant="h6">
+    {text}
+  </Typography>
+)
+
+const Breadcrumbs = ({ breadcrumbs, classes }) => (
   <React.Fragment>
     {breadcrumbs.map((breadcrumb, i) => (
       <React.Fragment key={breadcrumb.route || breadcrumb.text}>
         {breadcrumb.route ? (
           <Link to={breadcrumb.route}>
-            <Typography color="default" style={{ display: 'inline' }} variant="h6">
-              {breadcrumb.text}
-            </Typography>
+            <Title classes={classes} responsive text={breadcrumb.text} />
           </Link>
         ) : (
-          <Typography color="default" style={{ display: 'inline' }} variant="h6">
-            {breadcrumb.text}
-          </Typography>
+          <Title classes={classes} text={breadcrumb.text} />
         )}
-        {i < breadcrumbs.length - 1 && (
-          <Typography color="default" style={{ display: 'inline', margin: '0 0.5rem' }} variant="h6">
-            {'/'}
-          </Typography>
-        )}
+        {i < breadcrumbs.length - 1 && <Title classes={classes} responsive text="/" />}
       </React.Fragment>
     ))}
   </React.Fragment>

--- a/console-frontend/src/shared/form-elements/save-button.js
+++ b/console-frontend/src/shared/form-elements/save-button.js
@@ -1,13 +1,9 @@
 import MuiButton from '@material-ui/core/Button'
 import React from 'react'
-import SaveIcon from '@material-ui/icons/Save'
-
-const defaultMessage = 'Save'
 
 const Button = ({ message, ...props }) => (
   <MuiButton {...props} color="primary" type="submit" variant="contained">
-    <SaveIcon />
-    {message ? 'Save' : defaultMessage}
+    {message || 'Save'}
   </MuiButton>
 )
 


### PR DESCRIPTION
### Responsive AppBar
- `Title` now uses `theme` in order to change color when in mobile mode;
- `Breadcrumbs` are one-word only when in mobile mode;
- Save button had no icon in design, so it was removed.

![screenshot from 2018-12-06 15-01-05](https://user-images.githubusercontent.com/32452032/49591974-cfea8100-f967-11e8-9382-f5713ef95a6d.png)
![screenshot from 2018-12-06 15-01-16](https://user-images.githubusercontent.com/32452032/49591984-d678f880-f967-11e8-8b4a-9ef20516a01c.png)

