### PR TITLE
Temporary fix for cached plugin queries

### DIFF
--- a/backend/app/graphql/types/simple_chat_message_type.rb
+++ b/backend/app/graphql/types/simple_chat_message_type.rb
@@ -10,6 +10,11 @@ Types::SimpleChatMessageType = GraphQL::ObjectType.define do
       obj.pic_url if %w[SimpleChatPictureMessage SimpleChatProductMessage].include?(obj.class.name)
     }
   end
+  field :picture, Types::PicType do
+    resolve ->(obj, _args, _ctx) {
+      { url: obj.pic_url } if %w[SimpleChatPictureMessage SimpleChatProductMessage].include?(obj.class.name)
+    }
+  end
   field :url, types.String
   field :displayPrice, types.String do
     resolve ->(obj, _args, _ctx) {


### PR DESCRIPTION
### Changes
- As the plugin is cached for 10 minutes after each deploy, we should still support old GraphQL requests which is achieved by the changes in this PR.