### PR TITLE
Improve animations of CTA Button and progress bar

### DIFF
--- a/plugiamo/src/special/assessment/chat.js
+++ b/plugiamo/src/special/assessment/chat.js
@@ -1,8 +1,8 @@
 import Cover from 'app/content/scripted-chat/components/cover'
 import CtaButton from './steps/cta-button'
+import ProgressBar from 'shared/progress-bar'
 import ScrollLock from 'ext/scroll-lock'
 import Steps from './steps'
-import StepsProgressBar from 'shared/progress-bar'
 import Store from './store'
 import { h } from 'preact'
 
@@ -25,7 +25,7 @@ const Chat = ({
 }) => (
   <ScrollLock>
     <Cover assessment currentStep={currentStep} index={stepIndex} minimized={coverMinimized} step={step} />
-    {currentStep.type !== 'store' && <StepsProgressBar progress={((stepIndex || 0) / (depth + 1)) * 100} />}
+    <ProgressBar hide={currentStep.type === 'store'} progress={((stepIndex || 0) / (depth + 1)) * 100} />
     {currentStep.type === 'store' ? (
       <Store
         contentRef={getContentRef}
@@ -54,7 +54,7 @@ const Chat = ({
         touch={touch}
       />
     )}
-    {currentStep.type !== 'store' && <CtaButton goToNextStep={goToNextStep} showing={showingCtaButton} />}
+    <CtaButton goToNextStep={goToNextStep} hide={currentStep.type === 'store' || !showingCtaButton} />
   </ScrollLock>
 )
 

--- a/plugiamo/src/special/assessment/steps/cta-button.js
+++ b/plugiamo/src/special/assessment/steps/cta-button.js
@@ -1,10 +1,10 @@
 import getFrekklsConfig from 'frekkls-config'
 import mixpanel from 'ext/mixpanel'
 import styled from 'styled-components'
-import { branch, compose, renderNothing, withHandlers } from 'recompose'
+import { compose, withHandlers } from 'recompose'
 import { h } from 'preact'
 
-const CtaButton = styled.button.attrs({
+const Button = styled.button.attrs({
   type: 'button',
 })`
   appearance: none;
@@ -20,16 +20,31 @@ const CtaButton = styled.button.attrs({
   z-index: 1;
   background-color: #232323;
   color: white;
-  padding: 1rem;
+  padding: 25px 5px;
   font-size: 18px;
-  line-height: 1;
+  line-height: 0;
   text-transform: uppercase;
   cursor: pointer;
+  max-height: 50px;
+  ${({ hide }) =>
+    hide &&
+    `max-height: 0px;
+  padding: 0;
+  color: transparent;
+  `}
+
+  transition: color 0.3s${({ hide }) => !hide && ' 0.3s'}, padding 0.3s${({ hide }) =>
+  hide && ' 0.3s'}, max-height 0.0s${({ hide }) => hide && ' 0.3s'};
 `
 
+const CtaButton = ({ onClick, hide }) => (
+  <Button hide={hide} onClick={onClick}>
+    {'Done! Show me results!'}
+  </Button>
+)
+
 export default compose(
-  branch(({ showing }) => !showing, renderNothing),
   withHandlers({
     onClick: ({ goToNextStep }) => () => goToNextStep('showResults'),
   })
-)(({ onClick }) => <CtaButton onClick={onClick}>{'Done! Show me results!'}</CtaButton>)
+)(CtaButton)


### PR DESCRIPTION
### Changes
- Progress bar dissappears smoothly after going to store step;
- CTA Button animates smoothly on hide / show.

### Tested in
:heavy_check_mark:  Android (Chrome / Standard);
:heavy_check_mark: IPhone 10 (Chrome / Safari);
:heavy_check_mark: Ubuntu Desktop (Chrome / Firefox).

### Preview
![Peek 2019-03-19 17-54](https://user-images.githubusercontent.com/32452032/54629743-16c03a80-4a70-11e9-8a13-0d7836fc1d2f.gif)
