### PR TITLE
Add hack for Pionier-Workwear

### DIFF
--- a/backend/app/services/url_matcher.rb
+++ b/backend/app/services/url_matcher.rb
@@ -32,10 +32,10 @@ class UrlMatcher
       p = match_data[1].split("&")
       p.each do |e|
         r = e.split("=")
-        matches[CGI.unescape(r[0])] = CGI.unescape(r.slice(1).join("="))
+        matches[CGI.unescape(r[0])] = CGI.unescape(r.slice(1))
       end
     end
-    url = segmentize(pathname.sub(reg, ""))
+    url = segmentize(pathname)
     route = segmentize(url_matcher || "")
     max = [url.length, route.length].max
     i = 0

--- a/backend/test/services/url_matcher_test.rb
+++ b/backend/test/services/url_matcher_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class UrlMatcherTest < ActiveSupport::TestCase
+  test "matches root" do
+    assert UrlMatcher.perform("/", "/")
+  end
+
+  test "matches simple url" do
+    assert UrlMatcher.perform("/a", "/a")
+  end
+
+  test "does not match different urls" do
+    refute UrlMatcher.perform("/a", "/b")
+  end
+
+  test "matches url with search (aka the query params)" do
+    assert UrlMatcher.perform("/a?b=c", "/a?b=c")
+  end
+end

--- a/console-frontend/src/app/resources/triggers/form.js
+++ b/console-frontend/src/app/resources/triggers/form.js
@@ -15,6 +15,7 @@ import { withOnboardingHelp } from 'ext/recompose/with-onboarding'
 import { withRouter } from 'react-router'
 
 const pathPattern = '/[^?#]*'
+const pathAndSearchPattern = '/[^#]*'
 
 const FlexDiv = styled.div`
   display: flex;
@@ -85,11 +86,12 @@ const TriggerForm = ({
               // eslint-disable-next-line react/no-array-index-key
               <FlexDiv key={index}>
                 <StyledUrlTextField
-                  autoComplete="transaction-amount"
                   disabled={isFormLoading}
                   hostnames={hostnames}
                   index={index}
-                  inputProps={{ pattern: pathPattern }}
+                  inputProps={{
+                    pattern: hostnames.includes('www.pionier-workwear.com') ? pathAndSearchPattern : pathPattern,
+                  }}
                   onChange={editUrlValue}
                   required
                   value={url}

--- a/plugiamo/src/app/index.js
+++ b/plugiamo/src/app/index.js
@@ -159,7 +159,8 @@ export default compose(
     `,
     {
       hasPersona: !!optionsFromHash().persona,
-      pathname: location.pathname,
+      pathname:
+        location.hostname === 'www.pionier-workwear.com' ? `${location.pathname}${location.search}` : location.pathname,
       personaId: optionsFromHash().persona,
       pluginPath: optionsFromHash().path,
     }

--- a/plugiamo/webpack.config.js
+++ b/plugiamo/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     disableHostCheck: true,
     open: true,
     historyApiFallback: {
-      index: 'index.html',
+      rewrites: [{ from: /.*/, to: '/index.html' }],
     },
     host: '0.0.0.0',
     proxy: { '/graphql': 'http://localhost:5000' },


### PR DESCRIPTION
https://trello.com/c/mh5ysMVM/1023-pionier-shop-uses-same-path-for-every-page-only-differs-in-the-query-how-can-we-support-it

The pionier workwear website uses the same pathname for every page (/index.php) https://www.pionier-workwear.com/

So, let's workaround this by making the `search` (aka the query params) part of what's matched in the triggers. In the general case we don't want that, since most websites will add 'random' params to pages, such as `utm_campaign` (or other params); and those will not affect the page itself on **sane** websites. So this is hacked just for this case.