### PR TITLE
Show products tagged by improv

### DIFF
--- a/improv/src/utils/index.js
+++ b/improv/src/utils/index.js
@@ -61,6 +61,8 @@ const implFactory = {
           url:
             'https://www.baldessarini.com/de/kleidung/specials/business-looks/sakko-aus-120-schurwolle-14015-000-07124-999',
           title: 'SAKKO AUS 120-SCHURWOLLE',
+          picUrl:
+            'https://www.baldessarini.com/media/catalog/product/cache/small_image/e9c3970ab036de70892d86c6d221abfe/f/r/front_4049364472067.jpg',
           images: [
             {
               alt: '',
@@ -76,7 +78,6 @@ const implFactory = {
           displayPrice: '349,00 €',
           priceInCents: 34900,
           currency: 'EUR',
-          // other info...
         },
       ]
     },

--- a/plugiamo/src/special/assessment/store/index.js
+++ b/plugiamo/src/special/assessment/store/index.js
@@ -1,9 +1,8 @@
 import ChatLogUi from './chat-log-ui'
 import Cover from 'app/content/scripted-chat/components/cover'
 import Modal from './modal'
-import productsDB from 'special/assessment/products-db'
 import ScrollLock from 'ext/scroll-lock'
-import { compose, withProps } from 'recompose'
+import { compose, lifecycle, withState } from 'recompose'
 import { h } from 'preact'
 import { isSmall } from 'utils'
 
@@ -33,8 +32,21 @@ const StoreTemplate = ({
 )
 
 const Store = compose(
-  withProps({
-    results: productsDB.products,
+  withState('results', 'setResults', []),
+  lifecycle({
+    componentDidMount() {
+      const _this = this
+      fetch('https://console-assets-frb.ams3.digitaloceanspaces.com/manual/improv-clients.js', {
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+      })
+        .then(response => response.json())
+        .then(results => {
+          const { setResults } = _this.props
+          const client = results.find(client => client.hostname === location.hostname)
+          // TODO: inference system || setResults(inferenceSystem(client.products))
+          setResults(client.products)
+        })
+    },
   })
 )(StoreTemplate)
 


### PR DESCRIPTION
## Changes
- Instead of showing the hard-coded products from the `products-db.js`, we now fetch a json hosted on digitalocean containing all the information from restdb.io
- For now, all the products (fetched from the json) are shown in the assessment store step (results). This will change when the inference/scoring/filtering system based on tags is implemented.

![products](https://user-images.githubusercontent.com/35154956/54130939-41bfe400-4409-11e9-95aa-a6914e7796b1.gif)

[Link To Trello Card](https://trello.com/c/UfJyIzXf/942-assessment-show-the-products-from-the-products-database)


