### PR TITLE
Fix option animation bugs

### DIFF
--- a/plugiamo/src/app/content/scripted-chat/components/base-container.js
+++ b/plugiamo/src/app/content/scripted-chat/components/base-container.js
@@ -22,7 +22,7 @@ const ContainerDiv = styled.div`
     0% {
       opacity: 1;
     }
-    30% {
+    40% {
       visibility: hidden;
       transform: translateX(20px);
       max-height: 60px;

--- a/plugiamo/src/app/content/scripted-chat/components/consumer-content.js
+++ b/plugiamo/src/app/content/scripted-chat/components/consumer-content.js
@@ -37,9 +37,7 @@ export default compose(
     animateNewOptions: ({ logs, setLogs }) => () => {
       const newOptions = logs[logs.length - 1]
       if (newOptions && newOptions.type === 'option') {
-        logs[logs.length - 1].logs.map(log => {
-          log.animate = true
-        })
+        logs[logs.length - 1].animate = true
         setLogs(logs)
       }
     },

--- a/plugiamo/src/app/content/scripted-chat/components/item-div.js
+++ b/plugiamo/src/app/content/scripted-chat/components/item-div.js
@@ -23,7 +23,7 @@ const ItemDivTemplate = ({ logSection, onClick, hide }) => (
       log.type === 'message' ? (
         <ChatMessage index={index} log={log} />
       ) : log.type === 'option' ? (
-        <ChatOption animate={log.animate} chatOption={log} hide={hide} index={index} onClick={onClick} />
+        <ChatOption animate={logSection.animate} chatOption={log} hide={hide} index={index} onClick={onClick} />
       ) : null
     )}
   </Container>

--- a/plugiamo/src/app/content/scripted-chat/components/option.js
+++ b/plugiamo/src/app/content/scripted-chat/components/option.js
@@ -22,8 +22,8 @@ const Container = styled.div`
   max-width: 260px;
   text-align: right;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
-  opacity: ${({ animate }) => (animate ? 1 : 0)};
-  transform: ${({ animate }) => (animate ? 'none' : 'translateY(20px)')};
+  opacity: ${({ animate, hide }) => (hide || animate ? 1 : 0)};
+  transform: ${({ animate, hide }) => (hide || animate ? 'none' : 'translateY(20px)')};
   transition: opacity 0.4s, transform 0.4s;
   margin-left: auto;
   & + div {
@@ -34,7 +34,7 @@ const Container = styled.div`
   ${({ hide, clicked }) =>
     hide &&
     !clicked &&
-    ` animation: _frekkls_option_hide 0.5s;
+    ` animation: _frekkls_option_hide 0.4s;
       animation-fill-mode: forwards;
   `}
 `

--- a/plugiamo/src/app/content/scripted-chat/shared.js
+++ b/plugiamo/src/app/content/scripted-chat/shared.js
@@ -72,5 +72,5 @@ export const listeners = {
   },
 }
 
-export const MESSAGE_INTERVAL = 320
+export const MESSAGE_INTERVAL = 400
 export const MESSAGE_RANDOMIZER = 320


### PR DESCRIPTION
### Changes
- Fixed bug where new options were appearing without animation;
- Fixed bug where messages slightly changed position Y because of timing overlap with options animation (where `transform: translateY()` was applied).

### Bug
![peek 2019-03-05 12-12](https://user-images.githubusercontent.com/32452032/53805068-19377600-3f41-11e9-9ff4-79e52c3d3120.gif)

### Fix
![peek 2019-03-05 12-21](https://user-images.githubusercontent.com/32452032/53805124-38360800-3f41-11e9-89e4-499c1afdaeca.gif)
