### PR TITLE
Change mobile appbar design & contrast

### DIFF
--- a/console-frontend/src/app/layout/index.js
+++ b/console-frontend/src/app/layout/index.js
@@ -4,6 +4,7 @@ import CssBaseline from '@material-ui/core/CssBaseline'
 import Menu from './menu'
 import React from 'react'
 import Sidebar from './sidebar'
+import withClasses from 'ext/recompose/with-classes'
 import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
 import { styles } from './layout-styles'
 import { withRouter } from 'react-router'
@@ -45,6 +46,7 @@ const EnhancedLayout = compose(
   withProps(() => ({
     isLoggedIn: auth.isLoggedIn(),
   })),
+  withClasses,
   branch(({ isLoggedIn }) => !isLoggedIn, renderComponent(props => <EmptyLayout {...props} />))
 )(Layout)
 

--- a/console-frontend/src/app/layout/layout-styles.js
+++ b/console-frontend/src/app/layout/layout-styles.js
@@ -55,6 +55,17 @@ export const styles = theme => ({
       width: `calc(100% - ${drawerWidth}px)`,
     },
   },
+  appBarButton: {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      background: '#fff !important',
+    },
+    [theme.breakpoints.down('sm')]: {
+      background: '#fff',
+      color: theme.palette.primary.main,
+    },
+  },
   appFrame: {
     display: 'flex',
     flexDirection: 'column',
@@ -174,7 +185,7 @@ export const styles = theme => ({
     transform: 'translateY(-50%)',
   },
   menuButton: {
-    color: '#777',
+    color: theme.customPalette.sidebar.main,
     marginRight: '6px',
     [theme.breakpoints.down('sm')]: {
       color: '#fff',
@@ -224,17 +235,29 @@ export const styles = theme => ({
     zIndex: 1,
   },
   title: {
-    color: '#777',
+    color: theme.customPalette.sidebar.main,
     display: 'inline-block',
-    marginRight: '5px',
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+    fontSize: '14px',
+    marginRight: '2px',
     [theme.breakpoints.down('sm')]: {
       color: theme.palette.primary.contrastText,
       fontSize: '16px',
     },
+    transition: createTransition(theme, ['color']),
   },
   titleResponsive: {
     [theme.breakpoints.down('sm')]: {
       display: 'none',
+    },
+  },
+  titleHighlight: {
+    [theme.breakpoints.up('md')]: {
+      '&:hover': {
+        color: theme.palette.primary.main,
+      },
     },
   },
   toolbar: {

--- a/console-frontend/src/app/resources/triggers/list.js
+++ b/console-frontend/src/app/resources/triggers/list.js
@@ -1,3 +1,4 @@
+import AppBarButton from 'shared/app-bar-button'
 import Button from '@material-ui/core/Button'
 import Checkbox from '@material-ui/core/Checkbox'
 import Chip from '@material-ui/core/Chip'
@@ -43,15 +44,10 @@ const StyledReorderIcon = styled(ReorderIcon)`
   cursor: ns-resize;
 `
 
-const StyledButton = styled(Button)`
-  overflow: hidden;
-  white-space: nowrap;
-`
-
 const Actions = () => (
-  <StyledButton color="primary" component={Link} to={routes.triggerCreate()} variant="contained">
+  <AppBarButton color="primary" component={Link} to={routes.triggerCreate()} variant="contained">
     {'Create New'}
-  </StyledButton>
+  </AppBarButton>
 )
 
 const columns = [

--- a/console-frontend/src/app/theme.js
+++ b/console-frontend/src/app/theme.js
@@ -43,8 +43,12 @@ const palette = {
     main: '#ffaa00', // weird color is temporary here: make sure we're not using this yet.
   },
   text: {
-    disabled: '#ccc',
-    hint: '#ddd',
+    disabled: '#999',
+    hint: '#999',
+  },
+  action: {
+    disabled: '#fff',
+    disabledBackground: '#575a6a',
   },
 }
 

--- a/console-frontend/src/ext/recompose/enhance-list.js
+++ b/console-frontend/src/ext/recompose/enhance-list.js
@@ -1,4 +1,4 @@
-import Button from '@material-ui/core/Button'
+import AppBarButton from 'shared/app-bar-button'
 import Checkbox from '@material-ui/core/Checkbox'
 import CircularProgress from 'shared/circular-progress'
 import MUICheckBoxIcon from '@material-ui/icons/CheckBox'
@@ -17,15 +17,10 @@ const CheckBoxIcon = styled(MUICheckBoxIcon)`
   color: blue;
 `
 
-const StyledButton = styled(Button)`
-  overflow: hidden;
-  white-space: nowrap;
-`
-
 const Actions = ({ createRoute }) => (
-  <StyledButton color="primary" component={Link} to={createRoute} variant="contained">
+  <AppBarButton color="primary" component={Link} to={createRoute} variant="contained">
     {'Create New'}
-  </StyledButton>
+  </AppBarButton>
 )
 
 const enhanceList = ({ api, columns, breadcrumbs, routes }) => ResourceRow =>

--- a/console-frontend/src/ext/recompose/with-classes.js
+++ b/console-frontend/src/ext/recompose/with-classes.js
@@ -1,0 +1,29 @@
+import omit from 'lodash.omit'
+import React from 'react'
+import { compose, createSink, mapProps, withProps } from 'recompose'
+import { isEqual } from 'lodash'
+import { withStoreConsumer } from './with-store'
+
+const Sink = createSink(({ classes, store, setStore }) => {
+  if (isEqual(classes, store.classes)) return
+  setStore({ ...store, classes })
+})
+
+const withClasses = BaseComponent =>
+  compose(withStoreConsumer)(({ classes, store, ...props }) => (
+    <React.Fragment>
+      <Sink classes={classes} store={store} {...props} />
+      {store.classes && <BaseComponent classes={classes} {...omit(props, ['setStore'])} />}
+    </React.Fragment>
+  ))
+
+export const withClassesConsumer = BaseComponent =>
+  compose(
+    withStoreConsumer,
+    withProps(({ store }) => ({
+      classes: store.classes,
+    })),
+    mapProps(props => omit(props, ['store', 'setStore']))
+  )(BaseComponent)
+
+export default withClasses

--- a/console-frontend/src/shared/app-bar-button.js
+++ b/console-frontend/src/shared/app-bar-button.js
@@ -1,0 +1,13 @@
+import classnames from 'classnames'
+import MuiButton from '@material-ui/core/Button'
+import React from 'react'
+import { compose } from 'recompose'
+import { withClassesConsumer } from 'ext/recompose/with-classes'
+
+const Button = ({ children, classes, disabled, ...props }) => (
+  <MuiButton className={classnames(!disabled && classes.appBarButton)} disabled={disabled} {...props}>
+    {children}
+  </MuiButton>
+)
+
+export default compose(withClassesConsumer)(Button)

--- a/console-frontend/src/shared/breadcrumbs.js
+++ b/console-frontend/src/shared/breadcrumbs.js
@@ -3,8 +3,11 @@ import Link from 'shared/link'
 import React from 'react'
 import Typography from '@material-ui/core/Typography'
 
-const Title = ({ text, classes, responsive }) => (
-  <Typography className={classnames(classes.title, responsive && classes.titleResponsive)} variant="h6">
+const Title = ({ text, classes, responsive, highlight }) => (
+  <Typography
+    className={classnames(classes.title, highlight && classes.titleHighlight, responsive && classes.titleResponsive)}
+    variant="h6"
+  >
     {text}
   </Typography>
 )
@@ -15,7 +18,7 @@ const Breadcrumbs = ({ breadcrumbs, classes }) => (
       <React.Fragment key={breadcrumb.route || breadcrumb.text}>
         {breadcrumb.route ? (
           <Link to={breadcrumb.route}>
-            <Title classes={classes} responsive text={breadcrumb.text} />
+            <Title classes={classes} highlight responsive text={breadcrumb.text} />
           </Link>
         ) : (
           <Title classes={classes} text={breadcrumb.text} />

--- a/console-frontend/src/shared/form-elements/save-button.js
+++ b/console-frontend/src/shared/form-elements/save-button.js
@@ -1,10 +1,10 @@
-import MuiButton from '@material-ui/core/Button'
+import AppBarButton from 'shared/app-bar-button'
 import React from 'react'
 
 const Button = ({ message, ...props }) => (
-  <MuiButton {...props} color="primary" type="submit" variant="contained">
+  <AppBarButton color="primary" {...props} type="submit" variant="contained">
     {message || 'Save'}
-  </MuiButton>
+  </AppBarButton>
 )
 
 export default Button


### PR DESCRIPTION
### Changes in mobile design and contrast
- Changed colors of buttons based on design;
- Colors of disabled elements changed as well;
- Added store to classes (in future we may refactor classes in general);
- Changed the behavior of `breadcrumbs`;
### Preview:

![screenshot from 2018-12-10 18-30-58](https://user-images.githubusercontent.com/32452032/49752932-c3d52b00-fca9-11e8-911f-ba1a0fb0e62d.png)

![peek 2018-12-10 18-41](https://user-images.githubusercontent.com/32452032/49753423-3f83a780-fcab-11e8-939a-060b3084e200.gif)


![peek 2018-12-10 18-25](https://user-images.githubusercontent.com/32452032/49752899-a4d69900-fca9-11e8-979a-42c8cb01ae23.gif)