### PR TITLE
Fix hotkeys bug in improv

### DIFF
--- a/improv/src/app/index.js
+++ b/improv/src/app/index.js
@@ -22,12 +22,17 @@ const StyledIframe = styled(Iframe)`
   z-index: 12340000000;
 `
 
-const App = ({ closeModal, iframeRef, isModalOpen, getModalAppElement }) => (
+const App = ({ closeModal, iframeRef, isModalOpen, getModalState, getModalAppElement, iframeDocument }) => (
   <StyledIframe hidden={!isModalOpen} ref={iframeRef} title="Frekkls">
     {isModalOpen ? (
-      <Modal appElement={getModalAppElement()} isOpen={isModalOpen} onRequestClose={closeModal}>
+      <Modal
+        appElement={getModalAppElement()}
+        hotkeysDocument={iframeDocument()}
+        isOpen={isModalOpen}
+        onRequestClose={closeModal}
+      >
         <ModalContent>
-          <Tagger />
+          <Tagger getModalState={getModalState} hotkeysDocument={iframeDocument()} />
         </ModalContent>
       </Modal>
     ) : (
@@ -40,13 +45,20 @@ export default compose(
   withProps({ iframeRef: React.createRef() }),
   withState('isModalOpen', 'setIsModalOpen', false),
   withHandlers({
-    openModal: ({ setIsModalOpen }) => () => setIsModalOpen(true),
+    openModal: ({ setIsModalOpen, iframeRef }) => () => {
+      setTimeout(() => {
+        iframeRef && iframeRef.current.focus()
+      }, 0)
+      setIsModalOpen(true)
+    },
     closeModal: ({ setIsModalOpen }) => () => setIsModalOpen(false),
-  }),
-  withHotkeys({
-    [tKey]: ({ openModal }) => openModal,
+    getModalState: ({ isModalOpen }) => () => isModalOpen,
   }),
   withHandlers({
     getModalAppElement: ({ iframeRef }) => () => iframeRef.current.contentDocument.body,
+    iframeDocument: ({ iframeRef }) => () => iframeRef && iframeRef.current && iframeRef.current.contentDocument,
+  }),
+  withHotkeys({
+    [tKey]: ({ openModal }) => openModal,
   })
 )(App)

--- a/improv/src/ext/modal.js
+++ b/improv/src/ext/modal.js
@@ -56,10 +56,14 @@ const ModalComp = compose(
   </Background>
 ))
 
-const Modal = ({ appElement, allowBackgroundClose, onRequestClose, isOpen, children }) =>
+const Modal = ({ appElement, allowBackgroundClose, onRequestClose, isOpen, children, hotkeysDocument }) =>
   isOpen
     ? ReactDom.createPortal(
-        <ModalComp allowBackgroundClose={allowBackgroundClose} onRequestClose={onRequestClose}>
+        <ModalComp
+          allowBackgroundClose={allowBackgroundClose}
+          hotkeysDocument={hotkeysDocument}
+          onRequestClose={onRequestClose}
+        >
           {children}
         </ModalComp>,
         appElement

--- a/improv/src/ext/recompose/with-hotkeys.js
+++ b/improv/src/ext/recompose/with-hotkeys.js
@@ -26,16 +26,22 @@ const withHotkeys = (handlers, useCapture = false) =>
 
         componentDidMount() {
           // we listen for the event in both the element itself and on its containing window. This allows modals to work
+          const { hotkeysDocument } = this.props
+          const contentDocument =
+            hotkeysDocument && (typeof hotkeysDocument === 'function' ? hotkeysDocument() : hotkeysDocument)
           const base = this.hotkeysRef.current
-          const target = base.contentWindow || window
+          const target = base.contentWindow || contentDocument || window
           base.addEventListener('keyup', this.handleKeyDown, useCapture)
           target.addEventListener('keyup', this.handleKeyDown, useCapture)
         }
 
         componentWillUnmount() {
           // we listen for the event in both the element itself and on its containing window. This allows modals to work
+          const { hotkeysDocument } = this.props
+          const contentDocument =
+            hotkeysDocument && (typeof hotkeysDocument === 'function' ? hotkeysDocument() : hotkeysDocument)
           const base = this.hotkeysRef.current
-          const target = base.contentWindow || window
+          const target = base.contentWindow || contentDocument || window
           base.removeEventListener('keyup', this.handleKeyDown, useCapture)
           target.removeEventListener('keyup', this.handleKeyDown, useCapture)
         }

--- a/improv/src/tagger/index.js
+++ b/improv/src/tagger/index.js
@@ -161,8 +161,9 @@ export default compose(
   }),
   lifecycle({
     async componentDidMount() {
-      const { setClient, setIsLoading, products, setProducts } = this.props
+      const { setClient, setIsLoading, products, setProducts, getModalState } = this.props
       const client = await getClient(location.hostname)
+      if (client && !getModalState()) return
       if (client.length > 0) {
         setClient(client[0])
         products.forEach(product => {


### PR DESCRIPTION
### Changes
- Event listeners are now appended to iframe component rather than to the main window;
- Focus on the iframe is being set as soon as the modal opens;

### Important
- Modal can be closed before it even loads and displays the data (before `setState`'s), so right after the data was loaded and is ready to be shown, we check whether the modal is still open. If so, it displays the data, otherwise it just stops the execution.