### PR TITLE
Set correct order after creating orderable item

### DIFF
--- a/backend/app/models/navigation_item.rb
+++ b/backend/app/models/navigation_item.rb
@@ -6,7 +6,14 @@ class NavigationItem < ApplicationRecord
   validates :url, presence: true
   validates :pic_url, presence: true
 
+  before_create :update_order
+
   def as_json(_options = {})
     { id: id, text: text, url: url, pic_url: pic_url }
+  end
+
+  def update_order
+    return if self.class.where(navigation_id: navigation_id).empty?
+    self.order = self.class.where(navigation_id: navigation_id).order(:order).pluck(:order).last + 1
   end
 end

--- a/backend/app/models/product_pick.rb
+++ b/backend/app/models/product_pick.rb
@@ -1,4 +1,11 @@
 class ProductPick < ApplicationRecord
   acts_as_tenant
   belongs_to :spotlight
+
+  before_create :update_order
+
+  def update_order
+    return if self.class.where(spotlight_id: spotlight_id).empty?
+    self.order = self.class.where(spotlight_id: spotlight_id).order(:order).pluck(:order).last + 1
+  end
 end

--- a/backend/app/models/spotlight.rb
+++ b/backend/app/models/spotlight.rb
@@ -6,10 +6,17 @@ class Spotlight < ApplicationRecord
 
   accepts_nested_attributes_for :product_picks, allow_destroy: true
 
+  before_create :update_order
+
   def paths(spotlight_index)
     new_step = attributes.slice("id", "name")
     new_step[:name] = "#{showcase.name}: Spotlight ##{spotlight_index}"
     new_step[:path] = "/showcase/#{showcase.id}/#{self.class.name.underscore.tr('_', '-')}/#{id}"
     [new_step]
+  end
+
+  def update_order
+    return if self.class.where(showcase_id: showcase_id).empty?
+    self.order = self.class.where(showcase_id: showcase_id).order(:order).pluck(:order).last + 1
   end
 end

--- a/backend/app/models/trigger.rb
+++ b/backend/app/models/trigger.rb
@@ -7,6 +7,8 @@ class Trigger < ApplicationRecord
   validates :url_matchers, presence: true
   validate :url_matchers_cannot_be_blank
 
+  before_create :update_order
+
   def self.find_matching(pathname)
     Trigger.order(:order).find do |trigger|
       trigger.url_matchers.any? do |url_matcher|
@@ -19,6 +21,11 @@ class Trigger < ApplicationRecord
     attributes
       .slice("id", "order", "url_matchers", "flow_id", "flow_type", "created_at", "updated_at")
       .merge(flow: { id: flow.id, name: flow.name })
+  end
+
+  def update_order
+    return unless self.class.any?
+    self.order = self.class.order(:order).pluck(:order).last + 1
   end
 
   private

--- a/backend/test/factories/navigation_items.rb
+++ b/backend/test/factories/navigation_items.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :navigation_item do
+    sequence(:url) { Faker::Internet.url }
+    sequence(:text) { Faker::Lorem.sentence }
+    sequence(:pic_url) { Faker::Avatar.image }
+  end
+end

--- a/backend/test/factories/product_picks.rb
+++ b/backend/test/factories/product_picks.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :product_pick do
+    sequence(:url) { Faker::Internet.url }
+    sequence(:description) { Faker::Lorem.words(4) }
+    sequence(:pic_url) { Faker::Avatar.image }
+    sequence(:display_price) { Faker::Commerce.price }
+    sequence(:name) { Faker::Commerce.product_name }
+  end
+end

--- a/backend/test/factories/showcase.rb
+++ b/backend/test/factories/showcase.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :showcase do
+    sequence(:title) { Faker::Lorem.words(2) }
+    sequence(:subtitle) { Faker::Lorem.words(4) }
+    sequence(:name) { Faker::StarWars.planet }
+    persona
+  end
+end

