### PR TITLE
Allow upload by url in pictures modal

### DIFF
--- a/backend/app/controllers/api/v1/cors_proxy_controller.rb
+++ b/backend/app/controllers/api/v1/cors_proxy_controller.rb
@@ -1,0 +1,32 @@
+require "open-uri"
+
+module Api
+  module V1
+    class CorsProxyController < RestAdminController
+      before_action :authenticate_user!
+      before_action :ensure_tenant
+
+      def download
+        # rubocop:disable Open, UriEscapeUnescape
+        file = open(URI.encode(params[:url]).gsub(%r{^(https|http):/}, '\0/'))
+        # rubocop:enable  Open, UriEscapeUnescape
+      rescue StandardError
+        render json: { error: "Can't find any file at this URL" }, status: :unprocessable_entity
+      else
+        process_file(file)
+      end
+
+      private
+
+      def process_file(file)
+        if !file.content_type.start_with?("image")
+          render json: { error: "Wrong file format" }, status: :unprocessable_entity
+        elsif file.size > 20_000_000
+          render json: { error: "File size exceed limit" }, status: :unprocessable_entity
+        else
+          send_data(file.read, type: file.content_type)
+        end
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
         resource :me, only: %i[show update]
         resources :generated_urls, only: %i[index create]
         get "s3/sign", to: "s3#sign"
+        get "/cors_proxy(/*url)", to: "cors_proxy#download", format: false
 
         devise_scope :user do
           get "/users/confirmation", to: "users/confirmations#show"

--- a/console-frontend/src/app/layout/loading.js
+++ b/console-frontend/src/app/layout/loading.js
@@ -3,8 +3,8 @@ import { CircularProgress } from '@material-ui/core'
 import { compose } from 'recompose'
 import { withClassesConsumer } from 'ext/recompose/with-classes'
 
