### PR TITLE
Support multiple answers in last step

### DIFF
--- a/plugiamo/src/app/content/scripted-chat/components/item-div.js
+++ b/plugiamo/src/app/content/scripted-chat/components/item-div.js
@@ -38,7 +38,7 @@ export default compose(
     },
     onMessageClick: ({ goToNextStep, setHideAll }) => option => {
       goToNextStep(option)
-      setHideAll(true)
+      if (!option.endNode) setHideAll(true)
     },
   }),
   lifecycle({

--- a/plugiamo/src/app/content/scripted-chat/components/message-types/assessment-step-option.js
+++ b/plugiamo/src/app/content/scripted-chat/components/message-types/assessment-step-option.js
@@ -178,9 +178,9 @@ const TileDiv = ({ title, imageUrl, handleClick, isClicked, hideAll, highlight }
 const Tile = compose(
   withState('isClicked', 'setIsClicked', false),
   withHandlers({
-    handleClick: ({ setIsClicked, hideAll, onClick }) => () => {
+    handleClick: ({ isClicked, setIsClicked, hideAll, onClick }) => () => {
       if (!hideAll) {
-        setIsClicked(true)
+        setIsClicked(!isClicked)
         onClick()
       }
     },
@@ -188,12 +188,6 @@ const Tile = compose(
   lifecycle({
     componentWillUnmount() {
       timeout.clear('pluginClickItem')
-    },
-    componentDidUpdate() {
-      const { hideAll, isClicked, setIsClicked } = this.props
-      if (isClicked && !hideAll) {
-        setIsClicked(false)
-      }
     },
   })
 )(TileDiv)

--- a/plugiamo/src/app/content/scripted-chat/components/message-types/assessment-step-options.js
+++ b/plugiamo/src/app/content/scripted-chat/components/message-types/assessment-step-options.js
@@ -20,6 +20,7 @@ const AssessmentStepOptions = ({ onClick, options, hideAll }) => (
         imageUrl={imgixUrl(option.picUrl, { fit: 'crop', w: 156, h: 120 })}
         key={`option-${option.title}`}
         onClick={() => onClick(option)}
+        option={option}
         title={option.title}
       />
     ))}

--- a/plugiamo/src/special/assessment/chat.js
+++ b/plugiamo/src/special/assessment/chat.js
@@ -1,4 +1,5 @@
 import Cover from 'app/content/scripted-chat/components/cover'
+import CtaButton from './steps/cta-button'
 import ScrollLock from 'ext/scroll-lock'
 import Steps from './steps'
 import StepsProgressBar from 'shared/progress-bar'
@@ -20,6 +21,7 @@ const Chat = ({
   setShowingLauncher,
   tags,
   stepIndex,
+  showingCtaButton,
 }) => (
   <ScrollLock>
     <Cover assessment currentStep={currentStep} index={stepIndex} minimized={coverMinimized} step={step} />
@@ -46,11 +48,13 @@ const Chat = ({
         goToNextStep={goToNextStep}
         onScroll={handleScroll}
         setContentRef={setContentRef}
+        showingCtaButton={showingCtaButton}
         step={step}
         steps={steps}
         touch={touch}
       />
     )}
+    {currentStep.type !== 'store' && <CtaButton goToNextStep={goToNextStep} showing={showingCtaButton} />}
   </ScrollLock>
 )
 

--- a/plugiamo/src/special/assessment/steps/cta-button.js
+++ b/plugiamo/src/special/assessment/steps/cta-button.js
@@ -1,0 +1,35 @@
+import getFrekklsConfig from 'frekkls-config'
+import mixpanel from 'ext/mixpanel'
+import styled from 'styled-components'
+import { branch, compose, renderNothing, withHandlers } from 'recompose'
+import { h } from 'preact'
+
+const CtaButton = styled.button.attrs({
+  type: 'button',
+})`
+  appearance: none;
+  margin: 0;
+  border: 0;
+  outline: 0;
+
+  flex-shrink: 0;
+  width: 100%;
+
+  font-family: Roboto, sans-serif;
+  font-weight: 500;
+  z-index: 1;
+  background-color: #232323;
+  color: white;
+  padding: 1rem;
+  font-size: 18px;
+  line-height: 1;
+  text-transform: uppercase;
+  cursor: pointer;
+`
+
+export default compose(
+  branch(({ showing }) => !showing, renderNothing),
+  withHandlers({
+    onClick: ({ goToNextStep }) => () => goToNextStep('showResults'),
+  })
+)(({ onClick }) => <CtaButton onClick={onClick}>{'Done! Show me results!'}</CtaButton>)

--- a/plugiamo/src/special/assessment/store/assess-products.js
+++ b/plugiamo/src/special/assessment/store/assess-products.js
@@ -1,4 +1,9 @@
-const assessProducts = (products, tags) =>
-  products.filter(product => product.tags && !tags.map(tag => !!product.tags[tag]).includes(false))
+const assessProducts = (products, tagsArrays) => {
+  const productsResult = []
+  tagsArrays
+    .map(tags => products.filter(product => product.tags && !tags.map(tag => !!product.tags[tag]).includes(false)))
+    .forEach(productArray => productsResult.push(...productArray))
+  return productsResult
+}
 
 export default assessProducts


### PR DESCRIPTION
## Changes to Assessment:

- On the last step before the assessment store (i.e. if the current step has `endNode: true` ) the user only proceeds to the assessment store upon clicking the cta button. 
- On tag clicking, the `handleEndNodeTags` handler is called setting the chosen tags for the last step. 
- When the cta button is clicked the the tags is set to an array of tag arrays, example: 
```
User chooses "Regular Fit", "Modern Fit" , "Tapered Fit" in last step
User chose "Jeans & Hosen" and "Casual" in previous steps
resulting in tags array of arrays: [ ["Casual", "Jeans & Hosen", "Regular Fit"], ["Casual", "Jeans & Hosen", "Modern Fit"],  ["Casual", "Jeans & Hosen", "Tapered Fit" ] ]
```

![multiple-answers](https://user-images.githubusercontent.com/35154956/54527361-9c10f580-4971-11e9-84a2-9cd48dca50a4.gif)

[Link To Trello Card](https://trello.com/c/U9sgABh3/968-assessment-support-multiple-answers-in-the-last-step)