--- a/backend/test/factories/spotlights.rb
+++ b/backend/test/factories/spotlights.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :spotlight do
+    sequence(:text) { Faker::Lorem.words(4) }
+    persona
+  end
+end

--- a/backend/test/factories/triggers.rb
+++ b/backend/test/factories/triggers.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :trigger do
-    sequence(:order)
     url_matchers { %w[/] }
     association :flow, factory: :outro
   end

--- a/backend/test/models/navigation_item_test.rb
+++ b/backend/test/models/navigation_item_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class NavigationItemTest < ActiveSupport::TestCase
+  test "navigation items sorted after create" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    navigation = create(:navigation)
+    2.times { create(:navigation_item, navigation: navigation) }
+    result = navigation.navigation_items.pluck(:order)
+
+    assert_equal [1, 2], result
+  end
+
+  test "navigation items sorted after deleting navigation item and creating two new ones" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    navigation = create(:navigation)
+    3.times { create(:navigation_item, navigation: navigation) }
+    navigation.navigation_items.first.destroy
+    2.times { create(:navigation_item, navigation: navigation) }
+    result = navigation.navigation_items.pluck(:order)
+
+    assert_equal [2, 3, 4, 5], result
+  end
+end

--- a/backend/test/models/product_pick_test.rb
+++ b/backend/test/models/product_pick_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class ProductPickTest < ActiveSupport::TestCase
+  test "product picks sorted after create" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    showcase = create(:showcase)
+    spotlight = create(:spotlight, showcase: showcase)
+    2.times { create(:product_pick, spotlight: spotlight) }
+    result = spotlight.product_picks.pluck(:order)
+
+    assert_equal [1, 2], result
+  end
+
+  test "product picks sorted after deleting product pick and creating two new ones" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    showcase = create(:showcase)
+    spotlight = create(:spotlight, showcase: showcase)
+    3.times { create(:product_pick, spotlight: spotlight) }
+    spotlight.product_picks.first.destroy
+    2.times { create(:product_pick, spotlight: spotlight) }
+    result = spotlight.product_picks.pluck(:order)
+
+    assert_equal [2, 3, 4, 5], result
+  end
+end

--- a/backend/test/models/spotlight_test.rb
+++ b/backend/test/models/spotlight_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class SpotlightTest < ActiveSupport::TestCase
+  test "spotlights sorted after create" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    showcase = create(:showcase)
+    2.times { create(:spotlight, showcase: showcase) }
+    result = showcase.spotlights.pluck(:order)
+
+    assert_equal [1, 2], result
+  end
+
+  test "spotlights sorted after deleting spotlight and creating two new ones" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    showcase = create(:showcase)
+    3.times { create(:spotlight, showcase: showcase) }
+    showcase.spotlights.first.destroy
+    2.times { create(:spotlight, showcase: showcase) }
+    result = showcase.spotlights.pluck(:order)
+
+    assert_equal [2, 3, 4, 5], result
+  end
+end

--- a/backend/test/models/trigger_test.rb
+++ b/backend/test/models/trigger_test.rb
@@ -44,4 +44,24 @@ class TriggerTest < ActiveSupport::TestCase
 
     assert_nil result
   end
+
+  test "triggers sorted after create" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    2.times { create(:trigger) }
+    result = Trigger.pluck(:order)
+
+    assert_equal [1, 2], result
+  end
+
+  test "triggers sorted after deleting trigger and creating two new ones" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    3.times { create(:trigger) }
+    Trigger.first.destroy
+    2.times { create(:trigger) }
+    result = Trigger.pluck(:order)
+
+    assert_equal [2, 3, 4, 5], result
+  end
 end


### PR DESCRIPTION
https://trello.com/c/lI2aVKCh/643-on-create-set-correct-order-value-for-orderable-items

**Description:**
The default order value for `Spotlight`, `ProductPick`, `NavigationItem` and `Trigger` is **`1`**. 
This value is now being changed, before creating a new instance, according to the other existing items on that list (so that the new item is last).