### PR TITLE
Fix hotkeys in plugin

### DIFF
--- a/improv/src/ext/recompose/with-hotkeys.js
+++ b/improv/src/ext/recompose/with-hotkeys.js
@@ -25,23 +25,25 @@ const withHotkeys = (handlers, useCapture = false) =>
         }
 
         componentDidMount() {
-          // we listen for the event in both the element itself and on its containing window. This allows modals to work
-          const { hotkeysDocument } = this.props
-          const contentDocument =
-            hotkeysDocument && (typeof hotkeysDocument === 'function' ? hotkeysDocument() : hotkeysDocument)
-          const base = this.hotkeysRef.current
-          const target = base.contentWindow || contentDocument || window
-          base.addEventListener('keyup', this.handleKeyDown, useCapture)
-          target.addEventListener('keyup', this.handleKeyDown, useCapture)
+          this.manageKeyEvents('add')
         }
 
         componentWillUnmount() {
+          this.manageKeyEvents('remove')
+        }
+
+        manageKeyEvents = type => {
           // we listen for the event in both the element itself and on its containing window. This allows modals to work
           const { hotkeysDocument } = this.props
           const contentDocument =
             hotkeysDocument && (typeof hotkeysDocument === 'function' ? hotkeysDocument() : hotkeysDocument)
           const base = this.hotkeysRef.current
           const target = base.contentWindow || contentDocument || window
+          if (type === 'add') {
+            base.addEventListener('keyup', this.handleKeyDown, useCapture)
+            target.addEventListener('keyup', this.handleKeyDown, useCapture)
+            return
+          }
           base.removeEventListener('keyup', this.handleKeyDown, useCapture)
           target.removeEventListener('keyup', this.handleKeyDown, useCapture)
         }

--- a/plugiamo/src/ext/recompose/with-hotkeys.js
+++ b/plugiamo/src/ext/recompose/with-hotkeys.js
@@ -13,6 +13,11 @@
 import { Component, h } from 'preact'
 import { hoistStatics, wrapDisplayName } from 'recompose'
 
+const getIframeContentWindow = base => {
+  const iframes = base && base.getElementsByTagName('iframe')
+  if (iframes.length && iframes[0]) return base.getElementsByTagName('iframe')[0].contentWindow
+}
+
 const withHotkeys = (handlers, useCapture = false) =>
   hoistStatics(
     BaseComponent =>
@@ -20,23 +25,28 @@ const withHotkeys = (handlers, useCapture = false) =>
         displayName = wrapDisplayName(BaseComponent, 'withHotkeys')
 
         componentDidMount() {
-          // we listen for the event in both the element itself and on its containing window. This allows modals to work
-          const { base } = BaseComponent.hotkeysRef
-          const target = base.contentWindow || window
-          base.addEventListener('keyup', this.handleKeyDown, useCapture)
-          target.addEventListener('keyup', this.handleKeyDown, useCapture)
+          this.manageKeyEvents('add')
         }
 
         componentWillUnmount() {
-          // we listen for the event in both the element itself and on its containing window. This allows modals to work
-          const { base } = BaseComponent.hotkeysRef
-          const target = base.contentWindow || window
-          base.removeEventListener('keyup', this.handleKeyDown, useCapture)
-          target.removeEventListener('keyup', this.handleKeyDown, useCapture)
+          this.manageKeyEvents('remove')
         }
 
         setRef(ref) {
           BaseComponent.hotkeysRef = ref
+        }
+
+        manageKeyEvents = type => {
+          // we listen for the event in both the element itself and on its containing window. This allows modals to work
+          const { base } = BaseComponent.hotkeysRef
+          const target = base.contentWindow || getIframeContentWindow(base) || window
+          if (type === 'add') {
+            base.addEventListener('keyup', this.handleKeyDown, useCapture)
+            target.addEventListener('keyup', this.handleKeyDown, useCapture)
+            return
+          }
+          base.removeEventListener('keyup', this.handleKeyDown, useCapture)
+          target.removeEventListener('keyup', this.handleKeyDown, useCapture)
         }
 
         handleKeyDown = event => {


### PR DESCRIPTION
### Changes
- Hotkeys are now looking for the first instance of `iframe` in `base` and set the event listener to that if the `contentWindow` wasn't found;
- `Esc` key in assessment store modal works as expected now.

### Tests
- Escape in plugin works as expected