### PR TITLE
Fix empty image upload

### DIFF
--- a/console-frontend/src/app/resources/showcases/form/index.js
+++ b/console-frontend/src/app/resources/showcases/form/index.js
@@ -40,6 +40,11 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
         ...subform,
         picUrl: productPickPhotoUrl,
       }
+    } else {
+      return {
+        ...subform,
+        picUrl: '',
+      }
     }
   }, [])
 

--- a/console-frontend/src/app/resources/simple-chats/form/index.js
+++ b/console-frontend/src/app/resources/simple-chats/form/index.js
@@ -35,6 +35,11 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
         ...subform,
         picUrl: simpleChatMessagePicUrl,
       }
+    } else {
+      return {
+        ...subform,
+        picUrl: '',
+      }
     }
   }, [])
 


### PR DESCRIPTION
## Updates:
- The server now responds with a 422 unprocessable entity if an empty picture url is submitted. A snackbar shows the error message "Picture can't be blank", as you can see next 

![empty-images](https://user-images.githubusercontent.com/35154956/58024752-d2522900-7b0a-11e9-8ab0-62544d972463.gif)

[Link To Trello Card](https://trello.com/c/ZNXoZyrJ/1187-frontend-allows-to-upload-without-image-which-breaks-this-is-in-showcases-and-chat-product-messages-at-least)