### PR TITLE
Fix bug when creating new simple chat messages

### DIFF
--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
@@ -59,19 +59,18 @@ const SortableSimpleChatMessage = compose(
 
 const SimpleChatMessages = ({ allowDelete, simpleChatMessages, onChange, onFocus }) => (
   <div>
-    {simpleChatMessages
-      .filter(simpleChatMessage => !simpleChatMessage._destroy)
-      .map((simpleChatMessage, index) => (
-        <SortableSimpleChatMessage
-          allowDelete={allowDelete}
-          index={index}
-          key={simpleChatMessage.id || `simple-chat-message${index}`}
-          onChange={onChange}
-          onFocus={onFocus}
-          simpleChatMessage={simpleChatMessage}
-          simpleChatMessageIndex={index}
-        />
-      ))}
+    {simpleChatMessages.map((simpleChatMessage, index) => (
+      <SortableSimpleChatMessage
+        allowDelete={allowDelete}
+        disabled={simpleChatMessage._destroy}
+        index={index}
+        key={simpleChatMessage.id || `simple-chat-message${index}`}
+        onChange={onChange}
+        onFocus={onFocus}
+        simpleChatMessage={simpleChatMessage}
+        simpleChatMessageIndex={index}
+      />
+    ))}
   </div>
 )
 
@@ -196,10 +195,7 @@ export default compose(
       setAnchorEl(event.currentTarget)
     },
     onSimpleChatMessagesSortEnd: ({ onChange, simpleChatStepIndex, simpleChatStep }) => ({ oldIndex, newIndex }) => {
-      const filteredSimpleChatMessages = simpleChatStep.simpleChatMessagesAttributes.filter(
-        simpleChatMessage => !simpleChatMessage._destroy
-      )
-      const orderedSimpleChatMessages = arrayMove(filteredSimpleChatMessages, oldIndex, newIndex)
+      const orderedSimpleChatMessages = arrayMove(simpleChatStep.simpleChatMessagesAttributes, oldIndex, newIndex)
       onChange({ ...simpleChatStep, simpleChatMessagesAttributes: orderedSimpleChatMessages }, simpleChatStepIndex)
     },
     setSimpleChatMessagesForm: ({ simpleChatStep, simpleChatStepIndex, onChange }) => (


### PR DESCRIPTION
[Trello card](https://trello.com/c/jdXmIJtW)

## Changes

Fix bug in simple chat messages - when deleting a message in the form, then creating a new one and focusing on it, a new blank message was appearing. Also, when focusing on that new message, another new message was appearing.

The bug is related to the filtering methods implemented in #534 and #535. Remove those methods and add a `disable` props to not reorder the messages that have been deleted (https://github.com/clauderic/react-sortable-hoc#sortableelement-hoc).

## Preview

Previous behavior:

![preview](https://user-images.githubusercontent.com/24722181/57445493-6211f080-724a-11e9-9b32-e39c6755fe56.gif)