### PR TITLE
Close plugin and hide launcher in Desktop on store modal open

### DIFF
--- a/plugiamo/src/special/assessment/base.js
+++ b/plugiamo/src/special/assessment/base.js
@@ -4,7 +4,18 @@ import Store from './store'
 import { compose, withHandlers, withState } from 'recompose'
 import { h } from 'preact'
 
-const Base = ({ handleScroll, setContentRef, step, steps, coverMinimized, touch, getContentRef, goToNextStep }) => (
+const Base = ({
+  handleScroll,
+  setContentRef,
+  step,
+  steps,
+  coverMinimized,
+  touch,
+  getContentRef,
+  goToNextStep,
+  setShowingLauncher,
+  setShowingContent,
+}) => (
   <Container contentRef={getContentRef}>
     {step.type === 'store' ? (
       <Store
@@ -12,6 +23,8 @@ const Base = ({ handleScroll, setContentRef, step, steps, coverMinimized, touch,
         getContentRef={getContentRef}
         handleScroll={handleScroll}
         setContentRef={setContentRef}
+        setShowingContent={setShowingContent}
+        setShowingLauncher={setShowingLauncher}
         step={step}
       />
     ) : (

--- a/plugiamo/src/special/assessment/index.js
+++ b/plugiamo/src/special/assessment/index.js
@@ -10,21 +10,33 @@ import { h } from 'preact'
 import { matchUrl, timeout } from 'plugin-base'
 
 const Plugin = ({
+  showingLaucher,
   isUnmounting,
   step,
   steps,
   goToNextStep,
   module,
   onToggleContent,
+  setShowingLauncher,
   setPluginState,
+  setShowingContent,
   showingContent,
   launcherType,
 }) => (
   <AppBase
-    Component={<Base goToNextStep={goToNextStep} setPluginState={setPluginState} step={step} steps={steps} />}
+    Component={
+      <Base
+        goToNextStep={goToNextStep}
+        setPluginState={setPluginState}
+        setShowingContent={setShowingContent}
+        setShowingLauncher={setShowingLauncher}
+        step={step}
+        steps={steps}
+      />
+    }
     data={module}
     isUnmounting={isUnmounting}
-    Launcher={Launcher}
+    Launcher={showingLaucher && Launcher}
     launcherType={launcherType}
     onToggleContent={onToggleContent}
     persona={module.launcher.persona}
@@ -53,6 +65,7 @@ export default compose(
   branch(({ module }) => module.flowType === 'ht-nothing', renderNothing),
   withState('isUnmounting', 'setIsUnmounting', false),
   withState('showingContent', 'setShowingContent', false),
+  withState('showingLaucher', 'setShowingLauncher', true),
   lifecycle({
     componentDidMount() {
       const { module, setShowingContent } = this.props

--- a/plugiamo/src/special/assessment/store/index.js
+++ b/plugiamo/src/special/assessment/store/index.js
@@ -15,6 +15,8 @@ const StoreTemplate = ({
   touch,
   step,
   results,
+  setShowingLauncher,
+  setShowingContent,
 }) => (
   <ScrollLock>
     <Cover hackathon header={step.header} minimized={coverMinimized} />
@@ -27,7 +29,14 @@ const StoreTemplate = ({
       setContentRef={setContentRef}
       touch={touch}
     />
-    {!isSmall() && <Modal header={step.header} results={results} />}
+    {!isSmall() && (
+      <Modal
+        header={step.header}
+        results={results}
+        setShowingContent={setShowingContent}
+        setShowingLauncher={setShowingLauncher}
+      />
+    )}
   </ScrollLock>
 )
 

--- a/plugiamo/src/special/assessment/store/modal/index.js
+++ b/plugiamo/src/special/assessment/store/modal/index.js
@@ -2,7 +2,7 @@ import Content from './content'
 import Frame from 'shared/frame'
 import Header from './header'
 import Wrapper from 'shared/modal'
-import { compose, withHandlers, withState } from 'recompose'
+import { compose, lifecycle, withHandlers, withState } from 'recompose'
 import { h } from 'preact'
 
 const iframeStyle = {
@@ -33,8 +33,16 @@ const ModalTemplate = ({ closeModal, isOpen, results, header }) => (
 const Modal = compose(
   withState('isOpen', 'setIsOpen', true),
   withHandlers({
-    closeModal: ({ setIsOpen }) => () => {
+    closeModal: ({ setIsOpen, setShowingLauncher }) => () => {
       setIsOpen(false)
+      setShowingLauncher(true)
+    },
+  }),
+  lifecycle({
+    componentDidMount() {
+      const { setShowingLauncher, setShowingContent } = this.props
+      setShowingContent(false)
+      setShowingLauncher(false)
     },
   })
 )(ModalTemplate)


### PR DESCRIPTION
## Changes to Assessment Flow (Desktop only)
- When the store modal pops up the launcher is hidden.
- When the store modal is closed the plugin appears again, closed, and the assessment flow restarts.

![plugin-close-fix](https://user-images.githubusercontent.com/35154956/54136481-cf083600-4413-11e9-8bed-7eb21bd721b2.gif)

[Link To Trello Card](https://trello.com/c/sO5k8IZF/950-assessment-close-hide-plugin-content-and-launcher-in-desktop-before-the-product-store-modal-is-shown)