-const Loading = ({ classes }) => (
-  <div className={classes.loadingContainer}>
+const Loading = ({ classes, transparent }) => (
+  <div className={classes.loadingContainer} style={transparent && { backgroundColor: 'transparent' }}>
     <div className={classes.loadingInnerContainer}>
       <div className={classes.loadingMessage}>
         <CircularProgress className={classes.loadingIcon} color="primary" size="80" />

--- a/console-frontend/src/shared/picture-uploader.js
+++ b/console-frontend/src/shared/picture-uploader.js
@@ -40,7 +40,7 @@ const StyledDelete = styled(Delete)`
 `
 
 const FilteredReactDropzone = props => (
-  <ReactDropzone {...omit(props, ['isDragging', 'previewPicture', 'setIsDragging'])} />
+  <ReactDropzone {...omit(props, ['isDragging', 'onFileUpload', 'previewPicture', 'setIsDragging'])} />
 )
 
 const StyledDropzone = styled(FilteredReactDropzone)`
@@ -74,9 +74,9 @@ const Dropzone = compose(
     onDragLeave: ({ setIsDragging }) => () => {
       setIsDragging(false)
     },
-    onDrop: ({ onDrop, setIsDragging }) => (acceptedFiles, rejectedFiles) => {
+    onDrop: ({ onFileUpload, setIsDragging }) => (acceptedFiles, rejectedFiles) => {
       setIsDragging(false)
-      onDrop(acceptedFiles, rejectedFiles)
+      onFileUpload(acceptedFiles, rejectedFiles)
     },
   })
 )(({ disabled, square, isDragging, onDragEnter, onDragLeave, previewPicture, ...props }) => (
@@ -153,7 +153,7 @@ const BarebonesPictureUploader = ({
   onCropChange,
   onCropComplete,
   onDoneClick,
-  onDrop,
+  onFileUpload,
   onModalClose,
   onPictureLoaded,
   onRemovePicture,
@@ -172,7 +172,7 @@ const BarebonesPictureUploader = ({
       onCropChange={onCropChange}
       onCropComplete={onCropComplete}
       onDoneClick={onDoneClick}
-      onDrop={onDrop}
+      onFileUpload={onFileUpload}
       onModalClose={onModalClose}
       onPictureLoaded={onPictureLoaded}
       open={modalOpen}
@@ -189,7 +189,7 @@ const BarebonesPictureUploader = ({
           disabled={disabled}
           multiple={false}
           onClick={onClick}
-          onDrop={onDrop}
+          onFileUpload={onFileUpload}
           previewPicture={previewPicture}
           square={square}
         />
@@ -351,14 +351,14 @@ const PictureUploader = compose(
       setPic(blob)
       URL.revokeObjectURL(picture.preview)
     },
-    onDrop: ({ onChange, setDoneCropping, setModalOpen, setPicture, setPreviousValue, value }) => files => {
+    onFileUpload: ({ onChange, setDoneCropping, setModalOpen, setPicture, setPreviousValue, value }) => files => {
       setDoneCropping(false)
       onChange('')
       setPreviousValue(value)
       if (files.length === 0) return
       const file = files[0]
       setPicture({
-        name: file.name,
+        name: file.name || 'upload',
         preview: URL.createObjectURL(file),
         size: file.size,
         type: file.type,

--- a/console-frontend/src/utils/auth-requests.js
+++ b/console-frontend/src/utils/auth-requests.js
@@ -20,6 +20,7 @@ const ONBOARDING_URL = `${BASE_API_URL}/users/onboarding`
 const GENERATED_URLS_URL = `${BASE_API_URL}/generated_urls`
 const PATH_URL = `${BASE_API_URL}/path`
 const ACCOUNTS_URL = `${BASE_API_URL}/accounts`
+const CORS_PROXY_URL = `${BASE_API_URL}/cors_proxy`
 
 const filterBody = body => omitDeep(body, key => key.startsWith('__'))
 
@@ -118,6 +119,8 @@ export const apiPersonasAutocomplete = query => apiGetRequest(`${PERSONAS_URL}/a
 
 export const apiPictureList = query => apiListRequest(`${PICTURES_URL}/?${stringify(query)}`)
 export const apiPictureDestroy = body => apiDestroyMultipleRequest(PICTURES_URL, body)
+
+export const apiGetRemotePicture = url => apiGetRequest(`${CORS_PROXY_URL}/${url}`)
 
 export const apiOutroList = query => apiListRequest(`${OUTROS_URL}/?${stringify(query)}`)
 export const apiOutroDestroy = body => apiDestroyMultipleRequest(OUTROS_URL, body)

--- a/console-frontend/src/utils/index.js
+++ b/console-frontend/src/utils/index.js
@@ -7,6 +7,7 @@ import {
   apiFlowsList,
   apiGeneratedUrlCreate,
   apiGeneratedUrlList,
+  apiGetRemotePicture,
   apiGetSignedUrlFactory,
   apiMe,
   apiMeUpdate,
@@ -68,6 +69,7 @@ export {
   apiShowcaseShow,
   apiShowcaseUpdate,
   apiFlowsList,
+  apiGetRemotePicture,
   apiGetSignedUrlFactory,
   apiMe,
   apiMeUpdate,
@@ -138,7 +140,11 @@ export const apiRequest = async (requestMethod, args, options) => {
   const promise = args.length === 0 ? requestMethod() : requestMethod(...args)
   const response = await promise.catch(() => null)
   const { requestError } = await handleRequestError(response, options && options.isLoginRequest)
-  const json = requestError ? {} : await response.json()
+  const json = requestError
+    ? {}
+    : response.headers.get('content-type').startsWith('image')
+    ? await response.blob()
+    : await response.json()
   const errors = extractErrors(json)
   return { json, requestError, errors, response }
 }


### PR DESCRIPTION
[Trello card](https://trello.com/c/IAdXJPvL)

## Updates

- A picture can now be uploaded from an url, with a new specific view in the modal and some minor updates in the existing views (gallery and empty state) 
- To do that and avoid CORS issues, a new `cors_proxy_controller` was created with a `#download` action, and a new endpoint `/cors_proxy/:url` pointing to it. In this action, the file gets downloaded (if possible, otherwise a 4xx response is returned) and returned. 
- When a picture is valid and returned, the crop zone is shown with the downloaded picture; when the url provided is not valid (or pointing to a non-image file, or the picture is > 20MB), a snack bar is shown with a specific error message

## Minor updates

- The `onDrop` method was changed to `onFileUpload`, since it's the same for both uploads through the dropzone or a dialog
- The loader was also updated to have a transparent background before the modal opens, since a grey background was covering the content and then showing it again with the modal open

## Previews

> Gallery
![image](https://user-images.githubusercontent.com/24722181/56227935-8117cb00-606e-11e9-8a56-ba9267940745.png)

> Url upload
![image](https://user-images.githubusercontent.com/24722181/56227975-9856b880-606e-11e9-9975-ae902b4ed467.png)

> With invalid url
![image](https://user-images.githubusercontent.com/24722181/56363374-fc4ebd80-61e3-11e9-93c2-7b79e403140a.png)

> With invalid file format
![image](https://user-images.githubusercontent.com/24722181/56363407-125c7e00-61e4-11e9-885f-774e6fb2ea63.png)

> With picture size > 20MB
![image](https://user-images.githubusercontent.com/24722181/56363836-fc02f200-61e4-11e9-9624-201a2c129395.png)


