### PR TITLE
Implement pampling case

### DIFF
--- a/plugiamo/src/app/setup/index.js
+++ b/plugiamo/src/app/setup/index.js
@@ -5,18 +5,21 @@ import { location } from 'config'
 import { pushPath } from './flow-history'
 import { routes } from 'plugin-base'
 
+export const resolveHash = () => {
+  const result = {}
+  if (!location.hash) return result
+  const match = /trnd:([^&]+)/.exec(location.hash)
+  if (!match) return result
+  match[1].split(',').forEach(pairStr => {
+    const matches = /(.+):(.+)/.exec(pairStr)
+    result[matches[1]] = matches[2]
+  })
+  return result
+}
+
 export const optionsFromHash = () => {
-  if (!window.__trendiamoOptionsFromHash) {
-    const result = {}
-    if (!location.hash) return result
-    const match = /trnd:([^&]+)/.exec(location.hash)
-    if (!match) return result
-    match[1].split(',').forEach(pairStr => {
-      const matches = /(.+):(.+)/.exec(pairStr)
-      result[matches[1]] = matches[2]
-    })
-    window.__trendiamoOptionsFromHash = result
-  }
+  const result = resolveHash()
+  window.__trendiamoOptionsFromHash = getFrekklsConfig().processOptions(result)
   return window.__trendiamoOptionsFromHash
 }
 

--- a/plugiamo/src/frekkls-config/index.js
+++ b/plugiamo/src/frekkls-config/index.js
@@ -4,6 +4,7 @@ import corinthiansConfig from './corinthians'
 import eoticaConfig from './eotica'
 import frekklsDemoConfig from './frekkls-demo'
 import impressoraJatoConfig from './impressora-jato'
+import pampling from './pampling'
 import pierreCardinConfig from './pierre-cardin'
 import pionierConfig from './pionier'
 import rihappyConfig from './rihappy'
@@ -19,6 +20,7 @@ const defaultConfig = {
   onCtaClick: () => null, // action => null,
   onChatStop: () => null,
   processChatOptions: chatOptions => chatOptions,
+  processOptions: options => options,
   i18n: {
     backButton: 'Back',
     productsSelectedBy: firstName => `Products selected by ${firstName}`,
@@ -45,6 +47,7 @@ const getFrekklsConfig = () => {
   if (location.hostname === 'www.eotica.com.br') return eoticaConfig
   if (location.hostname === 'www.rihappy.com.br') return rihappyConfig
   if (location.hostname === 'villadonatello.com') return villaDonatelloConfig
+  if (location.hostname === 'www.pampling.com') return pampling
   return {}
 }
 

--- a/plugiamo/src/frekkls-config/pampling.js
+++ b/plugiamo/src/frekkls-config/pampling.js
@@ -1,0 +1,30 @@
+const moduleMatchers = [
+  { personaId: '211', homepagePath: '/simple-chat/288', productsPath: '/simple-chat/287' },
+  { personaId: '223', homepagePath: '/simple-chat/295', productsPath: '/simple-chat/292' },
+  { personaId: '222', homepagePath: '/simple-chat/297', productsPath: '/simple-chat/291' },
+]
+
+const isProductPage = () => {
+  return location.pathname.match(/\/product?.*/)
+}
+
+export default {
+  processOptions: options => {
+    const { persona, path } = options
+    if (persona && path) {
+      localStorage.setItem('trnd-pampling', JSON.stringify({ path, persona }))
+    }
+    const pamplingStorageItem = localStorage.getItem('trnd-pampling')
+    if (!pamplingStorageItem) return options
+    const pamplingObject = JSON.parse(pamplingStorageItem)
+    if (!pamplingObject) return options
+    const currentModuleMatcher = moduleMatchers.find(item => item.personaId === pamplingObject.persona)
+    if (!currentModuleMatcher) return options
+    const currentPath =
+      location.pathname === '/'
+        ? currentModuleMatcher.homepagePath
+        : isProductPage() && currentModuleMatcher.productsPath
+    if (!currentPath) return options
+    return { path: currentPath, persona: currentModuleMatcher.personaId }
+  },
+}


### PR DESCRIPTION
### Changes
- Made it so that in pampling there's a specific functionality which follows the rules described below:
### Rules to be implemented on www.pampling.com
- If a user enters from some external link that has persona and plugin path in it and he goes to homepage or product page, he should see the plugin with the same persona, but a module should be different depending on the type of a page he is on (e.g: if it's PDP we show that persona's chat related to products).