### PR TITLE
Attach the back button to the store

### DIFF
--- a/plugiamo/src/app/content/index.js
+++ b/plugiamo/src/app/content/index.js
@@ -27,8 +27,10 @@ const Content = ({
       {showAssessmentContent ? (
         <AssessmentContent
           animateOpacity
+          setShowAssessmentContent={setShowAssessmentContent}
           setShowingContent={setShowingContent}
           setShowingLauncher={setShowingLauncher}
+          showAssessmentContent={showAssessmentContent}
           showingContent
         />
       ) : (

--- a/plugiamo/src/special/assessment/chat.js
+++ b/plugiamo/src/special/assessment/chat.js
@@ -23,6 +23,8 @@ const Chat = ({
   showingCtaButton,
   goToPrevStep,
   nothingSelected,
+  ctaButtonClicked,
+  setCtaButtonClicked,
 }) => (
   <ScrollLock>
     <Cover
@@ -30,7 +32,7 @@ const Chat = ({
       currentStep={currentStep}
       goToPrevStep={goToPrevStep}
       minimized={coverMinimized}
-      showBackButton={currentStep.type !== 'store'}
+      showBackButton
       step={step}
     />
     <ProgressBar hide={currentStep.type === 'store'} progress={progress} />
@@ -39,6 +41,7 @@ const Chat = ({
         contentRef={contentRef}
         coverMinimized={coverMinimized}
         goToNextStep={goToNextStep}
+        goToPrevStep={goToPrevStep}
         onScroll={handleScroll}
         setContentRef={setContentRef}
         setShowingContent={setShowingContent}
@@ -62,7 +65,12 @@ const Chat = ({
         touch={touch}
       />
     )}
-    <CtaButton goToNextStep={goToNextStep} hide={currentStep.type === 'store' || !showingCtaButton} />
+    <CtaButton
+      clicked={ctaButtonClicked}
+      goToNextStep={goToNextStep}
+      hide={currentStep.type === 'store' || !showingCtaButton}
+      setClicked={setCtaButtonClicked}
+    />
   </ScrollLock>
 )
 

--- a/plugiamo/src/special/assessment/data.js
+++ b/plugiamo/src/special/assessment/data.js
@@ -453,6 +453,10 @@ const data = {
           imageUrl: 'https://console-assets.ams3.digitaloceanspaces.com/manual/pierre-cardin/list_modal_header.jpg',
           backgroundColor: '#111',
           textColor: '#fff',
+          backButton: {
+            textColor: '#fff',
+            backgroundColor: 'rgba(255, 255, 255, 0.3)',
+          },
         },
       },
     },

--- a/plugiamo/src/special/assessment/steps/cta-button.js
+++ b/plugiamo/src/special/assessment/steps/cta-button.js
@@ -44,7 +44,6 @@ const CtaButton = ({ onClick, animation }) => (
 
 export default compose(
   withState('animation', 'setAnimation', ({ hide }) => (hide ? 'remove' : 'show')),
-  withState('clicked', 'setClicked', false),
   lifecycle({
     componentWillUnmount() {
       timeout.clear('ctaButtonAnimation')

--- a/plugiamo/src/special/assessment/store/index.js
+++ b/plugiamo/src/special/assessment/store/index.js
@@ -20,6 +20,7 @@ const ChatLogUiTemplate = ({
   minHeight,
   logSection,
   step,
+  goToPrevStep,
 }) => (
   <Chat onScroll={onScroll} ref={setContentRef} touch={touch}>
     <ChatBackground ref={setBackgroundRef} style={{ minHeight }}>
@@ -27,6 +28,7 @@ const ChatLogUiTemplate = ({
     </ChatBackground>
     {!isSmall() && (
       <Modal
+        goToPrevStep={goToPrevStep}
         header={step.header}
         results={results}
         setShowingContent={setShowingContent}

--- a/plugiamo/src/special/assessment/store/modal/header.js
+++ b/plugiamo/src/special/assessment/store/modal/header.js
@@ -15,8 +15,15 @@ const config = {
   },
 }
 
-const Header = ({ header, coverMinimized }) => (
-  <Cover config={config} hackathon header={header} minimized={coverMinimized} />
+const Header = ({ header, coverMinimized, goToPrevStep }) => (
+  <Cover
+    assessment
+    config={config}
+    goToPrevStep={goToPrevStep}
+    minimized={coverMinimized}
+    showBackButton
+    step={{ header }}
+  />
 )
 
 export default Header

--- a/plugiamo/src/special/assessment/store/modal/index.js
+++ b/plugiamo/src/special/assessment/store/modal/index.js
@@ -15,17 +15,17 @@ const iframeStyle = {
   minHeight: '400px',
 }
 
-const FrameChild = ({ header, results }) => (
+const FrameChild = ({ header, results, goToPrevStep }) => (
   <div>
-    <Header header={header} />
+    <Header goToPrevStep={goToPrevStep} header={header} />
     <Content results={results} />
   </div>
 )
 
-const ModalTemplate = ({ closeModal, isOpen, results, header }) => (
+const ModalTemplate = ({ closeModal, isOpen, results, header, goToPrevStep }) => (
   <Wrapper allowBackgroundClose closeModal={closeModal} isOpen={isOpen}>
     <Frame style={iframeStyle}>
-      <FrameChild header={header} results={results} />
+      <FrameChild goToPrevStep={goToPrevStep} header={header} results={results} />
     </Frame>
   </Wrapper>
 )
@@ -36,6 +36,12 @@ const Modal = compose(
     closeModal: ({ setIsOpen, setShowingLauncher }) => () => {
       setIsOpen(false)
       setShowingLauncher(true)
+    },
+    goToPrevStep: ({ goToPrevStep, setIsOpen, setShowingLauncher, setShowingContent }) => () => {
+      setIsOpen(false)
+      setShowingLauncher(true)
+      setShowingContent(true)
+      goToPrevStep()
     },
   }),
   lifecycle({


### PR DESCRIPTION
### Changes
- Back button now appears in the store;
### Important
- Progress bar is now resetting smoothly to `100 - 33 = 77`% after going back from the `store`;
- The `CTA Button`'s `clicked` prop was passed to the root component in order to be reset upon going back;
- The `showAssessmentContent` prop is used to pass the `key` (e.g: 'Casual/Whatever') and the last `progress` value as the `Base` component is unmounted when in desktop mode;