### PR TITLE
Fix bug in simple chat picture messages

### DIFF
--- a/plugin-base/src/simple-chat/components/message-types/picture-message.js
+++ b/plugin-base/src/simple-chat/components/message-types/picture-message.js
@@ -26,8 +26,8 @@ export default compose(
     url: picUrl && imgixUrl(picUrl, { fit: 'crop', w: 260, h: 260 }),
   })),
   withHandlers({
-    onPictureClick: ({ onClick, url }) => () => {
-      onClick({ type: 'clickPictureMessage', item: { url } })
+    onPictureClick: ({ onClick, picUrl }) => () => {
+      onClick({ type: 'clickPictureMessage', item: { url: picUrl } })
     },
   })
 )(PictureMessage)


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/IN2gNdW2)

## Changes

Fix bug in simple chat picture messages: when you clicking on the picture and opening the modal, the picture is now displayed with the highest resolution available, without applying any crop.