### PR TITLE
Track Assessment interactions in mixpanel

### DIFF
--- a/plugiamo/src/app/content/scripted-chat/components/cover/video-button.js
+++ b/plugiamo/src/app/content/scripted-chat/components/cover/video-button.js
@@ -1,3 +1,4 @@
+import mixpanel from 'ext/mixpanel'
 import styled from 'styled-components'
 import VideoIcon from 'icons/ic-play.svg'
 import VideoModal from 'shared/video-modal'
@@ -50,8 +51,14 @@ export default compose(
     )}?autoplay=1&amp;mute=0&amp;controls=1&amp;playsinline=0&amp;rel=0&amp;iv_load_policy=3&amp;modestbranding=1&amp;enablejsapi=1`,
   })),
   withHandlers({
-    onClick: ({ setIsOpen }) => () => {
+    onClick: ({ setIsOpen, video }) => () => {
       setIsOpen(true)
+      mixpanel.track('Opened Assessment Header Video', {
+        hostname: location.hostname,
+        url: `https://www.youtube.com/embed/${extractYoutubeId(
+          video.url
+        )}?autoplay=1&amp;mute=0&amp;controls=1&amp;playsinline=0&amp;rel=0&amp;iv_load_policy=3&amp;modestbranding=1&amp;enablejsapi=1`,
+      })
     },
   })
 )(VideoButton)

--- a/plugiamo/src/app/content/scripted-chat/components/message-types/assessment-product.js
+++ b/plugiamo/src/app/content/scripted-chat/components/message-types/assessment-product.js
@@ -1,3 +1,4 @@
+import mixpanel from 'ext/mixpanel'
 import ProductMessage from './product-message'
 import styled from 'styled-components'
 import { compose, withHandlers } from 'recompose'
@@ -87,6 +88,11 @@ const AssessmentProduct = compose(
   withHandlers({
     onClick: ({ data }) => () => {
       if (!data.url) return
+      mixpanel.track('Clicked Assessment Store Product', {
+        hostname: location.hostname,
+        productUrl: data.url,
+        productName: data.title,
+      })
       window.location.href = data.url
     },
   })

--- a/plugiamo/src/special/assessment/index.js
+++ b/plugiamo/src/special/assessment/index.js
@@ -127,9 +127,15 @@ export default compose(
       }
       return setEndNodeTags(newTags)
     },
-    goToStore: ({ endNodeTags, stepIndex, tags, setStepIndex, setTags, setCurrentStepKey }) => () => {
+    goToStore: ({ endNodeTags, stepIndex, tags, setStepIndex, setTags, setCurrentStepKey }) => currentStepKey => {
       setStepIndex(stepIndex + 1)
       setTags(endNodeTags.map(tag => [...tags, tag]))
+      mixpanel.track('Clicked Assessment Step', {
+        hostname: location.hostname,
+        stepIndex,
+        step: currentStepKey,
+        tags: endNodeTags,
+      })
       setCurrentStepKey('store')
     },
     resetAssessment: ({
@@ -190,6 +196,7 @@ export default compose(
       tags,
       handleEndNodeTags,
       goToStore,
+      currentStepKey,
     }) => step => {
       if (step.url)
         return setStepIndex(
@@ -197,9 +204,16 @@ export default compose(
           timeout.set('loadingProgressBar', () => (window.location.href = step.url), 600)
         )
       if (step.endNode) return handleEndNodeTags(step)
-      if (step === 'showResults') return goToStore()
+      if (step === 'showResults') return goToStore(currentStepKey)
       setStepIndex(stepIndex + 1)
       setTags([...tags, step.title])
+      mixpanel.track('Clicked Assessment Step', {
+        hostname: location.hostname,
+        stepIndex,
+        step: currentStepKey,
+        tags: [step.title],
+      })
+      if (step.endNode) return setCurrentStepKey('store')
       // if depth declared in the step, set depth. Used in progress bar
       if (steps[step.title].depth) setAssessmentDepth(steps[step.title].depth)
       setCurrentStepKey(step.title)


### PR DESCRIPTION
 ## Track Assessment interactions on mixpanel: 

- **Clicked Assessment Step** -> On tag click, in every step, send: (hostname, stepIndex, step, tag)
- **Opened Assessment Header Video** -> On header video button click, send: (hostname, videoUrl)
- **Clicked Assessment Store Product** -> On product click in assessment store, send: (hostname, productName, productUrl)
- **Loaded Plugin** -> implemented already
- **Toggled Plugin** -> implemented already



[Link To Trello Card](https://trello.com/c/rJ8hzxMy/943-assessment-add-mixpanel-events-for-interactions)