### PR TITLE
Remove chars limit validation from Text Fields

### DIFF
--- a/console-frontend/src/shared/form-elements/field.js
+++ b/console-frontend/src/shared/form-elements/field.js
@@ -29,15 +29,16 @@ const FieldTemplate = ({
 }) => (
   <Container>
     <TextField
-      inputProps={{
-        maxLength: max,
-      }}
       {...omit(props, ['setTextLength', 'setIsOutsideLimits', 'setFocused'])}
       onBlur={handleBlur}
       onChange={handleChange}
       onFocus={handleFocus}
     />
-    {focused && max && <Counter isOutsideLimits={isOutsideLimits}>{`${max - textLength}`}</Counter>}
+    {focused && max && (
+      <Counter isOutsideLimits={isOutsideLimits}>
+        {isOutsideLimits ? 'Might be too long to display correctly' : max - textLength}
+      </Counter>
+    )}
   </Container>
 )
 


### PR DESCRIPTION
- **Changes:**
When the number of characters reaches the `max` prop passed to `Field` component **and** the `overflowText` prop is passed to the `Field` component, the validation is disabled and the counter shows the value of `overflowText` instead.

![max_description_chars](https://user-images.githubusercontent.com/35154956/52653052-1966c780-2ee7-11e9-9fe5-3c05eb88ecfd.gif)

[Link To Trello Card](https://trello.com/c/klhKTyM8/802-remove-validation-from-product-pick-description-field)
