### PR TITLE
Show highlighted products first

### DIFF
--- a/plugiamo/src/special/assessment/store/assess-products.js
+++ b/plugiamo/src/special/assessment/store/assess-products.js
@@ -5,7 +5,7 @@ const assessProducts = (products, tagsArrays) => {
     .map(tag => products.filter(product => product.tag && tag === product.tag))
     .forEach(productArray => productsResult.push(...productArray))
 
-  return productsResult
+  return productsResult.sort((a, b) => !!b.highlight - !!a.highlight)
 }
 
 export default assessProducts


### PR DESCRIPTION
## Changes to Assessment
Show highlighted products first in the assessment store

![Captura de ecrã 2019-03-21, às 13 03 45](https://user-images.githubusercontent.com/35154956/54753810-e3012400-4bd9-11e9-98a1-8c0f4f0e5c07.png)

[Link To Trello Card](https://trello.com/c/meXMOnOz/993-assessment-show-highlighted-products-first)
