### PR TITLE
Fix Assessment Flow Cta Button Bug

### DIFF
--- a/plugiamo/src/special/assessment/steps/cta-button.js
+++ b/plugiamo/src/special/assessment/steps/cta-button.js
@@ -44,14 +44,16 @@ const CtaButton = ({ onClick, animation }) => (
 
 export default compose(
   withState('animation', 'setAnimation', ({ hide }) => (hide ? 'remove' : 'show')),
+  withState('clicked', 'setClicked', false),
   lifecycle({
     componentWillUnmount() {
       timeout.clear('ctaButtonAnimation')
     },
     componentDidUpdate(prevProps) {
-      const { hide, setAnimation } = this.props
+      const { hide, setAnimation, clicked } = this.props
       if (hide !== prevProps.hide) {
         setAnimation(hide ? 'hide' : 'init')
+        if (clicked) return
         timeout.clear('ctaButtonAnimation')
         timeout.set('ctaButtonAnimation', () => setAnimation(hide ? 'remove' : 'show'), hide ? 600 : 30)
       }
@@ -59,6 +61,10 @@ export default compose(
   }),
   branch(({ animation }) => animation === 'remove', renderNothing),
   withHandlers({
-    onClick: ({ goToNextStep }) => () => goToNextStep('showResults'),
+    onClick: ({ goToNextStep, setClicked, clicked }) => () => {
+      if (clicked) return
+      goToNextStep('showResults')
+      setClicked(true)
+    },
   })
 )(CtaButton)


### PR DESCRIPTION
### Bug cause
- The Cta button wasn't running the `componentDidUnmount` and thus wasn't running the `timeout.clear` which resulted in the `setState` being fired and making the button unclickable;
- The bug doesn't occur in mobile mode because that the CTA button still exists there after going to the store part. In the desktop mode, however, it removes the plugin completely and fires the `setState` event afterwards.
### Changes
- When the button is clicked we don't want to fire the `timeout.set` method. That condition was added and it prevents this bug from happening;
- Bonus: now the button can be clicked only once;