### PR TITLE
Fix re-order to 1st position bug

### DIFF
--- a/backend/db/migrate/20190415094918_change_default_order.rb
+++ b/backend/db/migrate/20190415094918_change_default_order.rb
@@ -1,0 +1,16 @@
+class ChangeDefaultOrder < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default(:triggers, :order, from: 1, to: nil)
+    change_column_default(:navigation_items, :order, from: 1, to: nil)
+    change_column_default(:product_picks, :order, from: 1, to: nil)
+    change_column_default(:simple_chat_messages, :order, from: 1, to: nil)
+    change_column_default(:simple_chat_steps, :order, from: 1, to: nil)
+    change_column_default(:spotlights, :order, from: 1, to: nil)
+    change_column_null :triggers, :order, true
+    change_column_null :navigation_items, :order, true
+    change_column_null :product_picks, :order, true
+    change_column_null :simple_chat_messages, :order, true
+    change_column_null :simple_chat_steps, :order, true
+    change_column_null :spotlights, :order, true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190404155613) do
+ActiveRecord::Schema.define(version: 20190415094918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20190404155613) do
     t.string "pic_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "order", default: 1, null: false
+    t.integer "order"
     t.bigint "pic_id"
     t.index ["account_id"], name: "index_navigation_items_on_account_id"
     t.index ["navigation_id"], name: "index_navigation_items_on_navigation_id"
@@ -104,7 +104,7 @@ ActiveRecord::Schema.define(version: 20190404155613) do
     t.string "display_price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "order", default: 1, null: false
+    t.integer "order"
     t.bigint "pic_id"
     t.index ["account_id"], name: "index_product_picks_on_account_id"
     t.index ["pic_id"], name: "index_product_picks_on_pic_id"
@@ -137,7 +137,7 @@ ActiveRecord::Schema.define(version: 20190404155613) do
 
   create_table "simple_chat_messages", force: :cascade do |t|
     t.string "text", null: false
-    t.integer "order", default: 1, null: false
+    t.integer "order"
     t.bigint "simple_chat_step_id"
     t.bigint "account_id"
     t.datetime "created_at", null: false
@@ -148,7 +148,7 @@ ActiveRecord::Schema.define(version: 20190404155613) do
 
   create_table "simple_chat_steps", force: :cascade do |t|
     t.string "key", default: "default", null: false
-    t.integer "order", default: 1, null: false
+    t.integer "order"
     t.bigint "simple_chat_id"
     t.bigint "account_id"
     t.datetime "created_at", null: false
@@ -176,14 +176,14 @@ ActiveRecord::Schema.define(version: 20190404155613) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "showcase_id"
-    t.integer "order", default: 1, null: false
+    t.integer "order"
     t.index ["account_id"], name: "index_spotlights_on_account_id"
     t.index ["persona_id"], name: "index_spotlights_on_persona_id"
     t.index ["showcase_id"], name: "index_spotlights_on_showcase_id"
   end
 
   create_table "triggers", force: :cascade do |t|
-    t.integer "order", default: 1, null: false
+    t.integer "order"
     t.string "url_matchers", null: false, array: true
     t.string "flow_type"
     t.bigint "flow_id"

--- a/backend/test/models/simple_chat_message_test.rb
+++ b/backend/test/models/simple_chat_message_test.rb
@@ -1,19 +1,35 @@
 require "test_helper"
 
 class SimpleChatMessageTest < ActiveSupport::TestCase
-  test "duplicated simple chat preserves order of simple chat messages" do
+  test "simple chat messages sorted after create, without order field" do
     ActsAsTenant.default_tenant = Account.create!
 
     simple_chat = create(:simple_chat)
     simple_chat_step = create(:simple_chat_step, simple_chat: simple_chat)
 
     create(:simple_chat_message, simple_chat_step: simple_chat_step)
