### PR TITLE
Fix url field of product message

### DIFF
--- a/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
+++ b/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
@@ -1,6 +1,7 @@
 import PictureUploader, { ProgressBar } from 'shared/picture-uploader'
 import React, { useCallback, useState } from 'react'
 import { Field } from 'shared/form-elements'
+import { FormHelperText } from '@material-ui/core'
 
 const ProductMessagesForm = ({
   isCropping,
@@ -34,8 +35,10 @@ const ProductMessagesForm = ({
       onChange={onFormChange}
       onFocus={onFocus}
       required
+      type="URL"
       value={simpleChatMessage.url || ''}
     />
+    <FormHelperText>{'Use the whole url, eg: https://www.example.com/page1'}</FormHelperText>
     <Field
       disabled={isCropping || isFormLoading}
       fullWidth


### PR DESCRIPTION
[Trello card](https://trello.com/c/5QE2HHHu)

## Changes

The url field in simple chat product messages was missing some kind of validation. Add a `type="URL"` and a helper text, as for product picks.

## Preview

![preview](https://user-images.githubusercontent.com/24722181/58093436-6c2adc00-7bc6-11e9-8305-83899214817a.gif)
