### PR TITLE
Fix cropped section headers in menu

### DIFF
--- a/console-frontend/src/app/layout/menu.js
+++ b/console-frontend/src/app/layout/menu.js
@@ -63,6 +63,7 @@ const GroupText = styled(({ ...props }) => <Typography {...omit(props, ['sidebar
   text-transform: uppercase;
   transition: 0.6s all;
   height: 1rem;
+  line-height: 1rem;
   opacity: ${({ sidebarOpen }) => (sidebarOpen ? 1 : 0)};
   overflow: hidden;
   user-select: none;


### PR DESCRIPTION
https://trello.com/c/W6PE39I0/561-cropped-section-headers-in-menu-on-zoom-out