### PR TITLE
Fix empty array bugs on Showcases and Navigations

### DIFF
--- a/console-frontend/src/app/resources/navigations/form/index.js
+++ b/console-frontend/src/app/resources/navigations/form/index.js
@@ -10,7 +10,7 @@ import withForm from 'ext/recompose/with-form'
 import { Actions, AddItemContainer, Form } from 'shared/form-elements'
 import { apiPersonasAutocomplete } from 'utils'
 import { branch, compose, renderComponent, withHandlers, withProps, withState } from 'recompose'
-import { find } from 'lodash'
+import { findIndex } from 'lodash'
 import { FormHelperText, Grid, TextField } from '@material-ui/core'
 import { Navigation } from 'plugin-base'
 import { uploadImage } from 'shared/picture-uploader'
@@ -126,7 +126,7 @@ export default compose(
   withProps({ formRef: React.createRef() }),
   withState('errors', 'setErrors', null),
   withState('isCropping', 'setIsCropping', false),
-  withState('navigationItemsPictures', 'setNavigationItemsPictures', () => []),
+  withState('navigationItemsPictures', 'setNavigationItemsPictures', []),
   withState('persona', 'setPersona', emptyPersona),
   withHandlers({
     convertPersona: () => persona => ({
@@ -221,10 +221,12 @@ export default compose(
     },
     setPicture: ({ navigationItemsPictures, setNavigationItemsPictures }) => (index, blob, setProgress) => {
       const picture = { index, blob, setProgress }
-      find(navigationItemsPictures, { index })
-        ? navigationItemsPictures.splice(index, 1, picture)
-        : navigationItemsPictures.push(picture)
-      setNavigationItemsPictures(navigationItemsPictures)
+      let newNavigationItemsPictures = [...navigationItemsPictures]
+      const navigationItemsPictureIndex = findIndex(newNavigationItemsPictures, { index })
+      navigationItemsPictureIndex >= 0
+        ? newNavigationItemsPictures.splice(navigationItemsPictureIndex, 1, picture)
+        : newNavigationItemsPictures.push(picture)
+      setNavigationItemsPictures(newNavigationItemsPictures)
     },
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),

--- a/console-frontend/src/app/resources/showcases/form/spotlight.js
+++ b/console-frontend/src/app/resources/showcases/form/spotlight.js
@@ -5,6 +5,7 @@ import Select from 'shared/select'
 import { AddItemButton, Cancel, FormSection } from 'shared/form-elements'
 import { apiPersonasAutocomplete } from 'utils'
 import { branch, compose, renderNothing, withHandlers } from 'recompose'
+import { findIndex } from 'lodash'
 import { Grid, TextField } from '@material-ui/core'
 
 const Spotlight = ({
@@ -134,8 +135,13 @@ export default compose(
       blob,
       setProgress
     ) => {
-      productPicksPictures.push({ spotlightIndex: index, productPickIndex, blob, setProgress })
-      setProductPicksPictures(productPicksPictures)
+      const picture = { spotlightIndex: index, productPickIndex, blob, setProgress }
+      let newProductPicksPictures = [...productPicksPictures]
+      const productPickPictureIndex = findIndex(newProductPicksPictures, { spotlightIndex: index, productPickIndex })
+      productPickPictureIndex >= 0
+        ? newProductPicksPictures.splice(productPickPictureIndex, 1, picture)
+        : newProductPicksPictures.push(picture)
+      setProductPicksPictures(newProductPicksPictures)
     },
   })
 )(Spotlight)


### PR DESCRIPTION
https://trello.com/c/SHo2Qzl4/617-check-for-more-cases-of-potential-bugs-with-using-empty-array
**Fixed:** 
1) When a Navigation/Showcase picture is updated, the correspondent pictures array isn't cleared. 
2) When the user updates the picture twice the last picture is inserted in the array, neglecting the one that's already there.