### PR TITLE
Fix image upload by url

### DIFF
--- a/console-frontend/src/shared/pictures-modal.js
+++ b/console-frontend/src/shared/pictures-modal.js
@@ -344,7 +344,8 @@ const PicturesModal = compose(
     onPictureClick: ({ setActivePicture }) => picture => {
       setActivePicture(picture)
     },
-    onUrlUploadClick: ({ setUrlUploadState }) => () => {
+    onUrlUploadClick: ({ setUrlUploadState, setPictureUrl }) => () => {
+      setPictureUrl('')
       setUrlUploadState(true)
     },
   }),


### PR DESCRIPTION
## Bug:
-  `pictureUrl` state was not being reseted to initial the value (empty string, `''`) when the `onUrlUploadClick` handler was triggered, causing the upload of the last url if no url was entered, as seen below.

![image-upload-bug](https://user-images.githubusercontent.com/35154956/56898750-bae2cb80-6a89-11e9-8d0e-2fed7892d37b.gif)

[Link To Trello Card](https://trello.com/c/fSRNPOI9/1123-bug-in-image-upload-by-url)
