### PR TITLE
Restyle Sorting feature in Triggers

### DIFF
--- a/console-frontend/src/app/resources/triggers/list.js
+++ b/console-frontend/src/app/resources/triggers/list.js
@@ -12,6 +12,7 @@ import styled from 'styled-components'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableRow from '@material-ui/core/TableRow'
+import Typography from '@material-ui/core/Typography'
 import withAppBarContent from 'ext/recompose/with-app-bar-content'
 import { apiTriggerDestroy, apiTriggerList, apiTriggerSort } from 'utils'
 import { arrayMove, SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc'
@@ -25,9 +26,16 @@ const CheckBoxIcon = styled(MUICheckBoxIcon)`
   color: blue;
 `
 
+const InlineTypography = styled(Typography)`
+  display: inline-block;
+`
+
 const TriggerRowStyle = createGlobalStyle`
   .sortable-trigger-row {
+    pointer-events: auto !important;
     z-index: 1;
+    background: #fff !important;
+    box-shadow: 0px 4px 9px rgba(0, 0, 0, 0.24);
   }
 `
 
@@ -79,7 +87,9 @@ const TriggerRow = compose(
       <Checkbox checked={selectedIds.includes(trigger.id)} checkedIcon={<CheckBoxIcon />} onChange={handleSelect} />
     </TableCell>
     <TableCell width="50%">
-      {`${trigger.flowType} #${trigger.flowId}: '${trigger.flow.name}'`}
+      <InlineTypography variant="subtitle2">{`${trigger.flowType} #${trigger.flowId}: '${
+        trigger.flow.name
+      }'`}</InlineTypography>
       <Button
         component={Link}
         size="small"
@@ -165,11 +175,13 @@ const TriggerList = ({
         distance={1}
         handleSelectAll={handleSelectAll}
         helperClass="sortable-trigger-row"
+        lockAxis="y"
         onSortEnd={onSortEnd}
         selectedIds={selectedIds}
         setSelectedIds={setSelectedIds}
         triggers={triggers}
         useDragHandle
+        useWindowAsScrollContainer
       />
     </Table>
   </PaperContainer>

--- a/console-frontend/src/shared/table-elements/table-cell.js
+++ b/console-frontend/src/shared/table-elements/table-cell.js
@@ -6,6 +6,20 @@ const StyledCell = styled(MuiTableCell)`
   width: ${({ width }) => width};
   text-align: ${({ align }) => align};
   padding: 0 5px;
+  border: none;
+  position: relative;
+  :before {
+    content: '';
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: -1px;
+    position: absolute;
+    border-bottom: 1px solid #ddd;
+    border-top: 1px solid #ddd;
+    pointer-events: none;
+    user-select: none;
+  }
 `
 
 const TableCell = ({ ...props }) => <StyledCell {...props} scope="row" />


### PR DESCRIPTION
### Restyle Sorting-rows feature
- Added background and shadow for picked row;
- Locked row by `Y` axis;
- Changed border visualization in table `td` elements because of inability to transform usual borders;

![peek 2018-12-06 16-57](https://user-images.githubusercontent.com/32452032/49599118-134ceb80-f978-11e8-9b6f-9deb613ca70c.gif)
