### PR TITLE
For Monday 27th: Add plugin presence A/B test

### DIFF
--- a/plugiamo/package.json
+++ b/plugiamo/package.json
@@ -19,6 +19,7 @@
     "preact-portal": "^1.1.3",
     "preact-router": "^2.6.1",
     "react-focus-lock": "^1.17.7",
+    "react-ga": "^2.5.7",
     "recompose": "^0.28.2",
     "snarkdown": "^1.2.2",
     "styled-components": "^3.4.10"

--- a/plugiamo/src/app/index.js
+++ b/plugiamo/src/app/index.js
@@ -28,6 +28,7 @@ import { timeout } from 'plugin-base'
 
 export default compose(
   branch(() => assessmentCart(), renderComponent(AssessmentCart)),
+  withState('isGAReady', 'setIsGAReady', false),
   withProps({ Component: <Router /> }),
   withProps({ Launcher }),
   withProps({ pathFromNav: setupFlowHistory() }),
@@ -82,9 +83,9 @@ export default compose(
   withState('isUnmounting', 'setIsUnmounting', false),
   withState('showingContent', 'setShowingContent', false),
   withState('showAssessmentContent', 'setShowAssessmentContent', false),
-  withState('showingLauncher', 'setShowingLauncher', true),
+  withState('showingLauncher', 'setShowingLauncher', false),
   withState('skipContentEntry', 'setSkipContentEntry', false),
-  withState('showingBubbles', 'setShowingBubbles', true),
+  withState('showingBubbles', 'setShowingBubbles', false),
   withState('disappear', 'setDisappear', false),
   lifecycle({
     componentDidMount() {
@@ -115,7 +116,22 @@ export default compose(
       mixpanel.time_event('Toggled Plugin')
     },
     componentDidUpdate(prevProps) {
-      const { showingContent, setSkipContentEntry, showAssessmentContent } = this.props
+      const {
+        showAssessmentContent,
+        showingContent,
+        isGAReady,
+        setShowingLauncher,
+        setShowingBubbles,
+        googleAnalytics,
+        setSkipContentEntry,
+      } = this.props
+      if (!prevProps.isGAReady && isGAReady) {
+        const variation = googleAnalytics.getVariation()
+        if (variation !== 'absent') {
+          setShowingLauncher(true)
+          setShowingBubbles(true)
+        }
+      }
       if (showAssessmentContent !== prevProps.showAssessmentContent && !showAssessmentContent) {
         setSkipContentEntry(true)
       }

--- a/plugiamo/src/config.js
+++ b/plugiamo/src/config.js
@@ -1,6 +1,9 @@
 const graphQlUrl = process.env.GRAPHQL_URL || '/graphql'
 const mixpanelToken = process.env.MIXPANEL_TOKEN
 const rollbarToken = process.env.ROLLBAR_TOKEN
+const GApropertyId = process.env.GA_PROPERTY_ID
+const GOcontainerId = process.env.GO_CONTAINER_ID
+const GOexperimentId = process.env.GO_EXPERIMENT_ID
 const production = process.env.NODE_ENV === 'production'
 const MAIN_BREAKPOINT = 600 // in pixels. From this width up, we're in large screen mode. Up to this width we're in small (fullscreen mode)
 const HEIGHT_BREAKPOINT = 300 // in pixels. From this height up, the plugin may be shown. Up to this height, the plugin is not shown.
@@ -39,6 +42,9 @@ export {
   WIDTH,
   bigLauncherConfig,
   smallLauncherConfig,
+  GApropertyId,
+  GOcontainerId,
+  GOexperimentId,
 }
 export default {
   graphQlUrl,
@@ -52,4 +58,7 @@ export default {
   WIDTH,
   bigLauncherConfig,
   smallLauncherConfig,
+  GApropertyId,
+  GOcontainerId,
+  GOexperimentId,
 }

--- a/plugiamo/src/data-gathering/index.js
+++ b/plugiamo/src/data-gathering/index.js
@@ -14,6 +14,6 @@ const dataGatheringFactory = {
 
 const dataGathering = dataGatheringFactory[window.location.hostname]
 
-const setupDataGathering = () => dataGathering && dataGathering.setupDataGathering()
+const setupDataGathering = googleAnalytics => dataGathering && dataGathering.setupDataGathering(googleAnalytics)
 
 export default setupDataGathering

--- a/plugiamo/src/data-gathering/pierre-cardin.js
+++ b/plugiamo/src/data-gathering/pierre-cardin.js
@@ -111,7 +111,7 @@ export default {
       },
     }
   },
-  setupDataGathering() {
+  setupDataGathering(googleAnalytics) {
     const _this = this
     if (location.pathname.match(/^\/checkout\/cart/)) {
       jQuery
@@ -119,6 +119,13 @@ export default {
         .on('click', 'button.action.primary.checkout', () => {
           const json = _this.checkoutObject()
           mixpanel.track(json.name, json.data)
+          googleAnalytics.event({
+            hitType: 'event',
+            eventCategory: 'Page Event',
+            eventAction: 'Click',
+            eventLabel: 'proceedToCheckout',
+            page: location.hostname,
+          })
         })
     } else if (jQuery.noConflict()('#product-addtocart-button')[0]) {
       jQuery

--- a/plugiamo/src/data-gathering/shopinfo.js
+++ b/plugiamo/src/data-gathering/shopinfo.js
@@ -87,7 +87,7 @@ export default {
       },
     }
   },
-  setupDataGathering() {
+  setupDataGathering(googleAnalytics) {
     const _this = this
     const saveData = resultsObj => {
       mixpanel.track(resultsObj.name, resultsObj.data)
@@ -98,6 +98,13 @@ export default {
         .on('click', location.pathname.match(/^\/checkout\//) ? '.btn-place-order' : '.cartCheckout', () => {
           const json = _this.checkoutObject(location.pathname.match(/^\/checkout\//) ? true : false)
           mixpanel.track(json.name, json.data)
+          googleAnalytics.event({
+            hitType: 'event',
+            eventCategory: 'Page Event',
+            eventAction: 'Click',
+            eventLabel: 'proceedToCheckout',
+            page: location.hostname,
+          })
         })
     } else if (location.pathname.match(/.*\/p$/)) {
       window.$(document).on('click', '.buy-together--add', () => {

--- a/plugiamo/src/ext/google-analytics.js
+++ b/plugiamo/src/ext/google-analytics.js
@@ -1,0 +1,68 @@
+import ReactGA from 'react-ga'
+import { GApropertyId, GOcontainerId, GOexperimentId } from 'config'
+
+const loadGA = contentDocument =>
+  new Promise((resolve, reject) => {
+    const script = contentDocument.createElement('script')
+    script.src = `https://www.google-analytics.com/cx/api.js?experiment=${GOexperimentId}`
+    script.async = true
+    script.onload = resolve
+    script.onerror = reject
+    contentDocument.body.appendChild(script)
+  })
+
+const frekklsGA = {
+  iframeRef: null,
+  initialized: false,
+  initGA() {
+    if (!GApropertyId) return Promise.resolve()
+    ReactGA.initialize(GApropertyId, {
+      optimize_id: GOcontainerId,
+      gaOptions: {
+        name: 'frekkls_tracker',
+        cookieDomain: 'auto',
+        cookieName: '_ga_frekkls',
+        storeGac: true,
+      },
+    })
+    this.initialized = true
+    this.pageView()
+  },
+  event(fieldsObject) {
+    if (!this.initialized) return
+    if (!(this.iframeRef && this.iframeRef.contentWindow.cxApi)) {
+      const GOvariationId = localStorage.getItem('trnd-exp-var')
+      GOvariationId && ReactGA.ga()('frekkls_tracker.set', 'exp', `${GOexperimentId}.${GOvariationId}`)
+    }
+    ReactGA.ga()('frekkls_tracker.send', fieldsObject)
+  },
+  initGO(iframeRef) {
+    this.iframeRef = iframeRef
+    if (!GOexperimentId || !GOcontainerId || !this.initialized) return Promise.resolve()
+    const _this = this
+    return loadGA(iframeRef.contentDocument).then(() => {
+      const GOvariationId = _this.iframeRef.contentWindow.cxApi.chooseVariation()
+      localStorage.setItem('trnd-exp-var', GOvariationId)
+      _this.iframeRef.contentWindow.cxApi.setChosenVariation(GOvariationId, GOexperimentId)
+      ReactGA.ga()('frekkls_tracker.set', 'exp', `${GOexperimentId}.${GOvariationId}`)
+    })
+  },
+  pageView() {
+    if (!this.initialized) return
+    this.event({
+      hitType: 'pageview',
+      eventCategory: 'Page',
+      eventAction: 'view',
+      eventLabel: 'Page view',
+      page: location.href,
+    })
+  },
+  getVariation() {
+    if (!this.initialized) return
+    const pluginPresence =
+      this.iframeRef.contentWindow.cxApi.getChosenVariation(GOexperimentId) === 1 ? 'absent' : 'present'
+    return pluginPresence
+  },
+}
+
+export default frekklsGA

--- a/plugiamo/src/index.js
+++ b/plugiamo/src/index.js
@@ -4,6 +4,7 @@ import bridgeData from 'special/bridge/data'
 import getFrekklsConfig from 'frekkls-config'
 import { matchUrl } from 'plugin-base'
 // import initRollbar from 'ext/rollbar'
+import googleAnalytics from 'ext/google-analytics'
 import mixpanel from 'ext/mixpanel'
 import setupDataGathering from 'data-gathering'
 import SpotAHome from 'special/spotahome'
@@ -37,7 +38,7 @@ const initRootComponent = () => {
 
   const RootComponent = () => (
     <Provider value={client}>
-      <App />
+      <App googleAnalytics={googleAnalytics} />
     </Provider>
   )
 
@@ -46,9 +47,13 @@ const initRootComponent = () => {
 
 const main = () => {
   // initRollbar()
+
+  const experimentClients = ['www.shopinfo.com.br', 'www.pierre-cardin.de']
+  experimentClients.includes(location.hostname) && googleAnalytics.initGA()
+
   mixpanel.init(mixpanelToken)
   mixpanel.track('Visited Page', { hostname: location.hostname })
-  setupDataGathering()
+  setupDataGathering(googleAnalytics)
 
   const browser = detect()
   const supportedBrowsers = ['chrome', 'firefox', 'safari', 'edge', 'opera', 'ios', 'ios-webview', 'crios', 'fxios']

--- a/plugiamo/yarn.lock
+++ b/plugiamo/yarn.lock
@@ -7069,6 +7069,11 @@ react-fuzzy@^0.5.2:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
+react-ga@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.5.7.tgz#1c80a289004bf84f84c26d46f3a6a6513081bf2e"
+  integrity sha512-UmATFaZpEQDO96KFjB5FRLcT6hFcwaxOmAJZnjrSiFN/msTqylq9G+z5Z8TYzN/dbamDTiWf92m6MnXXJkAivQ==
+
 react-html-attributes@^1.4.2:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.4.3.tgz#8c36c35fce6b750938d286af428ed1da7625186e"


### PR DESCRIPTION
## New A/B Test:
- Targets only www.pierre-cardin.de and www.shopinfo.com.br.
- The objective is to check the conversion rate **with** plugin and **without** plugin, through the "Proceed To Checkout" `/cart` page click event.
- To run the experiment 3 new environment variables need to be set: `GApropertyId `, `GOcontainerId `, `GOexperimentId`.

**Note**: In "/cart" pages that do not include the plugin, the google analytics `cxApi` isn't loaded. Without `cxApi` we're not able to get the variation related to our session. To solve this, on pages where the plugin is loaded, a `trnd-exp-var` variable is stored in localStorage containing the variation value. This implies that a user that **does not** visit a page that includes the plugin and triggers the `proceedToCheckout` event **will not** be accounted for the experiment.

[Link To Trello Card](https://trello.com/c/CZUW6UG1/1194-new-a-b-test-plugin-vs-no-plugin-only-in-some-clients)