### PR TITLE
Fix onboarding escape key bug

### DIFF
--- a/console-frontend/src/onboarding/elements/modal-persona-create.js
+++ b/console-frontend/src/onboarding/elements/modal-persona-create.js
@@ -44,7 +44,13 @@ const DialogContent = () => (
 )
 
 const ModalTemplate = ({ open, setOpen }) => (
-  <Dialog content={<DialogContent />} dialogActions={<DialogActions setOpen={setOpen} />} open={open} title="" />
+  <Dialog
+    content={<DialogContent />}
+    dialogActions={<DialogActions setOpen={setOpen} />}
+    hideBackdrop
+    open={open}
+    title=""
+  />
 )
 
 export default compose(

--- a/console-frontend/src/onboarding/index.js
+++ b/console-frontend/src/onboarding/index.js
@@ -1,7 +1,7 @@
 import Joyride from 'react-joyride'
 import React from 'react'
 import SkipButton from './elements/skip-button'
-import { branch, compose, renderNothing } from 'recompose'
+import { branch, compose, lifecycle, renderNothing, withHandlers } from 'recompose'
 import { Hidden, Portal } from '@material-ui/core'
 import { stages, stagesArray } from './stages'
 import { withOnboardingConsumer } from 'ext/recompose/with-onboarding'
@@ -43,7 +43,9 @@ const Onboarding = ({ onboarding }) => (
   <Hidden smDown>
     <Joyride
       continuous
+      disableCloseOnEsc
       disableOverlayClose
+      disableScrolling
       floaterProps={floaterProps}
       run={onboarding.run || onboarding.help.run}
       stepIndex={getOnboardingConfig(onboarding).stepIndex}
@@ -62,5 +64,22 @@ export default compose(
   branch(
     ({ onboarding }) => (!onboarding.run || !stagesArray[onboarding.stageIndex]) && !onboarding.help.run,
     renderNothing
-  )
+  ),
+  withHandlers({
+    handleClose: ({ setOnboarding, onboarding }) => event => {
+      if (event.keyCode === 27) {
+        setOnboarding({ ...onboarding, run: false, help: { ...onboarding.help, run: false } })
+      }
+    },
+  }),
+  lifecycle({
+    componentDidMount() {
+      const { handleClose } = this.props
+      document.addEventListener('keydown', handleClose)
+    },
+    componentWillUnmount() {
+      const { handleClose } = this.props
+      document.removeEventListener('keydown', handleClose)
+    },
+  })
 )(Onboarding)

--- a/console-frontend/src/shared/dialog.js
+++ b/console-frontend/src/shared/dialog.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { DialogActions, DialogContent, DialogContentText, DialogTitle, Dialog as MuiDialog } from '@material-ui/core'
 
-const Dialog = ({ open, handleClose, dialogActions, title, content }) => (
-  <MuiDialog aria-labelledby="form-dialog-title" onClose={handleClose} open={open}>
+const Dialog = ({ open, handleClose, dialogActions, title, content, ...props }) => (
+  <MuiDialog aria-labelledby="form-dialog-title" onClose={handleClose} open={open} {...props}>
     <DialogTitle id="form-dialog-title">{title}</DialogTitle>
     <DialogContent>
       {typeof content == 'string' ? <DialogContentText>{content}</DialogContentText> : content}


### PR DESCRIPTION
### Changes
- Escape key works as expected in `onboarding`;
- Double backdrop (caused by a `dialog` component) removed;
- Disabled scrolling on overlay in order to remove warnings caused by `react-joyride` package timeouts and `setState`'s (isn't responsible for previous bug reports about scrolling);