### PR TITLE
Add default text message to new chat step

### DIFF
--- a/console-frontend/src/app/resources/simple-chats/form/index.js
+++ b/console-frontend/src/app/resources/simple-chats/form/index.js
@@ -94,7 +94,11 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
           ...form,
           simpleChatStepsAttributes: [
             ...form.simpleChatStepsAttributes,
-            { key: '', __key: `new-${form.simpleChatStepsAttributes.length}` },
+            {
+              key: '',
+              __key: `new-${form.simpleChatStepsAttributes.length}`,
+              simpleChatMessagesAttributes: [{ type: 'SimpleChatTextMessage', text: '', __key: 'new-0' }],
+            },
           ],
         }
       })

--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
@@ -185,16 +185,14 @@ const SimpleChatStep = ({
       onChange(
         {
           ...simpleChatStep,
-          simpleChatMessagesAttributes: simpleChatStep.simpleChatMessagesAttributes
-            ? [
-                ...simpleChatStep.simpleChatMessagesAttributes,
-                {
-                  ...simpleChatMessageObject,
-                  type: messageType,
-                  __key: `new-${simpleChatStep.simpleChatMessagesAttributes.length}`,
-                },
-              ]
-            : [{ ...simpleChatMessageObject, type: messageType, __key: 'new-0' }],
+          simpleChatMessagesAttributes: [
+            ...simpleChatStep.simpleChatMessagesAttributes,
+            {
+              ...simpleChatMessageObject,
+              type: messageType,
+              __key: `new-${simpleChatStep.simpleChatMessagesAttributes.length}`,
+            },
+          ],
         },
         simpleChatStepIndex
       )


### PR DESCRIPTION
## Update:
- A default blank text message appears when the user adds a new simple chat step.

## Before:
![before_fix_message](https://user-images.githubusercontent.com/35154956/58033920-4eee0300-7b1d-11e9-9cf6-3b2a864aa588.gif)

## After:

![after_fix_message](https://user-images.githubusercontent.com/35154956/58033924-50b7c680-7b1d-11e9-92b7-daadc6d66f54.gif)

[Link To Trello Card](https://trello.com/c/Ot0irg20/1183-chats-when-you-add-a-step-it-should-come-with-a-blank-message-by-default)