### PR TITLE
Fixing FOIT (Flash of Invisible Text) / font flickering

### DIFF
--- a/plugiamo/src/shared/frame.js
+++ b/plugiamo/src/shared/frame.js
@@ -69,7 +69,12 @@ export default compose(
       const { iframeRef, setIsLoaded } = this.props
       if (iframeRef && iframeRef !== prevProps.iframeRef) {
         const load = () => {
-          loadCss(iframeRef.contentDocument.head, 'https://fonts.googleapis.com/css?family=Roboto:400,500,700')
+          // Here we avoid FOIT (Flash of Invisible Text) on the slow network connections. Read more: https://medium.com/@pierluc/enable-font-display-on-google-fonts-with-cloudflare-workers-d7604cb30eab
+          fetch('https://fonts.googleapis.com/css?family=Roboto:400,500,700').then(response => {
+            response.text().then(body => {
+              addCss(iframeRef.contentDocument.head, body.replace(/}/g, 'font-display: swap; }'))
+            })
+          })
           addCss(iframeRef.contentDocument.head, style)
           addBase(iframeRef.contentDocument.head)
           addPlatformClass(iframeRef.contentDocument.body)


### PR DESCRIPTION
### Changes
Fixed FOIT by using the following technique:
- Loading google fonts manually and inserting `font-display: swap;` inside `@font-face` CSS declarations;
- Then inserting it as a regular CSS to our iframes;

### How it works?
When the font just starts loading from external resource (e.g: Goggle CDN), browser already applies it to the elements with text resulting in showing no visual text at all.
`font-display: swap;` makes the browser wait until font completely loads and, for now, there's almost no other way. Google Fonts doesn't provides us with this functionality yet.