### PR TITLE
Allow customizing of chat option actions and texts

### DIFF
--- a/backend/app/controllers/scripted_chats_controller.rb
+++ b/backend/app/controllers/scripted_chats_controller.rb
@@ -45,7 +45,7 @@ class ScriptedChatsController < RestController
   private
 
   def scripted_chat_params
-    result = params.require(:scripted_chat).permit(:id, :name, :title, :chat_bubble_text, :persona_id,
+    result = params.require(:scripted_chat).permit(:id, :name, :title, :action_type, :chat_bubble_text, :persona_id,
                                                    chat_step_attributes: {})
     add_order_fields(result[:chat_step_attributes])
     result

--- a/backend/app/graphql/types/chat_option_type.rb
+++ b/backend/app/graphql/types/chat_option_type.rb
@@ -9,6 +9,11 @@ Types::ChatOptionType = GraphQL::ObjectType.define do
       obj.chat_step
     }
   end
+  field :actionType, types.String do
+    resolve ->(obj, _args, _ctx) {
+      obj.action_type
+    }
+  end
   field :destinationChatStep, Types::ChatStepType do
     resolve ->(obj, _args, _ctx) {
       obj.destination_chat_step

--- a/backend/app/models/chat_option.rb
+++ b/backend/app/models/chat_option.rb
@@ -1,16 +1,19 @@
 class ChatOption < ApplicationRecord
   acts_as_tenant
   belongs_to :chat_step
-  belongs_to :destination_chat_step, foreign_key: "destination_chat_step_id", class_name: "ChatStep"
+  belongs_to :destination_chat_step, foreign_key: "destination_chat_step_id", class_name: "ChatStep", optional: true
 
   accepts_nested_attributes_for :destination_chat_step, allow_destroy: true
 
   validates :text, presence: true
+  validate :action_type_and_destination_step
 
   before_create :assign_order
 
+  enum action_type: %i[simple reset stop]
+
   def as_json(options = {})
-    result = attributes.slice("id", "text", "destination_chat_step_id", "created_at", "updated_at")
+    result = attributes.slice("id", "text", "destination_chat_step_id", "action_type", "created_at", "updated_at")
     chat_step_ids = options[:chat_step_ids] || []
     unless chat_step_ids.include?(destination_chat_step_id)
       result[:destination_chat_step_attributes] = destination_chat_step.as_json(options)
@@ -21,5 +24,10 @@ class ChatOption < ApplicationRecord
   def assign_order
     current_value = self.class.where(chat_step_id: chat_step_id).order(:order).pluck(:order).last || 0
     self.order = current_value + 1
+  end
+
+  def action_type_and_destination_step
+    errors.add(:destination_chat_step, "should exist") if action_type == "simple" &&
+                                                          destination_chat_step.nil?
   end
 end

--- a/backend/db/migrate/20190129165208_add_action_type_to_options.rb
+++ b/backend/db/migrate/20190129165208_add_action_type_to_options.rb
@@ -1,0 +1,7 @@
+class AddActionTypeToOptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :chat_options, :action_type, :integer, null: false, default: 0, :limit => 1
+    add_index :chat_options, :action_type
+    change_column :chat_options, :destination_chat_step_id, :integer, null: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190129160633) do
+ActiveRecord::Schema.define(version: 20190129165208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,10 +37,12 @@ ActiveRecord::Schema.define(version: 20190129160633) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "chat_step_id"
-    t.bigint "destination_chat_step_id"
+    t.integer "destination_chat_step_id"
     t.bigint "account_id"
     t.integer "order", default: 1, null: false
+    t.integer "action_type", limit: 2, default: 0, null: false
     t.index ["account_id"], name: "index_chat_options_on_account_id"
+    t.index ["action_type"], name: "index_chat_options_on_action_type"
     t.index ["chat_step_id"], name: "index_chat_options_on_chat_step_id"
     t.index ["destination_chat_step_id"], name: "index_chat_options_on_destination_chat_step_id"
   end

--- a/backend/lib/data_scripts/update_scripted_chats.rb
+++ b/backend/lib/data_scripts/update_scripted_chats.rb
@@ -1,0 +1,35 @@
+# Script that adds "stop" and "reset" type chat options to each account
+
+resets = {
+  'Impressorajato': "Legal! Quero saber mais!",
+  'Corinthians': "Me mostre outras sugestões",
+  'Shopinfo': "Me mostre outras sugestões",
+  'Shopinfo2': "Me mostre outras sugestões",
+  'Eotica': "Quero saber mais",
+  'RiHappy': "Preciso saber mais",
+  '_default': "I still need help",
+}
+
+stops = {
+  'Impressorajato': "Quero falar com um consultor",
+  'Corinthians': "Legal",
+  'Shopinfo': "Legal",
+  'Shopinfo2': "Legal",
+  'Eotica': "Legal, gostei!",
+  'RiHappy': "Ok, otimo",
+  '_default': "Ok, cool",
+}
+
+accounts = Account.all
+
+accounts.each do |account|
+  current_stop = stops[account.name.to_sym] || stops[:_default]
+  current_reset = resets[account.name.to_sym] || resets[:_default]
+  ActsAsTenant.default_tenant = account
+  account.chat_steps.each do |chat_step|
+    if chat_step.chat_options.all.length.zero?
+      chat_step.chat_options.create!(text: current_reset, order: 1, action_type: "reset")
+      chat_step.chat_options.create!(text: current_stop, order: 2, action_type: "stop")
+    end
+  end
+end

--- a/console-frontend/src/app/resources/scripted-chats/form/action-type-select.js
+++ b/console-frontend/src/app/resources/scripted-chats/form/action-type-select.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { FormControl, InputLabel, MenuItem, Select } from '@material-ui/core'
+
+const ActionTypeSelect = ({ onChange, value }) => (
+  <FormControl fullWidth margin="normal">
+    <InputLabel shrink>{'Action'}</InputLabel>
+    <Select name="chatOption_actionType" onChange={onChange} value={value}>
+      <MenuItem value="simple">{'Go to next step'}</MenuItem>
+      <MenuItem value="reset">{'Reset'}</MenuItem>
+      <MenuItem value="stop">{'Stop'}</MenuItem>
+    </Select>
+  </FormControl>
+)
+
+export default ActionTypeSelect

--- a/console-frontend/src/app/resources/scripted-chats/form/chat-option.js
+++ b/console-frontend/src/app/resources/scripted-chats/form/chat-option.js
@@ -1,3 +1,4 @@
+import ActionTypeSelect from './action-type-select'
 import ChatStep from './chat-step'
 import ChatStepSelect from './chat-step-select'
 import React from 'react'
@@ -44,9 +45,15 @@ const ChatStepOption = ({
         required
         value={chatOption.text}
       />
-      <ChatStepSelect chatOption={chatOption} disabled={isFormLoading} index={index} onChange={onChange} />
+      <ActionTypeSelect onChange={editChatOptionValue} value={chatOption.actionType} />
       <FormHelperText>{'How this chat proceeds after someone clicks this option.'}</FormHelperText>
-      {chatStep && (
+      {chatOption.actionType === 'simple' && (
+        <>
+          <ChatStepSelect chatOption={chatOption} disabled={isFormLoading} index={index} onChange={onChange} />
+          <FormHelperText>{'Chat will proceed to the selected step after click'}</FormHelperText>
+        </>
+      )}
+      {chatStep && chatOption.actionType === 'simple' && (
         <ChatStepPortal target={chatStep.__ref}>
           <ChatStep chatStep={chatStep} index={chatStep.__index} onChange={setChatStepForm} />
         </ChatStepPortal>
@@ -61,9 +68,16 @@ export default compose(
     chatStep: chatOption.destinationChatStepAttributes,
   })),
   withHandlers({
-    editChatOptionValue: ({ chatOption, index, onChange }) => event => {
+    editChatOptionValue: ({ chatOption, index, onChange, previousActionText, setPreviousActionText }) => event => {
       const name = event.target.name.replace('chatOption_', '')
-      chatOption[name] = event.target.value
+      const value = event.target.value
+      if (name === 'actionType' && chatOption.text === '' && value !== 'simple') {
+        chatOption.text = previousActionText[value] || ''
+      }
+      if (name === 'text' && chatOption.actionType !== 'simple') {
+        setPreviousActionText({ ...previousActionText, [chatOption.actionType]: value })
+      }
+      chatOption[name] = value
       onChange(chatOption, index)
     },
     deleteChatOption: ({ chatOption, index, onChange }) => () => {

--- a/console-frontend/src/app/resources/scripted-chats/form/chat-step.js
+++ b/console-frontend/src/app/resources/scripted-chats/form/chat-step.js
@@ -36,6 +36,8 @@ const ChatOptions = ({
   onChange,
   isFormLoading,
   setChatOptionForm,
+  setPreviousActionText,
+  previousActionText,
 }) => (
   <div>
     {chatStep.chatOptionsAttributes.map((chatOption, index) => (
@@ -51,6 +53,8 @@ const ChatOptions = ({
         isFormLoading={isFormLoading}
         key={chatOption.id || `new-${index}`}
         onChange={setChatOptionForm}
+        previousActionText={previousActionText}
+        setPreviousActionText={setPreviousActionText}
         sortIndex={index}
       />
     ))}
@@ -71,6 +75,8 @@ const ChatStep = ({
   onChatOptionsSortEnd,
   chatStepType,
   addAction,
+  previousActionText,
+  setPreviousActionText,
 }) => (
   <Section>
     <FormSection ellipsize foldable folded={chatStep.id} hideTop title={`Step #${chatStep.__index + 1}`}>
@@ -101,11 +107,13 @@ const ChatStep = ({
                 helperClass="sortable-element"
                 onChange={onChange}
                 onSortEnd={onChatOptionsSortEnd}
+                previousActionText={previousActionText}
                 setChatOptionForm={setChatOptionForm}
+                setPreviousActionText={setPreviousActionText}
                 useDragHandle
               />
             )}
-            <AddItemButton disabled={isFormLoading} message="Add Option" onClick={addChatOption} />
+            <AddItemButton disabled={isFormLoading} message="Add Option" onClick={addChatOption('simple')} />
           </FormSection>
         </div>
       )}
@@ -131,14 +139,15 @@ export default compose(
         ],
       })
     },
-    addChatOption: ({ onChange, chatStep }) => () => {
+    addChatOption: ({ onChange, chatStep }) => type => () => {
       onChange({
         ...chatStep,
         chatOptionsAttributes: [
           ...chatStep.chatOptionsAttributes,
           {
             text: '',
-            destinationChatStepId: '',
+            actionType: type,
+            destinationChatStepId: null,
           },
         ],
       })

--- a/console-frontend/src/ext/lodash/omit-deep.js
+++ b/console-frontend/src/ext/lodash/omit-deep.js
@@ -3,8 +3,7 @@
 const omitDeep = (input, excludesFn) => {
   return Object.entries(input).reduce((nextInput, [key, value]) => {
     const shouldExclude = excludesFn(key)
-    if (shouldExclude) return nextInput
-
+    if (shouldExclude || value === null) return nextInput
     if (Array.isArray(value)) {
       const arrValue = value
       const nextValue = arrValue.map(arrItem => {

--- a/plugiamo/src/app/content/scripted-chat/chat-log.js
+++ b/plugiamo/src/app/content/scripted-chat/chat-log.js
@@ -1,4 +1,3 @@
-import i18n from 'ext/i18n'
 import { gql } from 'ext/recompose/graphql'
 
 const STEP_DELAY = 250
@@ -14,6 +13,7 @@ const query = gql`
       chatOptions {
         id
         text
+        actionType
         destinationChatStep {
           id
         }
@@ -22,42 +22,15 @@ const query = gql`
   }
 `
 
-const finalOptions = () => {
-  const account = localStorage.getItem('trnd-plugin-account')
-  if (account === 'Impressorajato' && !document.querySelector('#livechat-compact-container')) {
-    return [
-      {
-        id: 'reset',
-        text: i18n.iStillNeedHelp(),
-      },
-    ]
-  } else {
-    return [
-      {
-        id: 'reset',
-        text: i18n.iStillNeedHelp(),
-      },
-      {
-        id: 'stop',
-        text: i18n.okCool(),
-      },
-    ]
-  }
-}
-
 const processChatOptions = chatOptions => {
   const account = localStorage.getItem('trnd-plugin-account')
-  if (account === 'Impressorajato' && document.querySelector('#livechat-compact-container')) {
-    return [
-      ...chatOptions,
-      {
-        id: 'stop',
-        text: i18n.okCool(),
-      },
-    ]
-  } else {
-    return chatOptions
-  }
+  return chatOptions.filter(chatOption => {
+    return !(
+      account === 'Impressorajato' &&
+      chatOption.actionType !== 'simple' &&
+      !document.querySelector('#livechat-compact-container')
+    )
+  })
 }
 
 const chatLog = {
@@ -84,8 +57,7 @@ const chatLog = {
           message,
           type: 'message',
         }))
-        const options =
-          data.chatStep.chatOptions.length > 0 ? processChatOptions(data.chatStep.chatOptions) : finalOptions()
+        const options = processChatOptions(data.chatStep.chatOptions)
         const optionsLog = { options, type: 'options' }
         const logs = [...messageLogs, optionsLog]
         this.addNextLog(logs, this.timestamp)

--- a/plugiamo/src/app/content/scripted-chat/chat-options.js
+++ b/plugiamo/src/app/content/scripted-chat/chat-options.js
@@ -21,12 +21,12 @@ const ChatOptions = compose(
       })
       if (log.selected) return
       chatLog.selectOption(log, chatOption)
-      if (chatOption.destinationChatStep) {
-        chatLog.fetchStep(chatOption.destinationChatStep.id)
-      } else if (chatOption.id === 'reset') {
-        onResetChat()
-      } else if (chatOption.id === 'stop') {
+      if (chatOption.actionType === 'stop') {
         onStopChat()
+      } else if (chatOption.actionType === 'reset') {
+        onResetChat()
+      } else if (chatOption.destinationChatStep) {
+        chatLog.fetchStep(chatOption.destinationChatStep.id)
       } else {
         console.error('No destination chat step for option', chatOption)
       }

--- a/plugiamo/src/ext/i18n/index.js
+++ b/plugiamo/src/ext/i18n/index.js
@@ -1,32 +1,4 @@
 const i18n = {
-  iStillNeedHelp: () => {
-    const account = localStorage.getItem('trnd-plugin-account')
-    if (['Corinthians', 'Shopinfo', 'Shopinfo2'].includes(account)) {
-      return 'Me mostre outras sugestões'
-    } else if (account === 'Impressorajato') {
-      return 'Legal! Quero saber mais!'
-    } else if (account === 'Eotica') {
-      return 'Quero saber mais'
-    } else if (account === 'RiHappy') {
-      return 'Preciso saber mais'
-    } else {
-      return 'I still need help'
-    }
-  },
-  okCool: () => {
-    const account = localStorage.getItem('trnd-plugin-account')
-    if (['Corinthians', 'Shopinfo', 'Shopinfo2'].includes(account)) {
-      return 'Legal'
-    } else if (account === 'Impressorajato') {
-      return 'Quero falar com um consultor'
-    } else if (account === 'Eotica') {
-      return 'Legal, gostei!'
-    } else if (account === 'RiHappy') {
-      return 'Ok, otimo'
-    } else {
-      return 'Ok, cool'
-    }
-  },
   productsSelectedBy: firstName => {
     const account = localStorage.getItem('trnd-plugin-account')
     if (account === 'Corinthians') {


### PR DESCRIPTION
### Changes
- Added `type_action` column to `chat_options` in DB;
- Added functionality of `copying` of previous `stop`/`reset` texts
- Added script which updates production DB to use `stop`/`reset` customization with preferences of different accounts;
- Removed hard-coded translations