### PR TITLE
Fix Navigation item picture bug

### DIFF
--- a/console-frontend/src/app/resources/navigations/form/index.js
+++ b/console-frontend/src/app/resources/navigations/form/index.js
@@ -9,6 +9,7 @@ import withForm from 'ext/recompose/with-form'
 import { Actions, AddItemContainer, Form } from 'shared/form-elements'
 import { apiPersonasAutocomplete } from 'utils'
 import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
+import { find } from 'lodash'
 import { FormHelperText, Grid, TextField } from '@material-ui/core'
 import { uploadImage } from 'shared/picture-uploader'
 import { withOnboardingHelp } from 'ext/recompose/with-onboarding'
@@ -89,7 +90,7 @@ export default compose(
   withProps({ formRef: React.createRef() }),
   withState('errors', 'setErrors', null),
   withState('isCropping', 'setIsCropping', false),
-  withState('navigationItemsPictures', 'setNavigationItemsPictures', []),
+  withState('navigationItemsPictures', 'setNavigationItemsPictures', () => []),
   withHandlers({
     uploadSubImage: () => async ({ blob, setProgress, subform }) => {
       const picUrl = await uploadImage({
@@ -167,7 +168,10 @@ export default compose(
       return result
     },
     setPicture: ({ navigationItemsPictures, setNavigationItemsPictures }) => (index, blob, setProgress) => {
-      navigationItemsPictures.push({ index, blob, setProgress })
+      const picture = { index, blob, setProgress }
+      find(navigationItemsPictures, { index })
+        ? navigationItemsPictures.splice(index, 1, picture)
+        : navigationItemsPictures.push(picture)
       setNavigationItemsPictures(navigationItemsPictures)
     },
   }),


### PR DESCRIPTION
https://trello.com/c/yH1r8OgX/596-edit-one-nav-add-pics-then-go-edit-another-nav-the-pics-are-set-to-the-first-nav-pics

**Description:** Starting with no Navigations, create one with one nav item. Create another Navigation with one nav item. The url for the last picture saved in the db is the same as the first one.

**Issue:** _navigationItemsPictures_ array wasn't empty when the form component was mounted. This was resulting in two objects with same index and generating a conflict ahead on:
```
withHandlers({
    uploadSubImages: ({ navigationItemsPictures, uploadSubImage }) => form => {
      return navigationItemsPictures.map(async ({ blob, index, setProgress }) => {
        form.navigationItemsAttributes[index] = await uploadSubImage({
          subform: form.navigationItemsAttributes[index],
          blob,
          setProgress,
        })
      })
    },
  }),```
