### PR TITLE
Fix video modal mixpanel events

### DIFF
--- a/plugiamo/src/app/content/scripted-chat/components/cover/video-button.js
+++ b/plugiamo/src/app/content/scripted-chat/components/cover/video-button.js
@@ -35,30 +35,31 @@ const Text = styled.div`
   transition: all 0.4s ease-in-out;
 `
 
-const VideoButton = ({ video, youtubeEmbedUrl, onClick, setIsOpen, isOpen }) => (
+const VideoButton = ({ video, youtubeEmbedUrl, onClick, closeModal, isOpen }) => (
   <VideoButtonContainer backgroundColor={video.backgroundColor} onClick={onClick}>
     <Text color={video.textColor}>{video.text}</Text>
     {video.icon && <Icon color={video.textColor} />}
-    <VideoModal isOpen={isOpen} setIsOpen={setIsOpen} url={youtubeEmbedUrl} />
+    <VideoModal closeModal={closeModal} isOpen={isOpen} url={youtubeEmbedUrl} />
   </VideoButtonContainer>
 )
 
 export default compose(
   withState('isOpen', 'setIsOpen', false),
   withProps(({ video }) => ({
-    youtubeEmbedUrl: `https://www.youtube.com/embed/${extractYoutubeId(
-      video.url
-    )}?autoplay=1&amp;mute=0&amp;controls=1&amp;playsinline=0&amp;rel=0&amp;iv_load_policy=3&amp;modestbranding=1&amp;enablejsapi=1`,
+    youtubeId: extractYoutubeId(video.url),
+  })),
+  withProps(({ youtubeId }) => ({
+    youtubeEmbedUrl: `https://www.youtube.com/embed/${youtubeId}?autoplay=1&amp;mute=0&amp;controls=1&amp;playsinline=0&amp;rel=0&amp;iv_load_policy=3&amp;modestbranding=1&amp;enablejsapi=1`,
+    youtubeUrl: `https://www.youtube.com/watch?v=${youtubeId}`,
   })),
   withHandlers({
-    onClick: ({ setIsOpen, video }) => () => {
+    onClick: ({ setIsOpen, youtubeUrl }) => () => {
       setIsOpen(true)
-      mixpanel.track('Opened Assessment Header Video', {
-        hostname: location.hostname,
-        url: `https://www.youtube.com/embed/${extractYoutubeId(
-          video.url
-        )}?autoplay=1&amp;mute=0&amp;controls=1&amp;playsinline=0&amp;rel=0&amp;iv_load_policy=3&amp;modestbranding=1&amp;enablejsapi=1`,
-      })
+      mixpanel.track('Opened Assessment Header Video', { hostname: location.hostname, url: youtubeUrl })
+    },
+    closeModal: ({ setIsOpen, youtubeUrl }) => () => {
+      setIsOpen(false)
+      mixpanel.track('Closed Assessment Header Video', { hostname: location.hostname, url: youtubeUrl })
     },
   })
 )(VideoButton)

--- a/plugiamo/src/app/content/scripted-chat/components/message-types/video-message.js
+++ b/plugiamo/src/app/content/scripted-chat/components/message-types/video-message.js
@@ -28,18 +28,22 @@ const VideoMessage = compose(
       setIsOpen(true)
       mixpanel.track('Open Video', { hostname: location.hostname, url: youtubeUrl })
     },
+    closeModal: ({ setIsOpen, youtubeUrl }) => () => {
+      setIsOpen(false)
+      mixpanel.track('Closed Video', { hostname: location.hostname, url: youtubeUrl })
+    },
   }),
   withHandlers({
     onClick: ({ openModal }) => openModal,
     onKeyUp: ({ openModal }) => event => (event.key === 'Enter' ? openModal() : undefined),
   })
-)(styled(({ className, setIsOpen, isOpen, onClick, onKeyUp, youtubeEmbedUrl, youtubePreviewImageUrl }) => (
+)(styled(({ className, closeModal, isOpen, onClick, onKeyUp, youtubeEmbedUrl, youtubePreviewImageUrl }) => (
   <div className={className} onClick={onClick} onKeyUp={onKeyUp} role="button" tabIndex={0}>
     <img alt="" src={youtubePreviewImageUrl} style={{ maxWidth: '100%' }} />
     <IconContainer>
       <IconPlayButton />
     </IconContainer>
-    <VideoModal isOpen={isOpen} setIsOpen={setIsOpen} url={youtubeEmbedUrl} />
+    <VideoModal closeModal={closeModal} isOpen={isOpen} url={youtubeEmbedUrl} />
   </div>
 ))`
   cursor: pointer;

--- a/plugiamo/src/shared/video-modal.js
+++ b/plugiamo/src/shared/video-modal.js
@@ -1,4 +1,3 @@
-import mixpanel from 'ext/mixpanel'
 import Modal from './modal'
 import { compose, withHandlers } from 'recompose'
 import { h } from 'preact'
@@ -23,10 +22,9 @@ const VideoModal = ({ url, closeModal, isOpen }) => (
 
 export default compose(
   withHandlers({
-    closeModal: ({ setIsOpen, url }) => event => {
+    closeModal: ({ closeModal }) => event => {
       event.stopPropagation()
-      setIsOpen(false)
-      mixpanel.track('Closed Video', { hostname: location.hostname, url })
+      closeModal()
     },
   })
 )(VideoModal)


### PR DESCRIPTION
### Changes
- Mixpanel modal open/close events are both sent with `youtubeUrl`;
- Now, modals aren't handling  sending of mixpanel events and changing the state `isClosed`, they only receive a callback function;
- Mixpanel events are defined only in one place - modal's parent component.