### PR TITLE
Make chat bubbles reappear

### DIFF
--- a/plugiamo/src/app/bubble/index.js
+++ b/plugiamo/src/app/bubble/index.js
@@ -118,6 +118,10 @@ export default compose(
       const { animateThis, isUnmounting, showingContent, hidden, setHidden } = this.props
       if (prevProps.bubble.message !== this.props.bubble.message) animateThis()
       if (!isUnmounting && showingContent && !hidden) setHidden(true)
+      if (hidden && !showingContent && isUnmounting) {
+        animateThis()
+        setHidden(false)
+      }
     },
   }),
   branch(({ hidden, bubble }) => !bubble.message || hidden, renderNothing)


### PR DESCRIPTION
### Changes
- Chat bubbles are now re-appearing after close
- They disappear as normal chat-bubbles do after `timeEnd` comes, and don't appear unless plugin is toggled one more time.