### PR TITLE
Fix outro preview bug

### DIFF
--- a/console-frontend/src/app/layout/sidebar.js
+++ b/console-frontend/src/app/layout/sidebar.js
@@ -46,5 +46,5 @@ export default compose(
       }, 2000)
     },
   }),
-  withWidth({ resizeInterval: Infinity }) // used to initialize the visibility on first render
+  withWidth({ resizeInterval: Infinity, noSSR: true }) // used to initialize the visibility on first render
 )(Sidebar)

--- a/console-frontend/src/app/resources/outros/form.js
+++ b/console-frontend/src/app/resources/outros/form.js
@@ -43,7 +43,7 @@ const PluginPreviewTemplate = styled(({ className, persona, width }) => (
   margin-bottom: 30px;
 `
 
-const PluginPreview = withWidth()(PluginPreviewTemplate)
+const PluginPreview = withWidth({ noSSR: true })(PluginPreviewTemplate)
 
 const OutroForm = ({
   formRef,

--- a/console-frontend/src/app/screens/welcome.js
+++ b/console-frontend/src/app/screens/welcome.js
@@ -31,7 +31,7 @@ const WelcomePage = ({ getStarted, skipOnboarding }) => (
 export default compose(
   withRouter,
   withOnboardingConsumer,
-  withWidth(),
+  withWidth({ noSSR: true }),
   lifecycle({
     componentDidMount() {
       const { width, history } = this.props


### PR DESCRIPTION
### Cause
Bug happened because of the Server Side Rendering option enabled which caused double render of the iframe resulting in it losing the data or reference to it's DOM object.
https://material-ui.com/layout/breakpoints/#withwidth-options-higher-order-component

### Fix
Removal of SSR as mentioned in MUI docs.