### PR TITLE
Fix showing close button on desktop

### DIFF
--- a/plugiamo/src/app/content/close-button.js
+++ b/plugiamo/src/app/content/close-button.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { h } from 'preact'
 import { IconClose } from 'plugin-base'
-import { MAIN_BREAKPOINT } from 'config'
+import { isSmall } from 'utils'
 
 const Container = styled.div`
   position: fixed;
@@ -10,10 +10,7 @@ const Container = styled.div`
   opacity: 0.8;
   padding: 8px;
   z-index: 12;
-
-  @media (min-width: ${MAIN_BREAKPOINT}px) {
-    display: none;
-  }
+  ${() => !isSmall() && 'display: none;'}
 `
 
 const CloseContent = styled(IconClose)`


### PR DESCRIPTION
## Changes: 
* Recover close button behavior on desktop (not show it), without being responsive 

## Issue
* Media query inside iframe targets the iframe instead of the window 

[Link To Trello Card](https://trello.com/c/ywmuE3hX/846-close-button-appears-in-desktop-mode)