### PR TITLE
Don't show Onboarding on mobile

### DIFF
--- a/console-frontend/src/app/layout/app-bar.js
+++ b/console-frontend/src/app/layout/app-bar.js
@@ -5,7 +5,7 @@ import MenuIcon from '@material-ui/icons/Menu'
 import React from 'react'
 import styled from 'styled-components'
 import { branch, compose, renderNothing, withHandlers, withProps } from 'recompose'
-import { IconButton, AppBar as MuiAppBar, Toolbar } from '@material-ui/core'
+import { Hidden, IconButton, AppBar as MuiAppBar, Toolbar } from '@material-ui/core'
 import { withOnboardingConsumer } from 'ext/recompose/with-onboarding'
 import { withStoreConsumer } from 'ext/recompose/with-store'
 
@@ -24,9 +24,11 @@ const StyledHelp = styled(IconButton)`
 `
 
 const OnboardingButtonTemplate = ({ handleClick }) => (
-  <StyledHelp onClick={handleClick}>
-    <HelpOutline />
-  </StyledHelp>
+  <Hidden smDown>
+    <StyledHelp onClick={handleClick}>
+      <HelpOutline />
+    </StyledHelp>
+  </Hidden>
 )
 
 const OnboardingButton = compose(

--- a/console-frontend/src/app/screens/welcome.js
+++ b/console-frontend/src/app/screens/welcome.js
@@ -2,10 +2,11 @@ import auth from 'auth'
 import React from 'react'
 import routes from 'app/routes'
 import { changeStage } from 'onboarding/scenario-actions'
-import { compose, withHandlers } from 'recompose'
+import { compose, lifecycle, withHandlers } from 'recompose'
 import { Container, Description, Header, Image, OutlinedButton, StyledButton } from 'shared/blank-state/components'
 import { withOnboardingConsumer } from 'ext/recompose/with-onboarding'
 import { withRouter } from 'react-router'
+import { withWidth } from '@material-ui/core'
 
 const title = `Welcome${auth.getUser().firstName ? `, ${auth.getUser().firstName}` : ''}!`
 const description =
@@ -30,6 +31,15 @@ const WelcomePage = ({ getStarted, skipOnboarding }) => (
 export default compose(
   withRouter,
   withOnboardingConsumer,
+  withWidth(),
+  lifecycle({
+    componentDidMount() {
+      const { width, history } = this.props
+      if (width === 'xs' || width === 'sm') {
+        history.push(routes.triggersList())
+      }
+    },
+  }),
   withHandlers({
     getStarted: ({ history, onboarding, setOnboarding }) => () => {
       setOnboarding({ ...onboarding, run: true })

--- a/console-frontend/src/onboarding/index.js
+++ b/console-frontend/src/onboarding/index.js
@@ -2,7 +2,7 @@ import Joyride from 'react-joyride'
 import React from 'react'
 import SkipButton from './elements/skip-button'
 import { branch, compose, renderNothing } from 'recompose'
-import { Portal } from '@material-ui/core'
+import { Hidden, Portal } from '@material-ui/core'
 import { stages, stagesArray } from './stages'
 import { withOnboardingConsumer } from 'ext/recompose/with-onboarding'
 
@@ -40,7 +40,7 @@ const getOnboardingConfig = onboarding => {
 const DummyContainer = ({ content, ...props }) => <div>{content && React.cloneElement(content, props)}</div>
 
 const Onboarding = ({ onboarding }) => (
-  <>
+  <Hidden smDown>
     <Joyride
       continuous
       disableOverlayClose
@@ -54,7 +54,7 @@ const Onboarding = ({ onboarding }) => (
     <Portal>
       <SkipButton />
     </Portal>
-  </>
+  </Hidden>
 )
 
 export default compose(


### PR DESCRIPTION
### Changes:
- When user logs in for the first time from mobile screen he's redirected to Triggers page and Onboarding is never shown after that.