### PR TITLE
Fix preview animations

### DIFF
--- a/plugin-base/src/simple-chat/components/chat-log-section.js
+++ b/plugin-base/src/simple-chat/components/chat-log-section.js
@@ -21,6 +21,7 @@ const Container = styled.div`
 const ChatLogSection = compose(
   withState('hide', 'setHide', false),
   withState('animate', 'setAnimate', false),
+  withState('doneAnimation', 'setDoneAnimation', false),
   withHandlers({
     onClick: ({ onClick, assessmentOptions, setHide, setHideAll }) => ({ type, item }) => {
       if (type === 'assessmentOption') {
@@ -62,27 +63,43 @@ const ChatLogSection = compose(
       timeout.clear('chatLogSectionAnimate')
     },
   })
-)(({ animate, containerRef, clickActionsExist, logSection, hide, hideAll, onClick, nothingSelected }) => (
-  <Container ref={containerRef}>
-    {logSection.logs.map((log, index) =>
-      log.type === 'message' ? (
-        /* eslint-disable react/no-array-index-key */
-        <ChatMessage
-          clickActionsExist={clickActionsExist}
-          hideAll={hideAll}
-          index={index}
-          key={index}
-          log={log}
-          nothingSelected={nothingSelected}
-          onClick={onClick}
-        />
-      ) : log.type === 'option' ? (
-        /* eslint-disable react/no-array-index-key */
-        <ChatOption animate={animate} chatOption={log} hide={hide} index={index} key={index} onClick={onClick} />
-      ) : null
-    )}
-  </Container>
-))
+)(
+  ({
+    animate,
+    containerRef,
+    clickActionsExist,
+    logSection,
+    hide,
+    hideAll,
+    onClick,
+    nothingSelected,
+    doneAnimation,
+    setDoneAnimation,
+  }) => (
+    <Container ref={containerRef}>
+      {logSection.logs.map((log, index) =>
+        log.type === 'message' ? (
+          /* eslint-disable react/no-array-index-key */
+          <ChatMessage
+            clickActionsExist={clickActionsExist}
+            doneAnimation={doneAnimation}
+            hideAll={hideAll}
+            index={index}
+            isLastMessage={index === logSection.logs.length - 1}
+            key={index}
+            log={log}
+            nothingSelected={nothingSelected}
+            onClick={onClick}
+            setDoneAnimation={setDoneAnimation}
+          />
+        ) : log.type === 'option' ? (
+          /* eslint-disable react/no-array-index-key */
+          <ChatOption animate={animate} chatOption={log} hide={hide} index={index} key={index} onClick={onClick} />
+        ) : null
+      )}
+    </Container>
+  )
+)
 
 const ChatLogSection1 = props => {
   const containerRef = useRef()

--- a/plugin-base/src/simple-chat/components/message.js
+++ b/plugin-base/src/simple-chat/components/message.js
@@ -107,11 +107,15 @@ const ChatMessage = compose(
   }),
   lifecycle({
     componentDidMount() {
-      const { setShow, index, setClickable } = this.props
-      const delay = index * MESSAGE_INTERVAL + Math.floor(Math.random() + MESSAGE_RANDOMIZER)
+      const { setShow, index, setClickable, isLastMessage, doneAnimation, setDoneAnimation } = this.props
+      const delay = doneAnimation ? 100 : index * MESSAGE_INTERVAL + Math.floor(Math.random() + MESSAGE_RANDOMIZER)
       timeout.set(
         'messageAnimation',
-        () => setShow(true) || timeout.set('messageAnimation', () => setClickable(true), 300),
+        () => {
+          setShow(true)
+          isLastMessage && setDoneAnimation(true)
+          timeout.set('messageAnimation', () => setClickable(true), 300)
+        },
         delay
       )
     },


### PR DESCRIPTION
### Bug description
When we created or added a new message in a chat preview, it would still have a delay equal to the length of all the messages in the log section where this messages was added.
### Changes
- If the message is last in log section and after it finishes its animation it sets the `skipAnimation` to false in order to allow newly created messages to be animated without the previously mentioned delay.