### PR TITLE
Add "Save & New" button to triggers form

### DIFF
--- a/console-frontend/src/app/routes.js
+++ b/console-frontend/src/app/routes.js
@@ -77,6 +77,9 @@ const routes = {
   admin() {
     return '/admin'
   },
+  nullRoute() {
+    return '/empty'
+  },
 }
 
 export default routes

--- a/console-frontend/src/app/theme.js
+++ b/console-frontend/src/app/theme.js
@@ -80,6 +80,13 @@ const customButtons = {
     color: 'rgba(0, 0, 0, 0.6)',
     boxShadow: '0 2px 6px 0 rgba(0, 0, 0, 0.1)',
   },
+  actions: {
+    backgroundColor: '#fff',
+    color: '#ff6641',
+    hover: {
+      color: '#ff6641',
+    },
+  },
 }
 
 const customPalette = {

--- a/console-frontend/src/shared/form-elements/actions.js
+++ b/console-frontend/src/shared/form-elements/actions.js
@@ -1,17 +1,76 @@
+import ActionsMenu from './simple-menu'
 import React from 'react'
 import SaveButton from './save-button'
+import styled from 'styled-components'
+import withWidth from '@material-ui/core/withWidth'
 
-const Actions = ({ tooltipEnabled, isFormSubmitting, onFormSubmit, saveDisabled, isFormPristine, tooltipText }) => (
+const Container = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-end;
+  @media (min-width: 800px) {
+    flex-flow: row;
+  }
+`
+
+const FlexDiv = styled.div`
+  flex: 1;
+  margin: 2px 5px;
+  white-space: nowrap;
+`
+
+const actions = [{ label: 'Save', color: 'primaryGradient' }, { label: 'Save & New', color: 'actions' }]
+
+const Actions = ({
+  tooltipEnabled,
+  isFormSubmitting,
+  onFormSubmit,
+  saveDisabled,
+  isFormPristine,
+  tooltipText,
+  saveAndCreateNewEnabled,
+  width,
+}) => (
   <React.Fragment>
-    <SaveButton
-      disabled={saveDisabled}
-      isFormPristine={isFormPristine}
-      isFormSubmitting={isFormSubmitting}
-      onClick={onFormSubmit}
-      tooltipEnabled={tooltipEnabled}
-      tooltipText={tooltipText}
-    />
+    {saveAndCreateNewEnabled ? (
+      width === 'sm' || width === 'xs' ? (
+        <ActionsMenu
+          actions={actions}
+          disabled={saveDisabled}
+          isFormPristine={isFormPristine}
+          isFormSubmitting={isFormSubmitting}
+          onFormSubmit={onFormSubmit}
+        />
+      ) : (
+        <Container>
+          {actions.map((action, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <FlexDiv key={index}>
+              <SaveButton
+                color={action.color}
+                disabled={saveDisabled}
+                isFormPristine={isFormPristine}
+                isFormSubmitting={isFormSubmitting}
+                message={action.label}
+                onClick={event => onFormSubmit(event, action.label)}
+                tooltipEnabled={tooltipEnabled}
+                tooltipText={tooltipText}
+              />
+            </FlexDiv>
+          ))}
+        </Container>
+      )
+    ) : (
+      <SaveButton
+        disabled={saveDisabled}
+        isFormPristine={isFormPristine}
+        isFormSubmitting={isFormSubmitting}
+        onClick={onFormSubmit}
+        tooltipEnabled={tooltipEnabled}
+        tooltipText={tooltipText}
+      />
+    )}
   </React.Fragment>
 )
 
-export default Actions
+export default withWidth()(Actions)

--- a/console-frontend/src/shared/form-elements/save-button.js
+++ b/console-frontend/src/shared/form-elements/save-button.js
@@ -1,9 +1,18 @@
 import Button from 'shared/button'
 import React from 'react'
 
-const SaveButton = ({ onClick, tooltipText, tooltipEnabled, isFormSubmitting, isFormPristine, message, disabled }) => (
+const SaveButton = ({
+  color,
+  onClick,
+  tooltipText,
+  tooltipEnabled,
+  isFormSubmitting,
+  isFormPristine,
+  message,
+  disabled,
+}) => (
   <Button
-    color="primaryGradient"
+    color={color || 'primaryGradient'}
     disabled={disabled}
     isFormPristine={isFormPristine}
     isFormSubmitting={isFormSubmitting}

--- a/console-frontend/src/shared/form-elements/simple-menu.js
+++ b/console-frontend/src/shared/form-elements/simple-menu.js
@@ -1,0 +1,51 @@
+import Button from 'shared/button'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import React from 'react'
+import { compose, withHandlers, withState } from 'recompose'
+
+const SimpleMenu = ({
+  anchorEl,
+  handleClick,
+  handleClose,
+  isFormPristine,
+  isFormSubmitting,
+  disabled,
+  message,
+  actions,
+  closeMenu,
+}) => (
+  <div>
+    <Button
+      aria-haspopup="true"
+      aria-owns={anchorEl ? 'actions-menu' : undefined}
+      color="actions"
+      disabled={disabled}
+      isFormPristine={isFormPristine}
+      isFormSubmitting={isFormSubmitting}
+      onClick={handleClick}
+    >
+      {message || 'Select Action'}
+    </Button>
+    <Menu anchorEl={anchorEl} id="actions-menu" onClose={closeMenu} open={Boolean(anchorEl)}>
+      {actions.map((action, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <MenuItem key={index} onClick={event => handleClose(event, action.label)}>
+          {action.label}
+        </MenuItem>
+      ))}
+    </Menu>
+  </div>
+)
+
+export default compose(
+  withState('anchorEl', 'setAnchorEl', null),
+  withHandlers({
+    closeMenu: ({ setAnchorEl }) => () => setAnchorEl(null),
+    handleClose: ({ onFormSubmit, setAnchorEl }) => (event, action) => {
+      setAnchorEl(null)
+      onFormSubmit(event, action)
+    },
+    handleClick: ({ setAnchorEl }) => event => setAnchorEl(event.currentTarget),
+  })
+)(SimpleMenu)

--- a/console-frontend/src/utils/index.js
+++ b/console-frontend/src/utils/index.js
@@ -1,4 +1,5 @@
 import auth from 'auth'
+import routes from 'app/routes'
 import {
   apiAccount,
   apiAccountCreate,
@@ -143,3 +144,10 @@ export const apiRequest = async (requestMethod, args, options) => {
 }
 
 export const atLeastOneNonBlankCharRegexp = '.*\\S+.*'
+
+// refreshRoute goes to "/empty", and replaces that history entry by the original route,
+// remounting the original component
+export const refreshRoute = (history, route, query) => {
+  history.push(routes.nullRoute())
+  history.replace(route, query)
+}


### PR DESCRIPTION
## Changes:
- "Save & New" appears in the trigger's form as a result of a `saveAndCreateNewEnabled` prop being passed to the `Actions` component;
- A `refreshRoute` method was added to `utils/index.js` so that when the user triggers an action that redirects him to the same route, that route's components are re-mounted.

![save new](https://user-images.githubusercontent.com/35154956/56350600-14faab80-61c3-11e9-8d57-16941c3b1e6a.gif)

[Link To Trello Card](https://trello.com/c/OclFmasg/1076-triggers-add-save-and-create-new-button-at-the-top)
