### PR TITLE
Fix order bug in duplicated instances

### DIFF
--- a/backend/app/models/navigation_item.rb
+++ b/backend/app/models/navigation_item.rb
@@ -6,7 +6,7 @@ class NavigationItem < ApplicationRecord
   validates :text, presence: true
   validates :url, presence: true
 
-  before_create :assign_order
+  before_create :assign_order, unless: :order_changed?
 
   def pic_url
     pic.url

--- a/backend/app/models/product_pick.rb
+++ b/backend/app/models/product_pick.rb
@@ -3,7 +3,7 @@ class ProductPick < ApplicationRecord
   belongs_to :spotlight
   belongs_to :pic, class_name: "Picture"
 
-  before_create :assign_order
+  before_create :assign_order, unless: :order_changed?
 
   def assign_order
     current_value = self.class.where(spotlight_id: spotlight_id).order(:order).pluck(:order).last || 0

--- a/backend/app/models/simple_chat_message.rb
+++ b/backend/app/models/simple_chat_message.rb
@@ -4,7 +4,7 @@ class SimpleChatMessage < ApplicationRecord
 
   validates :text, presence: true
 
-  before_create :assign_order
+  before_create :assign_order, unless: :order_changed?
 
   def as_json(_options = {})
     attributes.slice("id", "text", "order")

--- a/backend/app/models/simple_chat_step.rb
+++ b/backend/app/models/simple_chat_step.rb
@@ -5,7 +5,7 @@ class SimpleChatStep < ApplicationRecord
 
   accepts_nested_attributes_for :simple_chat_messages, allow_destroy: true
 
-  before_create :assign_order
+  before_create :assign_order, unless: :order_changed?
 
   validate :dafault_cannot_be_repeated
 

--- a/backend/app/models/spotlight.rb
+++ b/backend/app/models/spotlight.rb
@@ -6,7 +6,7 @@ class Spotlight < ApplicationRecord
 
   accepts_nested_attributes_for :product_picks, allow_destroy: true
 
-  before_create :assign_order
+  before_create :assign_order, unless: :order_changed?
 
   def paths(spotlight_index)
     new_step = attributes.slice("id", "name")

--- a/backend/app/models/trigger.rb
+++ b/backend/app/models/trigger.rb
@@ -7,7 +7,7 @@ class Trigger < ApplicationRecord
   validates :url_matchers, presence: true
   validate :url_matchers_cannot_be_blank
 
-  before_create :assign_order
+  before_create :assign_order, unless: :order_changed?
 
   def self.find_matching(pathname)
     Trigger.order(:order).find do |trigger|

--- a/backend/test/factories/simple_chat_messages.rb
+++ b/backend/test/factories/simple_chat_messages.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :simple_chat_message do
+    sequence(:text) { Faker::Lorem.sentence }
+  end
+end

--- a/backend/test/factories/simple_chat_steps.rb
+++ b/backend/test/factories/simple_chat_steps.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :simple_chat_step do
+    sequence(:key) { "default" }
+  end
+end

--- a/backend/test/factories/simple_chats.rb
+++ b/backend/test/factories/simple_chats.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :simple_chat do
+    sequence(:name) { Faker::StarWars.planet }
+    sequence(:title) { Faker::Lorem.words(2) }
+    sequence(:chat_bubble_text) { Faker::Lorem.words(4) }
+    sequence(:chat_bubble_extra_text) { Faker::Lorem.words(4) }
+    persona
+  end
+end

--- a/backend/test/models/simple_chat_message_test.rb
+++ b/backend/test/models/simple_chat_message_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class SimpleChatMessageTest < ActiveSupport::TestCase
+  test "duplicated simple chat preserves order of simple chat messages" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    simple_chat = create(:simple_chat)
+    simple_chat_step = create(:simple_chat_step, simple_chat: simple_chat)
+
+    create(:simple_chat_message, simple_chat_step: simple_chat_step)
+    create(:simple_chat_message, simple_chat_step: simple_chat_step, order: 2)
+    create(:simple_chat_message, simple_chat_step: simple_chat_step, order: 8)
+    create(:simple_chat_message, simple_chat_step: simple_chat_step, order: 3)
+
+    result = simple_chat.simple_chat_steps.first.simple_chat_messages.each(&:attributes).pluck(:order)
+
+    assert_equal [1, 2, 8, 3], result
+  end
+end

--- a/backend/test/models/simple_chat_step_test.rb
+++ b/backend/test/models/simple_chat_step_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class SimpleChatStepTest < ActiveSupport::TestCase
+  test "duplicated simple chat preserves order of simple chat steps" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    simple_chat = create(:simple_chat)
+
+    create(:simple_chat_step, simple_chat: simple_chat)
+    create(:simple_chat_step, simple_chat: simple_chat, order: 2, key: Faker::Lorem.sentence)
+    create(:simple_chat_step, simple_chat: simple_chat, order: 8, key: Faker::Lorem.sentence)
+    create(:simple_chat_step, simple_chat: simple_chat, order: 3, key: Faker::Lorem.sentence)
+
+    result = simple_chat.simple_chat_steps.each(&:attributes).pluck(:order)
+
+    assert_equal [1, 2, 8, 3], result
+  end
+end


### PR DESCRIPTION
## Bug:
Duplicated instances did not preserve order of original instances.
This caused the following when duplicating an account:

```
1: Account 1:
       Simple Chat 1:
         Initial Step:
           Message 1 
           Message 2

2: Duplicate Account 1 -> Account 2

3: Account 2:
       Simple Chat 1:
         Initial Step:
           Message 1 
           Message 2

4: Duplicate Simple Chat 1 in Account 2

5: Account 2:
       Copied from - Simple Chat 1:
         Initial Step:
           Message 2
           Message 1 
```
**TL;DR** The messages of the duplicated simple chat step had the wrong order

## Cause:
- The `assign_order` method called from the `before_create` callback (for ordered models) was always triggered, even on records that already had an order field (duplicated records) .

[Link To Trello Card](https://trello.com/c/7eWa6oDS/1059-investigate-bug-with-scripted-chat-message-order)