### PR TITLE
Fix picture-uploader on form save

### DIFF
--- a/console-frontend/src/app/resources/navigations/form/index.js
+++ b/console-frontend/src/app/resources/navigations/form/index.js
@@ -217,15 +217,16 @@ export default compose(
   }),
   withHandlers({
     uploadSubImage: () => async ({ blob, setProgress, subform }) => {
-      const picUrl = await uploadImage({
-        blob,
-        setProgress,
-        type: 'navigation-items-pics',
-        defaultValue: subform.picUrl,
-      })
-      return {
-        ...subform,
-        picUrl,
+      if (blob) {
+        const picUrl = await uploadImage({
+          blob,
+          setProgress,
+          type: 'navigation-items-pics',
+        })
+        return {
+          ...subform,
+          picUrl,
+        }
       }
     },
   }),
@@ -258,8 +259,9 @@ export default compose(
         })),
       }
     },
-    saveFormObject: ({ saveFormObject, setErrors, uploadSubImages }) => async form => {
+    saveFormObject: ({ saveFormObject, setErrors, uploadSubImages, setNavigationItemsPictures }) => async form => {
       await Promise.all(uploadSubImages(form))
+      setNavigationItemsPictures([])
       return saveFormObject(form, { setErrors })
     },
     afterFormMount: ({ convertPersona, setPersona }) => formObject => {

--- a/console-frontend/src/app/resources/personas/form.js
+++ b/console-frontend/src/app/resources/personas/form.js
@@ -112,14 +112,17 @@ export default compose(
     loadFormObject: ({ loadFormObject }) => async () => {
       return loadFormObject()
     },
-    saveFormObject: ({ saveFormObject, setProgress, profilePic, setErrors }) => async form => {
-      const profilePicUrl = await uploadImage({
-        blob: profilePic,
-        setProgress,
-        type: 'personas-profile-pics',
-        defaultValue: form.profilePicUrl,
-      })
-      return saveFormObject({ ...form, profilePicUrl }, { setErrors })
+    saveFormObject: ({ saveFormObject, setProgress, profilePic, setErrors, setProfilePic }) => async form => {
+      if (profilePic) {
+        const profilePicUrl = await uploadImage({
+          blob: profilePic,
+          setProgress,
+          type: 'personas-profile-pics',
+        })
+        setProfilePic(null)
+        return saveFormObject({ ...form, profilePicUrl }, { setErrors })
+      }
+      return saveFormObject(form, { setErrors })
     },
   }),
   withForm({

--- a/console-frontend/src/app/resources/showcases/form/index.js
+++ b/console-frontend/src/app/resources/showcases/form/index.js
@@ -258,15 +258,16 @@ export default compose(
   withState('productPicksPictures', 'setProductPicksPictures', []),
   withHandlers({
     uploadSubImage: () => async ({ blob, setProgress, subform }) => {
-      const productPickPhotoUrl = await uploadImage({
-        blob,
-        setProgress,
-        type: 'products-pics',
-        defaultValue: subform.picUrl,
-      })
-      return {
-        ...subform,
-        picUrl: productPickPhotoUrl,
+      if (blob) {
+        const productPickPhotoUrl = await uploadImage({
+          blob,
+          setProgress,
+          type: 'products-pics',
+        })
+        return {
+          ...subform,
+          picUrl: productPickPhotoUrl,
+        }
       }
     },
   }),
@@ -318,8 +319,9 @@ export default compose(
         })),
       }
     },
-    saveFormObject: ({ saveFormObject, setErrors, uploadSubImages }) => async form => {
+    saveFormObject: ({ saveFormObject, setErrors, uploadSubImages, setProductPicksPictures }) => async form => {
       await Promise.all(uploadSubImages(form))
+      setProductPicksPictures([])
       return saveFormObject(form, { setErrors })
     },
   }),

--- a/console-frontend/src/app/screens/account/edit-user.js
+++ b/console-frontend/src/app/screens/account/edit-user.js
@@ -91,16 +91,20 @@ export default compose(
     },
   }),
   withHandlers({
-    saveFormObject: ({ enqueueSnackbar, setErrors, setProgress, profilePic }) => async form => {
+    saveFormObject: ({ enqueueSnackbar, setErrors, setProgress, profilePic, setProfilePic }) => async form => {
       // upload the image
-      const profilePicUrl = await uploadImage({
-        blob: profilePic,
-        setProgress,
-        type: 'users-profile-pics',
-        defaultValue: form.profilePicUrl,
-      })
+      let data
+      if (profilePic) {
+        const profilePicUrl = await uploadImage({
+          blob: profilePic,
+          setProgress,
+          type: 'users-profile-pics',
+        })
+        data = { ...form, profilePicUrl }
+      } else {
+        data = form
+      }
       // update user data
-      const data = { ...form, profilePicUrl }
       const { json, errors, requestError } = await apiRequest(apiMeUpdate, [{ user: data }])
       if (requestError) enqueueSnackbar(requestError, { variant: 'error' })
       if (errors) setErrors(errors)
@@ -108,6 +112,7 @@ export default compose(
         enqueueSnackbar('Successfully updated personal info', { variant: 'success' })
         auth.setUser(json)
       }
+      setProfilePic(null)
       return json
     },
   }),

--- a/console-frontend/src/shared/picture-uploader.js
+++ b/console-frontend/src/shared/picture-uploader.js
@@ -265,8 +265,7 @@ const resultingCrop = (image, imageElement, pixelCrop) => {
   return new Promise(resolve => canvas.toBlob(resolve, image.type))
 }
 
-const uploadImage = async ({ blob, setProgress, type, defaultValue }) => {
-  if (!blob) return defaultValue
+const uploadImage = async ({ blob, setProgress, type }) => {
   try {
     const { fileUrl } = await S3Upload({
       contentDisposition: 'auto',


### PR DESCRIPTION
## Bug "catch": 
Upon a spotlight's product picks re-order, product picks pictures don't follow the updated order of the product picks: 

**example**: 
product 1/picture 1; product 2/picture 2; product 3/picture 3
change: product 1 <-> product 2
result: product 2/picture 1; product 1/picture 2; product 3/picture 3

**Expected / Result**:
![1 change](https://user-images.githubusercontent.com/35154956/55407376-c2c85200-5555-11e9-9e87-7ee0eea02f3c.png) ![result](https://user-images.githubusercontent.com/35154956/55407395-ca87f680-5555-11e9-960b-84aa160f40dd.png)

## Bug description:
1) user goes to showcase edit page
2) update product pick picture
3) save -> creates new product pick picture
4) Issue: saves again -> creates new product pick's picture **again**

**Reason**: The `uploadImage` function is always called when the form is saved. When the picture/pictures state isn't set to it's initial state, a new picture is uploaded, with a new url.

## Solution: 

When the form is saved, we reset the picture/pictures state so that we only call the `uploadImage` function when we actually update the picture/pictures.


[Link To Trello Card](https://trello.com/c/wH1SAkYb/1017-showcase-same-picture-got-used-in-more-than-one-product)