### PR TITLE
Fix Url Generator for Outro path

### DIFF
--- a/backend/app/models/outro.rb
+++ b/backend/app/models/outro.rb
@@ -16,7 +16,7 @@ class Outro < ApplicationRecord
 
   def paths
     new_step = attributes.slice("id", "name")
-    new_step[:path] = "/#{name.underscore.tr('_', '-')}/#{id}"
+    new_step[:path] = "/#{self.class.name.underscore.tr('_', '-')}/#{id}"
     [new_step]
   end
 end


### PR DESCRIPTION
**Fix - Url Generator:**

When an Outro is chosen as a "path", the resulting generated url was:
ex: `https://frekkls.com/#trnd:path:/last outro/12`
where `last outro`, the name of the `Outro` instance was being outputted instead of the name of the class: `Outro`
now: `https://frekkls.com/#trnd:path:/outro/12`