### PR TITLE
Fix autocomplete usability

### DIFF
--- a/console-frontend/src/shared/autocomplete.js
+++ b/console-frontend/src/shared/autocomplete.js
@@ -14,26 +14,46 @@ const StyledArrowDropDown = styled(ArrowDropDown)`
   }
 `
 
-const DropdownButton = ({ loadAllOptions }) => (
+const DropdownButton = ({ onClick }) => (
   <InputAdornment position="end">
-    <StyledArrowDropDown onClick={loadAllOptions} />
+    <StyledArrowDropDown onClick={onClick} />
   </InputAdornment>
 )
 
-const AutocompleteInput = ({ formControlProps, inputProps, label, name, loadAllOptions }) => (
+const AutocompleteInputTemplate = ({ formControlProps, inputProps, onDropdownClick, label, name, setInputRef }) => (
   <FormControl margin="normal" {...formControlProps}>
     <InputLabel htmlFor={inputProps.id} id={inputProps['aria-labelledby']}>
       {label}
     </InputLabel>
     <Input
-      endAdornment={<DropdownButton loadAllOptions={loadAllOptions} />}
+      endAdornment={<DropdownButton onClick={onDropdownClick} />}
       fullWidth
+      inputProps={{ ref: setInputRef }}
       name={name}
       type="text"
       {...inputProps}
     />
   </FormControl>
 )
+
+const AutocompleteInput = compose(
+  withHandlers(() => {
+    let inputRef
+    return {
+      setInputRef: () => ref => (inputRef = ref),
+      getInputRef: () => () => inputRef,
+    }
+  }),
+  withHandlers({
+    onDropdownClick: ({ getInputRef, loadAllOptions }) => () => {
+      loadAllOptions()
+      const ref = getInputRef()
+      if (ref) {
+        ref.focus()
+      }
+    },
+  })
+)(AutocompleteInputTemplate)
 
 const ResultsDiv = styled.div`
   width: 100%;


### PR DESCRIPTION
### Changes
- Autocomplete typing field is in focus when clicking on it's dropdown icon;

### Note
- `withHandlers` was used instead of `React.createRef()` because it isn't defining unique refs. For example, the page scrolls down to the last instance of `Autocomplete` and focuses there if the first instance was clicked though.