### PR TITLE
On ActiveRecord::DeleteRestrictionError return status code 422

### DIFF
--- a/backend/app/controllers/api/v1/pictures_controller.rb
+++ b/backend/app/controllers/api/v1/pictures_controller.rb
@@ -11,11 +11,28 @@ module Api
       def destroy
         @pictures = Picture.where(id: params[:ids])
         authorize @pictures
-        if @pictures.destroy_all
+        if destroy_all
           render json: { data: @pictures }
         else
           render_error
         end
+      end
+
+      private
+
+      def destroy_all
+        has_restriction_errors = false
+        @pictures.each do |picture|
+          picture.destroy!
+        rescue ActiveRecord::DeleteRestrictionError
+          has_restriction_errors = true
+        end
+        !has_restriction_errors
+      end
+
+      def render_error
+        errors = [{ title: "Cannot delete at least one record." }]
+        render json: { errors: errors }, status: :unprocessable_entity
       end
     end
   end

--- a/console-frontend/src/ext/recompose/enhance-list.js
+++ b/console-frontend/src/ext/recompose/enhance-list.js
@@ -120,8 +120,9 @@ const enhanceList = ({
     branch(({ recordsCount }) => recordsCount === 0, renderComponent(blankState)),
     withHandlers({
       deleteRecords: ({ enqueueSnackbar, selectedIds, fetchRecords, setSelectedIds, setIsSelectAll }) => async () => {
-        const { requestError } = await apiRequest(api.destroy, [{ ids: selectedIds }])
+        const { errors, requestError } = await apiRequest(api.destroy, [{ ids: selectedIds }])
         if (requestError) enqueueSnackbar(requestError, { variant: 'error' })
+        if (errors) enqueueSnackbar(errors.message, { variant: 'error' })
         await fetchRecords()
         setSelectedIds([])
         setIsSelectAll(false)


### PR DESCRIPTION
## Changes:
- The server responds with "Cannot delete record.", with status code 422 (Unprocessable Entity), if user tries to destroy a parent instance in N:1 or 1:1 associations (see [here](https://apidock.com/rails/ActiveRecord/DeleteRestrictionError) the raised exception). 

![delete422](https://user-images.githubusercontent.com/35154956/56362289-5c903000-61e1-11e9-97c8-1ddce55c0e72.gif)

[Link To Trello Card](https://trello.com/c/p42BE6Fr/1088-try-to-delete-a-picture-in-use-the-backend-returns-error-500)