+    create(:simple_chat_message, simple_chat_step: simple_chat_step)
+    create(:simple_chat_message, simple_chat_step: simple_chat_step)
+    create(:simple_chat_message, simple_chat_step: simple_chat_step)
+
+    result = simple_chat.simple_chat_steps.first.simple_chat_messages.each(&:attributes).pluck(:order)
+
+    assert_equal [1, 2, 3, 4], result
+  end
+
+  test "simple chat messages sorted after create, with order field" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    simple_chat = create(:simple_chat)
+    simple_chat_step = create(:simple_chat_step, simple_chat: simple_chat)
+
     create(:simple_chat_message, simple_chat_step: simple_chat_step, order: 2)
     create(:simple_chat_message, simple_chat_step: simple_chat_step, order: 8)
+    create(:simple_chat_message, simple_chat_step: simple_chat_step, order: 1)
     create(:simple_chat_message, simple_chat_step: simple_chat_step, order: 3)
 
     result = simple_chat.simple_chat_steps.first.simple_chat_messages.each(&:attributes).pluck(:order)
 
-    assert_equal [1, 2, 8, 3], result
+    assert_equal [2, 8, 1, 3], result
   end
 end

--- a/backend/test/models/simple_chat_step_test.rb
+++ b/backend/test/models/simple_chat_step_test.rb
@@ -1,18 +1,33 @@
 require "test_helper"
 
 class SimpleChatStepTest < ActiveSupport::TestCase
-  test "duplicated simple chat preserves order of simple chat steps" do
+  test "simple chat steps sorted after create, without order field" do
     ActsAsTenant.default_tenant = Account.create!
 
     simple_chat = create(:simple_chat)
 
     create(:simple_chat_step, simple_chat: simple_chat)
+    create(:simple_chat_step, simple_chat: simple_chat, key: Faker::Lorem.sentence)
+    create(:simple_chat_step, simple_chat: simple_chat, key: Faker::Lorem.sentence)
+    create(:simple_chat_step, simple_chat: simple_chat, key: Faker::Lorem.sentence)
+
+    result = simple_chat.simple_chat_steps.each(&:attributes).pluck(:order)
+
+    assert_equal [1, 2, 3, 4], result
+  end
+
+  test "simple chat messages steps after create, with order field" do
+    ActsAsTenant.default_tenant = Account.create!
+
+    simple_chat = create(:simple_chat)
+
     create(:simple_chat_step, simple_chat: simple_chat, order: 2, key: Faker::Lorem.sentence)
     create(:simple_chat_step, simple_chat: simple_chat, order: 8, key: Faker::Lorem.sentence)
+    create(:simple_chat_step, simple_chat: simple_chat, order: 1)
     create(:simple_chat_step, simple_chat: simple_chat, order: 3, key: Faker::Lorem.sentence)
 
     result = simple_chat.simple_chat_steps.each(&:attributes).pluck(:order)
 
-    assert_equal [1, 2, 8, 3], result
+    assert_equal [2, 8, 1, 3], result
   end
 end


### PR DESCRIPTION
**For `Triggers\Navigation Items\Product Picks\SimpleChatMessages\SimpleChatSteps\Spotlights`**

### Expected behaviour:
The user is able to set order of objects to the 1st position before instacianting them. 

### Actual behaviour:

If the user re-orders an object to the 1st position before saving it, the result will be the object in the wrong position. This happens due to the `assign_order` method triggered in the `before_create` callback, even when `order = 1`. 

### Steps to reproduce the behaviour:
In [admin.frekkls.com](https://admin.frekkls.com): 
On an existing `SimpleChat`, user creates a new `SimpleChatMessage` and before saving he re-orders the newly-created `SimpleChatMessage` to the 1st position in that `SimpleChatStep`. The response from the server to the `PUT` request returns the `SimpleChatStep` `SimpleChatMessage`'s with wrong order.

![bug](https://user-images.githubusercontent.com/35154956/56128871-bfcb5980-5f78-11e9-8ff5-900fc03b15fc.gif)


### Fix: 
Changed the default value from `1` to `nil`. Now, if the order field is not declared on create (`order = nil`), the `assign_order` method runs on the `before_create` callback. If order is specified (`order != nil`),  the `assign_order` method does not run, respecting the declared order.

[Link To Trello Card](https://trello.com/c/d5ZJkU3g/1084-simple-chats-message-re-order)