### PR TITLE
Redirect to persona/trigger edit page upon persona/trigger create

### DIFF
--- a/console-frontend/src/app/resources/personas/edit.js
+++ b/console-frontend/src/app/resources/personas/edit.js
@@ -15,6 +15,7 @@ export default compose(
       const { json, errors, requestError } = await apiRequest(apiPersonaUpdate, [id, { persona: form }])
       if (requestError) enqueueSnackbar(requestError, { variant: 'error' })
       if (errors) setErrors(errors)
+      if (!errors && !requestError) enqueueSnackbar('Successfully updated persona', { variant: 'success' })
       return json
     },
   }),

--- a/console-frontend/src/app/resources/personas/form.js
+++ b/console-frontend/src/app/resources/personas/form.js
@@ -135,6 +135,7 @@ export default compose(
     onFormSubmit: ({
       formRef,
       history,
+      location,
       onFormSubmit,
       onboarding,
       onboardingCreate,
@@ -150,7 +151,7 @@ export default compose(
           setOnboarding({ ...onboarding, stageIndex: 1, run: true })
         }
       }, 0)
-      history.push(routes.personasList())
+      if (location.pathname !== routes.personaEdit(result.id)) history.push(routes.personaEdit(result.id))
       setIsFormSubmitting(false)
       return result
     },

--- a/console-frontend/src/app/resources/triggers/edit.js
+++ b/console-frontend/src/app/resources/triggers/edit.js
@@ -16,6 +16,7 @@ export default compose(
       const id = match.params.triggerId
       const { json, errors, requestError } = await apiRequest(apiTriggerUpdate, [id, { trigger: form }])
       if (requestError) enqueueSnackbar(requestError, { variant: 'error' })
+      if (!errors && !requestError) enqueueSnackbar('Successfully updated trigger', { variant: 'success' })
       if (errors) setErrors(errors)
       return json
     },

--- a/console-frontend/src/app/resources/triggers/form.js
+++ b/console-frontend/src/app/resources/triggers/form.js
@@ -117,6 +117,7 @@ export default compose(
   withHandlers({
     formObjectTransformer: () => json => {
       return {
+        id: json.id,
         flowId: json.flowId || '',
         flowType: json.flowType || '',
         urlMatchers: json.urlMatchers || [''],
@@ -149,11 +150,12 @@ export default compose(
   }),
   withRouter,
   withHandlers({
-    onFormSubmit: ({ formRef, history, onFormSubmit, setIsFormSubmitting }) => async event => {
+    onFormSubmit: ({ formRef, history, location, onFormSubmit, setIsFormSubmitting }) => async event => {
       if (!formRef.current.reportValidity()) return
       setIsFormSubmitting(true)
       const result = await onFormSubmit(event)
-      if (!result.error && !result.errors) history.push(routes.triggersList())
+      if (result.error || result.errors) return setIsFormSubmitting(false)
+      if (location.pathname !== routes.triggerEdit(result.id)) history.push(routes.triggerEdit(result.id))
       setIsFormSubmitting(false)
       return result
     },


### PR DESCRIPTION
**- Changes:**

Now, when a Persona/Trigger is created the user is redirected to the edit page of that Persona/Trigger

[Link to Trello Card](https://trello.com/c/GrNvN0IT/737-clicking-on-save-in-editors-should-not-make-the-user-leave-the-editor)