### PR TITLE
Fix showcase bug with back button

### DIFF
--- a/plugiamo/src/app/setup/flow-history.js
+++ b/plugiamo/src/app/setup/flow-history.js
@@ -43,7 +43,7 @@ export const markGoFwd = () => {
 export const shouldRenderBack = () => {
   try {
     const paths = JSON.parse(sessionStorage.getItem('trnd-history'))
-    return paths.length > 1
+    return paths.length > 1 && !paths[paths.length - 2].includes(paths[paths.length - 1])
   } catch (e) {
     return false
   }


### PR DESCRIPTION
[Trello card](https://trello.com/c/9KMnz5mx)

## Changes

In the plugin, the back button was shown in the root of the showcase when moving to an external website and going back to the previous one. This was caused by the fact that 2 urls were being stored in `sessionStorage` (e.g. `/showcase/3` and `/showcase/3/spotlight/7`), causing the button to render.

## Preview

![preview](https://user-images.githubusercontent.com/24722181/57630035-c9a2a580-7594-11e9-81e5-8210769d941a.gif)
