### PR TITLE
Fix outro dissappearing issue

### DIFF
--- a/plugiamo/src/app/index.js
+++ b/plugiamo/src/app/index.js
@@ -143,7 +143,15 @@ export const AppBase = compose(
       mixpanel.track('Clicked Outro Button', { hostname: location.hostname, value })
     },
   }),
-  withState('disappear', 'setDisappear', ({ disappear }) => !!disappear)
+  withState('disappear', 'setDisappear', false),
+  lifecycle({
+    componentDidUpdate(prevProps) {
+      const { launcherDisappear, setDisappear } = this.props
+      if (launcherDisappear !== prevProps.launcherDisappear) {
+        setDisappear(launcherDisappear)
+      }
+    },
+  })
 )(AppBaseTemplate)
 
 export default compose(

--- a/plugiamo/src/special/assessment/size-guide/index.js
+++ b/plugiamo/src/special/assessment/size-guide/index.js
@@ -29,7 +29,7 @@ const Plugin = ({
   pluginState,
   products,
   productsData,
-  disappear,
+  launcherDisappear,
 }) => (
   <AppBase
     Component={
@@ -49,9 +49,9 @@ const Plugin = ({
       />
     }
     data={module}
-    disappear={disappear}
     isUnmounting={isUnmounting}
     Launcher={showingLauncher && Launcher}
+    launcherDisappear={launcherDisappear}
     launcherPulsating={pluginState !== 'closed'}
     onToggleContent={onToggleContent}
     persona={module.launcher.persona}
@@ -71,7 +71,7 @@ export default compose(
   withState('showingContent', 'setShowingContent', ({ showingContent }) => showingContent),
   withState('showingLauncher', 'setShowingLauncher', true),
   withState('product', 'setProduct', null),
-  withState('disappear', 'setDisappear', false),
+  withState('launcherDisappear', 'setLauncherDisappear', false),
   lifecycle({
     componentDidMount() {
       const { setProduct } = this.props
@@ -110,12 +110,12 @@ export default compose(
       setIsUnmounting,
       setShowingContent,
       showingContent,
-      setDisappear,
-      disappear,
+      launcherDisappear,
+      setLauncherDisappear,
     }) => () => {
       if (module.flowType === 'outro') return
       if (pluginState === 'closed') {
-        !disappear && setTimeout(() => setDisappear(true), 22000)
+        !launcherDisappear && setTimeout(() => setLauncherDisappear(true), 22000)
         if (!showingContent) return
       }
       if (pluginState !== 'closed') {


### PR DESCRIPTION
### Changes
- Rename the `disappear` prop from parent component to `launcherDisappear` in order to change childs `disappear` state prop depending on whether the `launcherDisappear` was changed. That way we avoid changing the state by received props (which isn't possible because of React structure);