### PR TITLE
Fix loading sidebar shapes color in onboarding

### DIFF
--- a/console-frontend/src/app/layout/dummy-menu.js
+++ b/console-frontend/src/app/layout/dummy-menu.js
@@ -13,7 +13,7 @@ const shine = keyframes`
 const ShinyItem = styled.div`
   position: relative;
   overflow: hidden;
-  background: #3b3c46;
+  background: #e0e0e0;
   &:before {
     content: '';
     position: absolute;
@@ -43,7 +43,7 @@ const Avatar = styled(ShinyItem)`
 const Divider = styled.div`
   height: 1px;
   width: 100%;
-  background: #3b3c46;
+  background: #e0e0e0;
 `
 
 const DummyText = styled(ShinyItem)`


### PR DESCRIPTION
## Changes

On the first step of onboarding the menu mock UI had black shapes, they are now gray.

## Preview

![image](https://user-images.githubusercontent.com/24722181/56040101-94086380-5d2d-11e9-8224-9af8e04de39f.png)

---

[Trello card](https://trello.com/c/POcF8tVq)
