### PR TITLE
Fix variable width bug on frekkls clients slider

### DIFF
--- a/landing-pages/frekkls/src/sections/social-proof.js
+++ b/landing-pages/frekkls/src/sections/social-proof.js
@@ -62,13 +62,21 @@ const Logo = ({ file }) => (
   </LogoContainer>
 )
 
+const FixedWidthContainer = styled.div`
+  @media (min-width: 1200px) {
+    width: 1200px;
+  }
+`
+
 const ClientLogos = ({ clients }) =>
   clients.edges.length > 0 && (
-    <Slider {...sliderSettings}>
-      {clients.edges.map(client => (
-        <Logo file={client.node.logo.file} key={client.node.clientName} />
-      ))}
-    </Slider>
+    <FixedWidthContainer>
+      <Slider {...sliderSettings}>
+        {clients.edges.map(client => (
+          <Logo file={client.node.logo.file} key={client.node.clientName} />
+        ))}
+      </Slider>
+    </FixedWidthContainer>
   )
 
 const TestimonialContainer = styled.div`


### PR DESCRIPTION
## Fixes:
Bug related to width of each slider element for screens larger than 1200px. This would make the elements not render.

![captura de ecra 2019-02-25 as 10 57 22](https://user-images.githubusercontent.com/35154956/53332827-2a063d00-38ec-11e9-8045-3dfa3893d29d.png)
