### PR TITLE
List and allow admins to create users in new section of account page

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  module V1
+    class UsersController < RestAdminController
+      def index
+        @users = policy_scope(User).where(account: current_tenant)
+        authorize @users
+        chain = sorting(pagination(@users))
+        render json: chain
+      end
+
+      def create
+        @user = User.new(user_params)
+        @user.account = current_tenant
+        authorize @user
+        if @user.save
+          render json: @user, status: :created
+        else
+          render_error
+        end
+      end
+
+      def destroy
+        @users = policy_scope(User).where(id: params[:ids])
+        authorize @users
+        if @users.destroy_all
+          render json: { data: @users }
+        else
+          render_error
+        end
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:email, :first_name, :last_name, :profile_pic_url, :role,
+                                     :password, :password_confirmation)
+      end
+
+      def render_error
+        errors = @user.errors.full_messages.map { |string| { title: string } }
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/backend/app/policies/user_policy.rb
+++ b/backend/app/policies/user_policy.rb
@@ -1,0 +1,23 @@
+class UserPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user&.editor? && !user&.admin
+        scope.none
+      else
+        scope
+      end
+    end
+  end
+
+  def index?
+    !user&.editor? || user&.admin
+  end
+
+  def create?
+    user&.admin
+  end
+
+  def destroy?
+    user&.admin
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -52,6 +52,8 @@ Rails.application.routes.draw do
         resources :triggers, only: %i[index show update create]
         post "/triggers/sort", to: "triggers#sort"
         delete "/triggers", to: "triggers#destroy"
+        resources :users, only: %i[index create]
+        delete "/users", to: "users#destroy"
         resources :flows, only: %i[index]
       end
     end

--- a/console-frontend/package.json
+++ b/console-frontend/package.json
@@ -16,6 +16,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.omit": "^4.5.0",
     "lodash.pickby": "^4.6.0",
+    "lodash.snakecase": "^4.1.1",
     "lodash.trim": "^4.5.1",
     "notistack": "^0.8.2",
     "plugin-base": "../plugin-base",

--- a/console-frontend/src/app/index.js
+++ b/console-frontend/src/app/index.js
@@ -27,6 +27,7 @@ import { SimpleChatCreate, SimpleChatEdit, SimpleChatsList } from './resources/s
 import { SnackbarProvider } from 'notistack'
 import { StoreProvider } from 'ext/hooks/store'
 import { TriggerCreate, TriggerEdit, TriggersList } from './resources/triggers'
+import { UserCreate } from 'app/screens/account/users'
 import { useSnackbar } from 'notistack'
 import 'assets/css/fonts.css'
 
