### PR TITLE
Prevent multiple instance create/update on form submitting (client-side)

### DIFF
--- a/console-frontend/src/app/resources/navigations/form/index.js
+++ b/console-frontend/src/app/resources/navigations/form/index.js
@@ -276,11 +276,13 @@ export default compose(
       })
       setPersona(convertPersona(value))
     },
-    onFormSubmit: ({ location, formRef, history, onFormSubmit }) => async event => {
+    onFormSubmit: ({ location, formRef, history, onFormSubmit, setIsFormSubmitting }) => async event => {
       if (!formRef.current.reportValidity()) return
+      setIsFormSubmitting(true)
       const result = await onFormSubmit(event)
-      if (result.error || result.errors) return
+      if (result.error || result.errors) return setIsFormSubmitting(false)
       if (location.pathname !== routes.navigationEdit(result.id)) history.push(routes.navigationEdit(result.id))
+      setIsFormSubmitting(false)
       return result
     },
     setPicture: ({ navigationItemsPictures, setNavigationItemsPictures }) => (index, blob, setProgress) => {
@@ -298,8 +300,8 @@ export default compose(
     },
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
-  withAppBarContent(({ breadcrumbs, isCropping, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isCropping || isFormLoading} />,
+  withAppBarContent(({ breadcrumbs, isCropping, isFormLoading, isFormSubmitting, onFormSubmit }) => ({
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormSubmitting || isCropping || isFormLoading} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/app/resources/outros/form.js
+++ b/console-frontend/src/app/resources/outros/form.js
@@ -135,17 +135,19 @@ export default compose(
         persona: convertPersona(value),
       })
     },
-    onFormSubmit: ({ location, formRef, history, onFormSubmit }) => async event => {
+    onFormSubmit: ({ location, formRef, history, onFormSubmit, setIsFormSubmitting }) => async event => {
       if (!formRef.current.reportValidity()) return
+      setIsFormSubmitting(true)
       const result = await onFormSubmit(event)
-      if (result.error || result.errors) return
+      if (result.error || result.errors) return setIsFormSubmitting(false)
       if (location.pathname !== routes.outroEdit(result.id)) history.push(routes.outroEdit(result.id))
+      setIsFormSubmitting(false)
       return result
     },
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
-  withAppBarContent(({ breadcrumbs, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormLoading} />,
+  withAppBarContent(({ breadcrumbs, isFormLoading, isFormSubmitting, onFormSubmit }) => ({
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormSubmitting || isFormLoading} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/app/resources/personas/form.js
+++ b/console-frontend/src/app/resources/personas/form.js
@@ -129,16 +129,26 @@ export default compose(
   withRouter,
   withOnboardingConsumer,
   withHandlers({
-    onFormSubmit: ({ formRef, history, onFormSubmit, onboarding, setOnboarding, onboardingCreate }) => async event => {
+    onFormSubmit: ({
+      formRef,
+      history,
+      onFormSubmit,
+      onboarding,
+      onboardingCreate,
+      setOnboarding,
+      setIsFormSubmitting,
+    }) => async event => {
       if (!formRef.current.reportValidity()) return
+      setIsFormSubmitting(true)
       const result = await onFormSubmit(event)
-      if (result.error || result.errors) return
+      if (result.error || result.errors) return setIsFormSubmitting(false)
       setTimeout(() => {
         if (onboardingCreate && (onboarding.stageIndex < 2 && !onboarding.run)) {
           setOnboarding({ ...onboarding, stageIndex: 1, run: true })
         }
       }, 0)
       history.push(routes.personasList())
+      setIsFormSubmitting(false)
       return result
     },
     setProfilePicUrl: ({ form, setForm }) => profilePicUrl => {
@@ -146,12 +156,12 @@ export default compose(
     },
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
-  withAppBarContent(({ breadcrumbs, isCropping, isFormLoading, onFormSubmit, create }) => ({
+  withAppBarContent(({ breadcrumbs, create, isCropping, isFormLoading, isFormSubmitting, onFormSubmit }) => ({
     Actions: (
       <Actions
         onFormSubmit={onFormSubmit}
         saveClassName={create && 'onboard-create-persona'}
-        saveDisabled={isFormLoading || isCropping}
+        saveDisabled={isFormSubmitting || isFormLoading || isCropping}
       />
     ),
     breadcrumbs,

--- a/console-frontend/src/app/resources/scripted-chats/form/index.js
+++ b/console-frontend/src/app/resources/scripted-chats/form/index.js
@@ -185,17 +185,19 @@ export default compose(
         personaId: value.id,
       })
     },
-    onFormSubmit: ({ location, formRef, history, onFormSubmit }) => async event => {
+    onFormSubmit: ({ location, formRef, history, onFormSubmit, setIsFormSubmitting }) => async event => {
       if (!formRef.current.reportValidity()) return
+      setIsFormSubmitting(true)
       const result = await onFormSubmit(event)
-      if (result.error || result.errors) return
+      if (result.error || result.errors) return setIsFormSubmitting(false)
       if (location.pathname !== routes.scriptedChatEdit(result.id)) history.push(routes.scriptedChatEdit(result.id))
+      setIsFormSubmitting(false)
       return result
     },
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
-  withAppBarContent(({ breadcrumbs, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormLoading} />,
+  withAppBarContent(({ breadcrumbs, isFormLoading, isFormSubmitting, onFormSubmit }) => ({
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormSubmitting || isFormLoading} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/app/resources/showcases/form/index.js
+++ b/console-frontend/src/app/resources/showcases/form/index.js
@@ -362,12 +362,14 @@ export default compose(
         personaId: value.id,
       })
     },
-    onFormSubmit: ({ location, formRef, history, onFormSubmit }) => async event => {
+    onFormSubmit: ({ location, formRef, history, onFormSubmit, setIsFormSubmitting }) => async event => {
       if (!formRef.current.reportValidity()) return
+      setIsFormSubmitting(true)
       const result = await onFormSubmit(event)
-      if (result.error || result.errors) return
+      if (result.error || result.errors) return setIsFormSubmitting(false)
       pluginHistory.replace(pluginRoutes.showcase(result.id))
       if (location.pathname !== routes.showcaseEdit(result.id)) history.push(routes.showcaseEdit(result.id))
+      setIsFormSubmitting(false)
       return result
     },
     onSortEnd: ({ setForm, form }) => ({ oldIndex, newIndex }) => {
@@ -395,8 +397,8 @@ export default compose(
     },
   })),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
-  withAppBarContent(({ breadcrumbs, isCropping, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isCropping || isFormLoading} />,
+  withAppBarContent(({ breadcrumbs, isCropping, isFormLoading, isFormSubmitting, onFormSubmit }) => ({
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormSubmitting || isCropping || isFormLoading} />,
     breadcrumbs,
   })),
   lifecycle({

--- a/console-frontend/src/app/resources/triggers/form.js
+++ b/console-frontend/src/app/resources/triggers/form.js
@@ -154,10 +154,12 @@ export default compose(
   }),
   withRouter,
   withHandlers({
-    onFormSubmit: ({ formRef, history, onFormSubmit }) => async event => {
+    onFormSubmit: ({ formRef, history, onFormSubmit, setIsFormSubmitting }) => async event => {
       if (!formRef.current.reportValidity()) return
+      setIsFormSubmitting(true)
       const result = await onFormSubmit(event)
       if (!result.error && !result.errors) history.push(routes.triggersList())
+      setIsFormSubmitting(false)
       return result
     },
     selectFlow: ({ form, setForm }) => ({ value }) => {
@@ -169,8 +171,8 @@ export default compose(
     },
   }),
   branch(({ isFormLoading }) => isFormLoading, renderComponent(CircularProgress)),
-  withAppBarContent(({ breadcrumbs, isFormLoading, onFormSubmit }) => ({
-    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormLoading} />,
+  withAppBarContent(({ breadcrumbs, isFormLoading, isFormSubmitting, onFormSubmit }) => ({
+    Actions: <Actions onFormSubmit={onFormSubmit} saveDisabled={isFormSubmitting || isFormLoading} />,
     breadcrumbs,
   })),
   withProps(({ breadcrumbs }) => ({

--- a/console-frontend/src/ext/recompose/with-form.js
+++ b/console-frontend/src/ext/recompose/with-form.js
@@ -6,6 +6,7 @@ const withForm = initialForm => BaseComponent =>
     withState('initialForm', 'setInitialForm', initialForm),
     withState('form', 'setForm', ({ initialForm }) => initialForm),
     withState('isFormLoading', 'setIsFormLoading', true),
+    withState('isFormSubmitting', 'setIsFormSubmitting', false),
     withProps(({ form, initialForm }) => ({
       isFormPristine: isEqual(form, initialForm),
     })),


### PR DESCRIPTION
https://trello.com/c/EqZOuJFr/731-double-click-save-button-dont-double-create

- Changes to **Triggers**/**Showcases**/**Navigations**/**Scripted Chats**/**Outros**/**Personas**:

The save button is now disabled while the form is submitting by controlling the new `isFormSubmitting` state value on the `onFormSubmit` handler. 