### PR TITLE
Add max-height to crop container

### DIFF
--- a/console-frontend/src/shared/pictures-modal.js
+++ b/console-frontend/src/shared/pictures-modal.js
@@ -106,7 +106,9 @@ const UrlIcon = styled(LinkIcon)`
   height: 24px;
 `
 
+// max-height: 253px = dialog's margin (96px) + dialog title height (76px) + dialog action height (81px)
 const DialogCroppingContainer = styled.div`
+  max-height: calc(100vh - 253px);
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Before:
![bug](https://user-images.githubusercontent.com/35154956/56498116-4099d080-64f8-11e9-95db-33d6296b8942.gif)

## After:
![fixed](https://user-images.githubusercontent.com/35154956/56498123-45f71b00-64f8-11e9-97bc-8b6692778c48.gif)

[Link To Trello Card](https://trello.com/c/u2UQQW6i/1079-picture-modal-make-it-so-we-never-have-to-scroll-the-area-where-the-picture-to-be-cropped-is)