@@ -98,6 +99,7 @@ const Routes = () => (
     <PrivateRoute component={TriggerCreate} exact isOwnerScoped path={routes.triggerCreate()} />
     <PrivateRoute component={TriggerEdit} exact isOwnerScoped path={routes.triggerEdit(':triggerId')} />
     <PrivateRoute component={Account} exact path={routes.account()} />
+    <PrivateRoute component={UserCreate} exact isOwnerScoped path={routes.userCreate()} />
     <PrivateRoute component={ChangePassword} exact isOwnerScoped path={routes.passwordChange()} />
     <PrivateRoute component={UrlGenerator} exact isOwnerScoped path={routes.urlGenerator()} />
     <PrivateRoute component={Admin} exact isOwnerScoped path={routes.admin()} />

--- a/console-frontend/src/app/layout/app-bar.js
+++ b/console-frontend/src/app/layout/app-bar.js
@@ -35,7 +35,7 @@ const OnboardingButton = withRouter(({ location }) => {
     [onboarding, setOnboarding]
   )
 
-  if (location.pathname !== onboarding.help.pathname) return null
+  if (location.pathname !== onboarding.help.pathname || !onboarding.help.stepName) return null
 
   return (
     <Hidden smDown>

--- a/console-frontend/src/app/resources/simple-chats/list.js
+++ b/console-frontend/src/app/resources/simple-chats/list.js
@@ -36,7 +36,7 @@ const SimpleChatsRow = ({ record, highlightInactive }) => (
 const api = { fetch: apiSimpleChatList, destroy: apiSimpleChatDestroy, duplicate: apiSimpleChatDuplicate }
 const simpleChatsRoutes = { create: routes.simpleChatCreate, edit: routes.simpleChatEdit }
 const highlightInactive = ['triggerIds']
-const canEditResource = resource => auth.getUser().role === 'editor' && resource.triggerIds.length > 0
+const canEditResource = resource => auth.getUser().role !== 'editor' || resource.triggerIds.length < 1
 
 const SimpleChatsList = () => (
   <EnhancedList

--- a/console-frontend/src/app/routes.js
+++ b/console-frontend/src/app/routes.js
@@ -74,6 +74,12 @@ const routes = {
   urlGenerator() {
     return '/url-generator'
   },
+  userCreate() {
+    return '/account/users/create'
+  },
+  userEdit(id) {
+    return `/account/users/${id}/edit`
+  },
   admin() {
     return '/admin'
   },

--- a/console-frontend/src/app/screens/account/edit-me.js
+++ b/console-frontend/src/app/screens/account/edit-me.js
@@ -5,6 +5,7 @@ import Link from 'shared/link'
 import PictureUploader, { ProgressBar, uploadPicture } from 'shared/picture-uploader'
 import React, { useCallback, useState } from 'react'
 import routes from 'app/routes'
+import Section from 'shared/section'
 import useForm from 'ext/hooks/use-form'
 import { apiMe, apiMeUpdate, apiRequest, atLeastOneNonBlankCharInputProps } from 'utils'
 import { Prompt } from 'react-router'
@@ -22,7 +23,7 @@ const formObjectTransformer = json => {
 
 const inputProps = { pattern: '.*S+.*' }
 
-const EditUser = () => {
+const EditMe = () => {
   const { enqueueSnackbar } = useSnackbar()
 
   const [isCropping, setIsCropping] = useState(false)
@@ -85,74 +86,74 @@ const EditUser = () => {
   if (isFormLoading) return <CircularProgress />
 
   return (
-    <form onSubmit={onFormSubmit}>
-      <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
-      <PictureUploader
-        circle
-        disabled={isCropping}
-        label="Picture"
-        onChange={setProfilePicUrl}
-        setDisabled={setIsCropping}
-        setPic={setProfilePic}
-        value={form.profilePicUrl}
-      />
-      <TextField
-        disabled
-        fullWidth
-        id="email"
-        inputProps={inputProps}
-        label="Email"
-        margin="normal"
-        required
-        value={form.email}
-      />
-      <TextField
-        disabled={isFormLoading || isCropping}
-        fullWidth
-        inputProps={atLeastOneNonBlankCharInputProps}
-        label="First Name"
-        margin="normal"
-        name="firstName"
-        onChange={setFieldValue}
-        required
-        value={form.firstName}
-      />
-      <TextField
-        disabled={isFormLoading || isCropping}
-        fullWidth
-        inputProps={atLeastOneNonBlankCharInputProps}
-        label="Last Name"
-        margin="normal"
-        name="lastName"
-        onChange={setFieldValue}
-        required
-        value={form.lastName}
-      />
-      {progress && <ProgressBar progress={progress} />}
-      <div style={{ marginTop: '1rem' }}>
-        <Button
-          color="primaryGradient"
-          disabled={isFormLoading || isCropping || isFormPristine || isFormSubmitting}
-          isFormPristine={isFormPristine}
-          isFormSubmitting={isFormSubmitting}
-          tooltipEnabled
-          tooltipPlacement="right"
-          tooltipText="No changes to save"
-          type="submit"
-          variant="contained"
-        >
-          {'Save'}
-        </Button>
-      </div>
-      <div style={{ marginTop: '1rem' }}>
-        <Link to={routes.passwordChange()}>
-          <Button color="primaryText" variant="text">
-            {'Change Password'}
+    <Section title="Your Personal Info">
+      <form onSubmit={onFormSubmit}>
+        <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
+        <PictureUploader
+          circle
+          disabled={isCropping}
+          label="Picture"
+          onChange={setProfilePicUrl}
+          setDisabled={setIsCropping}
+          setPic={setProfilePic}
+          value={form.profilePicUrl}
+        />
+        <TextField
+          disabled
+          fullWidth
+          id="email"
+          inputProps={inputProps}
+          label="Email"
+          margin="normal"
+          required
+          value={form.email}
+        />
+        <TextField
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          inputProps={atLeastOneNonBlankCharInputProps}
+          label="First Name"
+          margin="normal"
+          name="firstName"
+          onChange={setFieldValue}
+          required
+          value={form.firstName}
+        />
+        <TextField
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          inputProps={atLeastOneNonBlankCharInputProps}
+          label="Last Name"
+          margin="normal"
+          name="lastName"
+          onChange={setFieldValue}
+          required
+          value={form.lastName}
+        />
+        {progress && <ProgressBar progress={progress} />}
+        <div style={{ marginTop: '1rem' }}>
+          <Button
+            color="primaryGradient"
+            disabled={isFormLoading || isCropping || isFormPristine || isFormSubmitting}
+            isFormPristine={isFormPristine}
+            isFormSubmitting={isFormSubmitting}
+            tooltipEnabled
+            tooltipPlacement="right"
+            tooltipText="No changes to save"
+            type="submit"
+            variant="contained"
+          >
+            {'Save'}
           </Button>
-        </Link>
-      </div>
-    </form>
+          <Link to={routes.passwordChange()}>
+            <Button color="primaryText" variant="text">
+              {'Change Password'}
+            </Button>
+          </Link>
+        </div>
+      </form>
+    </Section>
   )
 }
 
-export default EditUser
+export default EditMe

--- a/console-frontend/src/app/screens/account/edit-website.js
+++ b/console-frontend/src/app/screens/account/edit-website.js
@@ -3,6 +3,7 @@ import Button from 'shared/button'
 import CircularProgress from 'shared/circular-progress'
 import HostnamesForm from 'shared/hostnames-form'
 import React, { useCallback, useMemo } from 'react'
+import Section from 'shared/section'
 import useForm from 'ext/hooks/use-form'
 import { apiRequest, apiWebsiteShow, apiWebsiteUpdate, atLeastOneNonBlankCharInputProps } from 'utils'
 import { Checkbox, FormControlLabel, TextField } from '@material-ui/core'
@@ -94,47 +95,49 @@ const EditWebsite = () => {
   if (isFormLoading) return <CircularProgress />
 
   return (
-    <form onSubmit={onFormSubmit}>
-      <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
-      <TextField
-        disabled
-        fullWidth
-        inputProps={atLeastOneNonBlankCharInputProps}
-        label="Name"
-        margin="normal"
-        name="name"
-        required
-        value={form.name}
-      />
-      <FormControlLabel
-        control={<Checkbox checked={!form.previewMode} color="primary" onChange={setPreviewMode} />}
-        disabled={isFormLoading}
-        label="Live"
-      />
-      <FormHelperText>{'Dangerous: this controls whether or not the plugin appears on your website.'}</FormHelperText>
-      <HostnamesForm
-        addHostnameSelect={addHostnameSelect}
-        deleteHostname={deleteHostname}
-        editHostnameValue={editHostnameValue}
-        form={form}
-        isFormLoading={isFormLoading}
-      />
-      <div style={{ marginTop: '1rem' }}>
-        <Button
-          color="primaryGradient"
-          disabled={isFormLoading || isFormPristine || isFormSubmitting}
-          isFormPristine={isFormPristine}
-          isFormSubmitting={isFormSubmitting}
-          tooltipEnabled
-          tooltipPlacement="right"
-          tooltipText="No changes to save"
-          type="submit"
-          variant="contained"
-        >
-          {'Save'}
-        </Button>
-      </div>
-    </form>
+    <Section title="Website">
+      <form onSubmit={onFormSubmit}>
+        <Prompt message="You have unsaved changes, are you sure you want to leave?" when={!isFormPristine} />
+        <TextField
+          disabled
+          fullWidth
+          inputProps={atLeastOneNonBlankCharInputProps}
+          label="Name"
+          margin="normal"
+          name="name"
+          required
+          value={form.name}
+        />
+        <FormControlLabel
+          control={<Checkbox checked={!form.previewMode} color="primary" onChange={setPreviewMode} />}
+          disabled={isFormLoading}
+          label="Live"
+        />
+        <FormHelperText>{'Dangerous: this controls whether or not the plugin appears on your website.'}</FormHelperText>
+        <HostnamesForm
+          addHostnameSelect={addHostnameSelect}
+          deleteHostname={deleteHostname}
+          editHostnameValue={editHostnameValue}
+          form={form}
+          isFormLoading={isFormLoading}
+        />
+        <div style={{ marginTop: '1rem' }}>
+          <Button
+            color="primaryGradient"
+            disabled={isFormLoading || isFormPristine || isFormSubmitting}
+            isFormPristine={isFormPristine}
+            isFormSubmitting={isFormSubmitting}
+            tooltipEnabled
+            tooltipPlacement="right"
+            tooltipText="No changes to save"
+            type="submit"
+            variant="contained"
+          >
+            {'Save'}
+          </Button>
+        </div>
+      </form>
+    </Section>
   )
 }
 

--- a/console-frontend/src/app/screens/account/index.js
+++ b/console-frontend/src/app/screens/account/index.js
@@ -1,26 +1,35 @@
+import AppBarButton from 'shared/app-bar-button'
 import auth from 'auth'
-import EditUser from './edit-user'
+import EditMe from './edit-me'
 import EditWebsite from './edit-website'
 import React from 'react'
-import Section from 'shared/section'
+import routes from 'app/routes'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
+import { Link } from 'react-router-dom'
+import { UsersList } from './users'
 
-const appBarContent = { title: 'Account' }
+const Actions = () => {
+  return auth.isAdmin() ? (
+    <AppBarButton color="primary" component={Link} to={routes.userCreate()} variant="contained">
+      {'Add User'}
+    </AppBarButton>
+  ) : null
+}
+
+const appBarContent = { Actions: <Actions />, title: 'Account' }
 
 const Account = () => {
   useAppBarContent(appBarContent)
+
   return (
     <>
       {(auth.isAdmin() || auth.getUser().role !== 'editor') && (
-        <Section title="Account">
+        <>
           <EditWebsite />
-        </Section>
+          <UsersList />
+        </>
       )}
-      {!auth.isAdmin() && (
-        <Section title="Your Personal Info">
-          <EditUser />
-        </Section>
-      )}
+      {!auth.isAdmin() && <EditMe />}
     </>
   )
 }

--- a/console-frontend/src/app/screens/account/users/create.js
+++ b/console-frontend/src/app/screens/account/users/create.js
@@ -1,0 +1,218 @@
+import CircularProgress from 'shared/circular-progress'
+import PictureUploader, { ProgressBar, uploadPicture } from 'shared/picture-uploader'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import routes from 'app/routes'
+import Section from 'shared/section'
+import useAppBarContent from 'ext/hooks/use-app-bar-content'
+import useForm from 'ext/hooks/use-form'
+import { Actions, Field, Form, Select } from 'shared/form-elements'
+import { apiRequest, apiUserCreate, atLeastOneNonBlankCharInputProps } from 'utils'
+import { useSnackbar } from 'notistack'
+import { withRouter } from 'react-router'
+
+const formObjectTransformer = json => {
+  return {
+    id: json.id,
+    profilePicUrl: json.profilePicUrl || '',
+    firstName: json.firstName || '',
+    lastName: json.lastName || '',
+    role: json.role || '',
+    email: json.email || '',
+    password: json.password || '',
+    passwordConfirmation: json.passwordConfirmation || '',
+    lockVersion: json.lockVersion,
+  }
+}
+
+const loadFormObject = () => {
+  return {
+    profilePicUrl: '',
+    firstName: '',
+    lastName: '',
+    role: '',
+    email: '',
+    password: '',
+    passwordConfirmation: '',
+  }
+}
+
+const passwordInputProps = { minLength: '6' }
+const roleOptions = ['Editor', 'Owner']
+
+const UserCreate = ({ history }) => {
+  const { enqueueSnackbar } = useSnackbar()
+
+  const formRef = useRef()
+  const [isCropping, setIsCropping] = useState(false)
+  const [profilePic, setProfilePic] = useState(null)
+  const [progress, setProgress] = useState(null)
+
+  const saveFormObject = useCallback(
+    async form => {
+      let data
+      if (profilePic) {
+        const profilePicUrl = await uploadPicture({
+          blob: profilePic,
+          setProgress,
+        })
+        data = { ...form, profilePicUrl }
+      } else {
+        data = form
+      }
+      if (data.password !== data.passwordConfirmation) {
+        enqueueSnackbar("Passwords don't match", { variant: 'error' })
+        return
+      }
+      const { json, errors, requestError } = await apiRequest(apiUserCreate, [{ user: data }])
+      if (requestError) enqueueSnackbar(requestError, { variant: 'error' })
+      if (errors) enqueueSnackbar(errors.message, { variant: 'error' })
+      if (!errors && !requestError) enqueueSnackbar('Successfully added user', { variant: 'success' })
+      setProfilePic(null)
+      return json
+    },
+    [enqueueSnackbar, profilePic]
+  )
+
+  const {
+    form,
+    isFormLoading,
+    isFormPristine,
+    isFormSubmitting,
+    mergeForm,
+    onFormSubmit,
+    setFieldValue,
+    setIsFormSubmitting,
+  } = useForm({
+    formObjectTransformer,
+    loadFormObject,
+    saveFormObject,
+  })
+
+  const newOnFormSubmit = useCallback(
+    event => {
+      return (async () => {
+        if (!formRef.current.reportValidity()) return
+        const result = await onFormSubmit(event)
+        setIsFormSubmitting(false)
+        if (!result || result.error || result.errors) return
+        history.push(routes.account())
+        return result
+      })()
+    },
+    [history, onFormSubmit, setIsFormSubmitting]
+  )
+
+  const setProfilePicUrl = useCallback(
+    profilePicUrl => {
+      mergeForm({ profilePicUrl })
+    },
+    [mergeForm]
+  )
+
+  const appBarContent = useMemo(
+    () => ({
+      Actions: (
+        <Actions
+          isFormPristine={isFormPristine}
+          isFormSubmitting={isFormSubmitting}
+          onFormSubmit={newOnFormSubmit}
+          saveDisabled={isFormSubmitting || isFormLoading || isCropping || isFormPristine}
+        />
+      ),
+      backRoute: routes.account(),
+      title: 'Add User',
+    }),
+    [isCropping, isFormLoading, isFormPristine, isFormSubmitting, newOnFormSubmit]
+  )
+  useAppBarContent(appBarContent)
+
+  if (isFormLoading) return <CircularProgress />
+
+  return (
+    <Section title="Add User">
+      <Form formRef={formRef} isFormPristine={isFormPristine} onSubmit={newOnFormSubmit}>
+        <PictureUploader
+          circle
+          disabled={isFormLoading || isCropping}
+          label="Picture"
+          onChange={setProfilePicUrl}
+          setDisabled={setIsCropping}
+          setPic={setProfilePic}
+          value={form.profilePicUrl}
+        />
+        {progress && <ProgressBar progress={progress} />}
+        <Field
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          inputProps={atLeastOneNonBlankCharInputProps}
+          label="First Name"
+          margin="normal"
+          name="firstName"
+          onChange={setFieldValue}
+          required
+          type="text"
+          value={form.firstName}
+        />
+        <Field
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          inputProps={atLeastOneNonBlankCharInputProps}
+          label="Last Name"
+          margin="normal"
+          name="lastName"
+          onChange={setFieldValue}
+          required
+          type="text"
+          value={form.lastName}
+        />
+        <Select
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          label="Role"
+          margin="normal"
+          name="role"
+          onChange={setFieldValue}
+          options={roleOptions}
+          required
+          value={form.role}
+        />
+        <Field
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          label="Email"
+          margin="normal"
+          name="email"
+          onChange={setFieldValue}
+          required
+          type="email"
+          value={form.email}
+        />
+        <Field
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          inputProps={passwordInputProps}
+          label="Password"
+          margin="normal"
+          name="password"
+          onChange={setFieldValue}
+          required
+          type="password"
+          value={form.password}
+        />
+        <Field
+          disabled={isFormLoading || isCropping}
+          fullWidth
+          label="Password Confirmation"
+          margin="normal"
+          name="passwordConfirmation"
+          onChange={setFieldValue}
+          required
+          type="password"
+          value={form.passwordConfirmation}
+        />
+      </Form>
+    </Section>
+  )
+}
+
+export default withRouter(UserCreate)

--- a/console-frontend/src/app/screens/account/users/index.js
+++ b/console-frontend/src/app/screens/account/users/index.js
@@ -1,0 +1,4 @@
+import UserCreate from './create'
+import UsersList from './list'
+
+export { UserCreate, UsersList }

--- a/console-frontend/src/app/screens/account/users/list.js
+++ b/console-frontend/src/app/screens/account/users/list.js
@@ -1,0 +1,67 @@
+import auth from 'auth'
+import React, { useMemo } from 'react'
+import routes from 'app/routes'
+import Section from 'shared/section'
+import styled from 'styled-components'
+import { apiUserDestroy, apiUserList } from 'utils'
+import { Avatar, EnhancedList, TableCell } from 'shared/table-elements'
+import { Typography } from '@material-ui/core'
+
+const StyledAvatar = styled(Avatar)`
+  display: flex;
+  font-size: 1rem;
+  margin-right: 0.5rem;
+`
+
+const columns = [
+  { name: 'avatar' },
+  { name: 'firstName', label: 'name', sortable: true },
+  { name: 'email', label: 'email', sortable: true },
+  { name: 'role', label: 'role', sortable: true },
+]
+
+const BlankState = () => (
+  <Section title="Users">
+    <Typography variant="body1">{'There are no users yet in this account.'}</Typography>
+  </Section>
+)
+
+const UsersRow = ({ record: { email, firstName, lastName, profilePicUrl, role } }) => {
+  const initials = useMemo(() => (!firstName || !lastName ? null : `${firstName[0]}${lastName[0]}`), [
+    firstName,
+    lastName,
+  ])
+
+  return (
+    <>
+      <TableCell>
+        <StyledAvatar src={profilePicUrl}>{profilePicUrl ? null : initials ? initials : ''}</StyledAvatar>
+      </TableCell>
+      <TableCell width="40%">
+        {firstName} {lastName}
+      </TableCell>
+      <TableCell width="40%">{email}</TableCell>
+      <TableCell width="20%">{role.charAt(0).toUpperCase() + role.slice(1)}</TableCell>
+    </>
+  )
+}
+
+const api = { fetch: apiUserList, destroy: apiUserDestroy }
+const canEditResource = () => auth.isAdmin()
+const defaultSorting = { column: 'role', direction: 'asc' }
+const usersRoutes = { create: routes.userCreate }
+
+const UsersList = () => (
+  <EnhancedList
+    api={api}
+    BlankState={BlankState}
+    canEditResource={canEditResource}
+    columns={columns}
+    defaultSorting={defaultSorting}
+    ResourceRow={UsersRow}
+    routes={usersRoutes}
+    title="Users"
+  />
+)
+
+export default UsersList

--- a/console-frontend/src/shared/form-elements/index.js
+++ b/console-frontend/src/shared/form-elements/index.js
@@ -12,6 +12,7 @@ import Header from './header'
 import InlineTypography from './inline-typography'
 import Prompt from './prompt'
 import SaveButton from './save-button'
+import Select from './select'
 
 export {
   Actions,
@@ -28,4 +29,5 @@ export {
   Prompt,
   SaveButton,
   Field,
+  Select,
 }

--- a/console-frontend/src/shared/form-elements/select.js
+++ b/console-frontend/src/shared/form-elements/select.js
@@ -1,0 +1,49 @@
+import React, { memo, useCallback, useState } from 'react'
+import snakeCase from 'lodash.snakecase'
+import styled from 'styled-components'
+import { FormControl, InputLabel, MenuItem, Select as MuiSelect } from '@material-ui/core'
+
+const StyledSelect = styled(MuiSelect)`
+  div[role='button']:focus {
+    background: transparent;
+  }
+`
+
+const Select = ({ fullWidth, label, margin, onChange, onClose, onOpen, options, required, value, ...props }) => {
+  const [open, setOpen] = useState(false)
+
+  const handleOpen = useCallback(
+    () => {
+      setOpen(true)
+      onOpen && onOpen()
+    },
+    [onOpen]
+  )
+
+  const handleClose = useCallback(
+    () => {
+      setOpen(false)
+      onClose && onClose()
+    },
+    [onClose]
+  )
+
+  return (
+    <FormControl fullWidth={fullWidth} margin={margin} required={required}>
+      <InputLabel required={required} shrink={open || !!value}>
+        {label}
+      </InputLabel>
+      <StyledSelect onChange={onChange} onClose={handleClose} onOpen={handleOpen} open={open} value={value} {...props}>
+        {options.map(option => {
+          return (
+            <MenuItem key={snakeCase(option)} value={snakeCase(option)}>
+              {option}
+            </MenuItem>
+          )
+        })}
+      </StyledSelect>
+    </FormControl>
+  )
+}
+
+export default memo(Select)

--- a/console-frontend/src/shared/table-elements/enhanced-list.js
+++ b/console-frontend/src/shared/table-elements/enhanced-list.js
@@ -59,14 +59,20 @@ const EnhancedList = ({
       } else if (action.type === 'setSelectedIds') {
         return {
           ...state,
-          isSelectAll: action.selectedIds.length === state.records.length,
+          isSelectAll:
+            action.selectedIds.length ===
+            state.records.filter(resource => (canEditResource ? canEditResource(resource) : true)).length,
           selectedIds: action.selectedIds,
         }
       } else if (action.type === 'handleSelectAll') {
         return {
           ...state,
           isSelectAll: !state.isSelectAll,
-          selectedIds: action.checked ? state.records.map(resource => resource.id) : [],
+          selectedIds: action.checked
+            ? state.records
+                .filter(resource => (canEditResource ? canEditResource(resource) : true))
+                .map(resource => resource.id)
+            : [],
         }
       } else if (action.type === 'setLoading') {
         return {
@@ -203,7 +209,7 @@ const EnhancedList = ({
 
   if (state.isLoading) return <CircularProgress />
 
-  if (state.recordsCount === 0) return <BlankState />
+  if (state.recordsCount === 0) return BlankState ? <BlankState /> : null
 
   return (
     <Section>
@@ -223,6 +229,7 @@ const EnhancedList = ({
                 checked={state.isSelectAll}
                 checkedIcon={<CheckBoxIcon />}
                 color="primary"
+                disabled={canEditResource && state.records.every(record => !canEditResource(record))}
                 onClick={handleSelectAll}
               />
             </TableCell>

--- a/console-frontend/src/shared/table-elements/table-row.js
+++ b/console-frontend/src/shared/table-elements/table-row.js
@@ -56,23 +56,19 @@ const TableRow = ({
           checked={selectedIds.includes(resource.id)}
           checkedIcon={<CheckBoxIcon />}
           color="primary"
-          disabled={canEditResource && canEditResource(resource)}
+          disabled={canEditResource && !canEditResource(resource)}
           onChange={handleSelect}
         />
       </TableCell>
       {React.cloneElement(children, { highlightInactive })}
-      <TableCell
-        style={{
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <TableCell style={{ whiteSpace: 'nowrap' }}>
         {resourceEditPath && (
-          <Button component={Link} disabled={canEditResource && canEditResource(resource)} to={resourceEditPath}>
+          <Button component={Link} disabled={canEditResource && !canEditResource(resource)} to={resourceEditPath}>
             <EditIcon />
           </Button>
         )}
         {api.duplicate && (
-          <Button onClick={duplicateResource}>
+          <Button disabled={canEditResource && !canEditResource(resource)} onClick={duplicateResource}>
             <CopyIcon />
           </Button>
         )}

--- a/console-frontend/src/shared/table-elements/table-toolbar.js
+++ b/console-frontend/src/shared/table-elements/table-toolbar.js
@@ -6,6 +6,7 @@ import { Toolbar as MuiToolbar, Typography } from '@material-ui/core'
 const SimpleToolbar = styled(MuiToolbar)`
   display: flex;
   justify-content: space-between;
+  padding: 0;
 `
 
 const Title = styled.div`

--- a/console-frontend/src/utils/auth-requests.js
+++ b/console-frontend/src/utils/auth-requests.js
@@ -19,6 +19,7 @@ const ONBOARDING_URL = `${BASE_API_URL}/users/onboarding`
 const GENERATED_URLS_URL = `${BASE_API_URL}/generated_urls`
 const PATH_URL = `${BASE_API_URL}/path`
 const ACCOUNTS_URL = `${BASE_API_URL}/accounts`
+const USERS_URL = `${BASE_API_URL}/users`
 const CORS_PROXY_URL = `${BASE_API_URL}/cors_proxy`
 
 const filterBody = body => omitDeep(body, key => key.startsWith('__'))
@@ -160,3 +161,7 @@ export const apiPathAutocomplete = query => apiGetRequest(`${PATH_URL}/autocompl
 export const apiAccountList = query => apiGetRequest(`${ACCOUNTS_URL}/?${stringify(query)}`)
 export const apiAccountCreate = body => apiCreateRequest(ACCOUNTS_URL, body)
 export const apiAccountDestroy = id => apiDestroyRequest(`${ACCOUNTS_URL}/${id}`)
+
+export const apiUserList = query => apiListRequest(`${USERS_URL}/?${stringify(query)}`)
+export const apiUserCreate = body => apiCreateRequest(USERS_URL, body)
+export const apiUserDestroy = body => apiDestroyMultipleRequest(USERS_URL, body)

--- a/console-frontend/src/utils/index.js
+++ b/console-frontend/src/utils/index.js
@@ -47,6 +47,9 @@ import {
   apiTriggerShow,
   apiTriggerSort,
   apiTriggerUpdate,
+  apiUserCreate,
+  apiUserDestroy,
+  apiUserList,
   apiWebsiteShow,
   apiWebsiteUpdate,
 } from './auth-requests'
@@ -101,6 +104,9 @@ export {
   apiTriggerSort,
   apiGeneratedUrlCreate,
   apiGeneratedUrlList,
+  apiUserCreate,
+  apiUserDestroy,
+  apiUserList,
   apiWebsiteShow,
   apiWebsiteUpdate,
 }


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/Vz9Wi4sv)

## Changes

- Add new `users_controller` with `#index`, `#create`, and `#destroy` actions
- Users are now listed in a new paper section of `/account` (only for owners and admins). An admin is also able to delete users from the list
- An admin can see an 'Add User' button in the app bar of `/account`, linking to a new page where he can create a new user for the current account
- Small changes: 
    - Add `Select` component to manage the selection of a role in `UserCreate`
    - Fix logic of `canEditResource` in `EnhancedList`  (was the other way round)
    - Update `handleSelectAll` action in `EnhancedList` to select only the records that can be edited
