### PR TITLE
Fix pagination

### DIFF
--- a/console-frontend/src/shared/table-elements/enhanced-list.js
+++ b/console-frontend/src/shared/table-elements/enhanced-list.js
@@ -85,6 +85,11 @@ const EnhancedList = ({
           ...state,
           isLoading: true,
         }
+      } else if (action.type === 'handleChangePage') {
+        return {
+          ...state,
+          page: parse(location.search).page - 1 || 0,
+        }
       } else if (action.type === 'completeFetch') {
         if (action.requestError) enqueueSnackbar(action.requestError, { variant: 'error' })
         if (action.requestError || action.errors) {
@@ -137,7 +142,7 @@ const EnhancedList = ({
       range: JSON.stringify([state.page * state.rowsPerPage, (state.page + 1) * state.rowsPerPage - 1]),
       sort: JSON.stringify([state.orderBy, state.orderDirection]),
     }),
-    [state.page, state.orderBy, state.orderDirection, state.rowsPerPage]
+    [state.page, state.rowsPerPage, state.orderBy, state.orderDirection]
   )
 
   const inactiveRows = state.records.map(record => {
@@ -165,6 +170,7 @@ const EnhancedList = ({
       const uri =
         Object.keys(newSearch).length === 0 ? location.pathname : `${location.pathname}?${stringify(newSearch)}`
       history.push(uri)
+      dispatch({ type: 'handleChangePage' })
     },
     [history, location.pathname, location.search]
   )


### PR DESCRIPTION
## Fix:
`state.page` was not being updated after changing the page. This would result in 
```
fetchRecords = useCallback(..., [api.fetch, cancelable, query])
```
not being called by:
```
useEffect(fetchRecords, [fetchRecords])
```

### Before fix:
![before_fix](https://user-images.githubusercontent.com/35154956/58194363-361c5380-7cbd-11e9-8c00-02da10c374bf.gif)



### After fix:
![after_fix](https://user-images.githubusercontent.com/35154956/58194373-3caacb00-7cbd-11e9-9ee1-58c89c6fe985.gif)

[Link To Trello Card](https://trello.com/c/kPYC0cUH/1203-pagination-apparently-not-working-needs-refresh)
