### PR TITLE
Fix scroll lock flickering

### DIFF
--- a/plugiamo/src/app/content/index.js
+++ b/plugiamo/src/app/content/index.js
@@ -19,6 +19,7 @@ export default compose(
     },
     componentWillUnmount() {
       history.removeListeners()
+      document.body.style.overflow = ''
     },
   }),
   withHotkeys({

--- a/plugiamo/src/ext/scroll-lock.js
+++ b/plugiamo/src/ext/scroll-lock.js
@@ -25,7 +25,9 @@ const ScrollContainer = styled.div`
 `
 
 const ScrollElement = styled.div`
-  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 `
 
 const isIos = () => /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
@@ -45,6 +47,9 @@ const ScrollLock = compose(
       setElementRef: () => ref => (elementRef = ref),
       setInitialScroll: ({ isEnabled }) => () => {
         if (isEnabled) containerRef.base.scrollTop = PADDING_TOP
+        if (!isEnabled && window.innerWidth < 600) {
+          document.body.style.overflow = 'hidden'
+        }
       },
       handleScroll: ({ isEnabled, onScroll }) => event => {
         if (event.target.scrollTop <= (isEnabled ? PADDING_TOP : 0)) {

--- a/plugiamo/src/special/nowadays/base.js
+++ b/plugiamo/src/special/nowadays/base.js
@@ -23,11 +23,11 @@ const ColFlexDiv = styled.div`
   }
 `
 
-const Base = ({ handleScroll, module, onToggleContent, coverMinimized, setPluginState }) => (
+const Base = ({ handleScroll, module, onToggleContent, coverMinimized, setPluginState, touch }) => (
   <ColFlexDiv>
-    <ScrollLock onScroll={handleScroll}>
+    <ScrollLock>
       <Cover header={module.header} minimized={coverMinimized} />
-      <ChatLogUi coverMinimized={coverMinimized} module={module} />
+      <ChatLogUi coverMinimized={coverMinimized} module={module} onScroll={handleScroll} touch={touch} />
       <CtaButton ctaButton={module.ctaButton} onToggleContent={onToggleContent} setPluginState={setPluginState} />
     </ScrollLock>
   </ColFlexDiv>
@@ -35,10 +35,18 @@ const Base = ({ handleScroll, module, onToggleContent, coverMinimized, setPlugin
 
 export default compose(
   withState('coverMinimized', 'setCoverMinimized', ({ module }) => !!module.header.minimized),
+  withState('touch', 'setTouch', true),
   withHandlers({
-    handleScroll: ({ setCoverMinimized, coverMinimized }) => (event, scrollLockInfo) => {
-      if (scrollLockInfo.at === 'top' && coverMinimized) return setCoverMinimized(false)
-      if (scrollLockInfo.at !== 'top' && !coverMinimized) return setCoverMinimized(true)
+    handleScroll: ({ setCoverMinimized, coverMinimized, setTouch, touch }) => event => {
+      const scrollTop = event.target.scrollTop
+      if (scrollTop <= 0 && coverMinimized) {
+        setTouch(false)
+        setTimeout(() => {
+          setTouch(true)
+        }, 50)
+        return setCoverMinimized(false)
+      }
+      if (scrollTop > 0 && !coverMinimized && touch) return setCoverMinimized(true)
     },
   })
 )(Base)

--- a/plugiamo/src/special/nowadays/chat-log-ui.js
+++ b/plugiamo/src/special/nowadays/chat-log-ui.js
@@ -150,8 +150,8 @@ const ChatLogUi = compose(
       initChatLog()
     },
   })
-)(({ className, clickChatOption, logs }) => (
-  <div className={className}>
+)(({ className, clickChatOption, logs, onScroll, touch }) => (
+  <div className={className} onScroll={onScroll} touch={touch}>
     <ChatBackground>
       <ChatContainer>
         {logs.map(log =>
@@ -167,11 +167,10 @@ const ChatLogUi = compose(
 ))
 
 export default styled(ChatLogUi)`
-  padding-bottom: 50px;
-
-  @media (min-height: 500px) {
-    padding-top: ${({ coverMinimized }) => (coverMinimized ? '90px' : '140px')};
-  }
+  flex-grow: 1;
+  overflow: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: ${({ touch }) => (touch ? 'touch' : 'auto')};
 
   ${ChatMessageContainer} + ${ChatOption} {
     padding-top: 16px;

--- a/plugiamo/src/special/nowadays/cover.js
+++ b/plugiamo/src/special/nowadays/cover.js
@@ -16,10 +16,7 @@ const CoverBase = styled.div`
   transition: max-height 0.4s ease-in-out;
   box-shadow: 0px 5px 10px rgba(25, 39, 54, 0.13);
 
-  @media (min-height: 500px) {
-    position: fixed;
-    top: 0;
-  }
+  flex-shrink: 0;
 `
 
 const Name = styled.div`

--- a/plugiamo/src/special/nowadays/cta-button.js
+++ b/plugiamo/src/special/nowadays/cta-button.js
@@ -12,8 +12,7 @@ const CtaButton = styled.button.attrs({
   border: 0;
   outline: 0;
 
-  position: fixed;
-  bottom: 0;
+  flex-shrink: 0;
   width: 100%;
 
   font-family: Roboto, sans-serif;


### PR DESCRIPTION
### Tested in:
- Android Chrome;
- Android Default Browser;
- IOS Chrome (IPhone 7/10)
- IOS Safari (IPhone 7/10)
- Desktop Chrome

### Changes
- Now the header and CTA button are using `flexbox` rather than `position:fixed` to avoid flickering;
#### Android & others
- `overflow: hidden` applied on body of the parent site and fixes everything here.
- `overflow: hidden` isn't used when screen width `>= 600` to allow scroll of the parent website on desktop.

#### IPhone & IOS
- Trick with padding scroll lock works here;
- When user scrolls to the top of the plugin content `touch` mode is disabled for 50ms to avoid plugin content flickering;
- `overflow: hidden` isn't applied when accessing from IOS device.