### PR TITLE
Add loader for fullscreen picture, carousel, and video

### DIFF
--- a/plugiamo/src/icons/loader.svg
+++ b/plugiamo/src/icons/loader.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+  <g transform="rotate(0 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.9166666666666666s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(30 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.8333333333333334s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(60 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.75s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(90 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.6666666666666666s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(120 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.5833333333333334s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(150 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.5s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(180 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.4166666666666667s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(210 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.3333333333333333s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(240 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.25s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(270 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.16666666666666666s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(300 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.08333333333333333s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+  <g transform="rotate(330 50 50)">
+    <rect x="47" y="24" rx="9.4" ry="4.8" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="0s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+</svg>

--- a/plugiamo/src/shared/carousel-modal-arrows.js
+++ b/plugiamo/src/shared/carousel-modal-arrows.js
@@ -52,7 +52,7 @@ const CarouselModalArrows = ({ selectedImageIndex, onLeftArrowClick, onRightArro
     >
       <RightArrowIcon
         style={{
-          display: 0 < selectedImageIndex < urlsArray.length - 1 ? 'block' : 'none',
+          display: selectedImageIndex < urlsArray.length - 1 ? 'block' : 'none',
           fill: '#fff',
           width: '42px',
           height: '42px',

--- a/plugiamo/src/shared/images-modal.js
+++ b/plugiamo/src/shared/images-modal.js
@@ -32,9 +32,11 @@ const ImagesModalTemplate = ({
   selectedImage,
   onTouchEnd,
   isTouch,
+  isPictureLoaded,
+  onPictureLoad,
 }) => (
   <div>
-    <Modal allowBackgroundClose={false} closeModal={closeModal} isOpen={isOpen}>
+    <Modal allowBackgroundClose={false} closeModal={closeModal} isOpen={isOpen} isResourceLoaded={isPictureLoaded}>
       {!isTouch && (
         <CarouselModalArrows
           onLeftArrowClick={onLeftArrowClick}
@@ -59,8 +61,10 @@ const ImagesModalTemplate = ({
       >
         <img
           alt=""
+          onLoad={onPictureLoad}
           src={selectedImage}
           style={{
+            opacity: isPictureLoaded ? 1 : 0,
             width: '100%',
             height: '100%',
             objectFit: 'contain',
@@ -76,6 +80,7 @@ const ImagesModal = compose(
   withState('selectedImage', 'setSelectedImage', null),
   withState('selectedImageIndex', 'setSelectedImageIndex', 0),
   withState('originalWindowWidth', 'setOriginalWindowWidth', window.innerWidth),
+  withState('isPictureLoaded', 'setIsPictureLoaded', false),
   lifecycle({
     componentDidUpdate(prevProps) {
       const { setSelectedImageIndex, index, isOpen } = this.props
@@ -99,8 +104,19 @@ const ImagesModal = compose(
       })
       setIsOpen(false)
     },
-    onLeftArrowClick: ({ selectedImageIndex, urlsArray, setSelectedImageIndex, selectedImage, flowType }) => () => {
+    onPictureLoad: ({ setIsPictureLoaded }) => () => {
+      setIsPictureLoaded(true)
+    },
+    onLeftArrowClick: ({
+      selectedImageIndex,
+      urlsArray,
+      setSelectedImageIndex,
+      selectedImage,
+      flowType,
+      setIsPictureLoaded,
+    }) => () => {
       if (selectedImageIndex === 0) return
+      setIsPictureLoaded(false)
       setSelectedImageIndex(selectedImageIndex - 1)
       mixpanel.track('Carousel Image Switch', {
         flowType: flowType || 'simpleChat',
@@ -109,8 +125,16 @@ const ImagesModal = compose(
         urlTo: urlsArray[selectedImageIndex - 1],
       })
     },
-    onRightArrowClick: ({ selectedImageIndex, urlsArray, setSelectedImageIndex, selectedImage, flowType }) => () => {
+    onRightArrowClick: ({
+      selectedImageIndex,
+      urlsArray,
+      setSelectedImageIndex,
+      selectedImage,
+      flowType,
+      setIsPictureLoaded,
+    }) => () => {
       if (selectedImageIndex >= urlsArray.length - 1) return
+      setIsPictureLoaded(false)
       setSelectedImageIndex(selectedImageIndex + 1)
       mixpanel.track('Carousel Image Switch', {
         flowType: flowType || 'simpleChat',
@@ -132,6 +156,7 @@ const ImagesModal = compose(
       setSelectedImageIndex,
       selectedImage,
       flowType,
+      setIsPictureLoaded,
     }) => event => {
       if (isTwoFingerScroll || originalWindowWidth > window.innerWidth) return
       touchendX = event.changedTouches[0].screenX
@@ -162,6 +187,7 @@ const ImagesModal = compose(
           }
         }
       }
+      setIsPictureLoaded(false)
     },
   })
 )(ImagesModalTemplate)

--- a/plugiamo/src/shared/modal.js
+++ b/plugiamo/src/shared/modal.js
@@ -1,43 +1,64 @@
 import FocusLock from 'react-focus-lock'
+import Loader from 'icons/loader.svg'
 import withHotkeys, { escapeKey } from 'ext/recompose/with-hotkeys'
 import { compose } from 'recompose'
 import { createPortal } from 'preact/compat'
 import { h } from 'preact'
 import { IconClose } from 'plugin-base'
 
-const ModalTemplate = ({ allowBackgroundClose, closeModal, children }) => (
-  <div
-    onClick={allowBackgroundClose && closeModal}
-    role="presentation"
-    style={{
-      position: 'fixed',
-      top: 0,
-      bottom: -50,
-      paddingBottom: 50,
-      left: 0,
-      right: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.7)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: '12340000000',
-    }}
-    tabIndex="-1"
-  >
-    <IconClose
-      onClick={closeModal}
-      style={{
-        position: 'absolute',
-        top: '10px',
-        right: '10px',
-        fill: '#fff',
-        width: '32px',
-        height: '32px',
-        cursor: 'pointer',
-        zIndex: '12340000005',
-      }}
-    />
-    <div role="dialog" style={{ width: '100%', maxWidth: '60em' }}>
+const styles = {
+  modal: {
+    position: 'fixed',
+    top: 0,
+    bottom: -50,
+    paddingBottom: 50,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: '12340000000',
+  },
+  iconClose: {
+    position: 'absolute',
+    top: '10px',
+    right: '10px',
+    fill: '#fff',
+    width: '32px',
+    height: '32px',
+    cursor: 'pointer',
+    zIndex: '12340000005',
+  },
+  dialog: {
+    width: '100%',
+    maxWidth: '60em',
+  },
+  loaderContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100vh',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loader: {
+    height: '150px',
+    width: '150px',
+  },
+}
+
+const ModalTemplate = ({ allowBackgroundClose, closeModal, children, isResourceLoaded }) => (
+  <div onClick={allowBackgroundClose && closeModal} role="presentation" style={styles.modal} tabIndex="-1">
+    <IconClose onClick={closeModal} style={styles.iconClose} />
+    <div role="dialog" style={styles.dialog}>
+      {!isResourceLoaded && (
+        <div style={styles.loaderContainer}>
+          <Loader style={styles.loader} />
+        </div>
+      )}
       <FocusLock>{children}</FocusLock>
     </div>
   </div>
@@ -49,7 +70,7 @@ const ModalComp = compose(
   })
 )(ModalTemplate)
 
-const Modal = ({ allowBackgroundClose, closeModal, isOpen, container, children }) => {
+const Modal = ({ allowBackgroundClose, closeModal, isOpen, container, children, isResourceLoaded }) => {
   if (!isOpen) return null
 
   if (!container) {
@@ -63,7 +84,7 @@ const Modal = ({ allowBackgroundClose, closeModal, isOpen, container, children }
   }
 
   return createPortal(
-    <ModalComp allowBackgroundClose={allowBackgroundClose} closeModal={closeModal}>
+    <ModalComp allowBackgroundClose={allowBackgroundClose} closeModal={closeModal} isResourceLoaded={isResourceLoaded}>
       {children}
     </ModalComp>,
     container

--- a/plugiamo/src/shared/picture-modal.js
+++ b/plugiamo/src/shared/picture-modal.js
@@ -1,6 +1,6 @@
 import Modal from './modal'
-import { compose, withHandlers } from 'recompose'
 import { h } from 'preact'
+import { useCallback, useState } from 'preact/hooks'
 
 const styles = {
   container: {
@@ -13,26 +13,35 @@ const styles = {
     bottom: 50,
     left: 0,
   },
-  image: {
+  picture: {
     width: '100%',
     height: '100%',
     objectFit: 'contain',
   },
 }
 
-const PictureModal = ({ closeModal, isOpen, url }) => (
-  <Modal allowBackgroundClose closeModal={closeModal} isOpen={isOpen}>
-    <div style={styles.container} tabIndex="-1">
-      <img alt="" src={url} style={styles.image} />
-    </div>
-  </Modal>
-)
+const PictureModal = ({ closeModal, isOpen, setIsResourceLoaded, url }) => {
+  const [isPictureLoaded, setIsPictureLoaded] = useState(false)
 
-export default compose(
-  withHandlers({
-    closeModal: ({ closeModal }) => event => {
+  const closePictureModal = useCallback(
+    event => {
       event.stopPropagation()
       closeModal()
     },
-  })
-)(PictureModal)
+    [closeModal]
+  )
+
+  const onPictureLoad = useCallback(() => {
+    setIsPictureLoaded(true)
+  }, [setIsResourceLoaded])
+
+  return (
+    <Modal allowBackgroundClose closeModal={closePictureModal} isOpen={isOpen} isResourceLoaded={isPictureLoaded}>
+      <div style={styles.container} tabIndex="-1">
+        <img alt="" onLoad={onPictureLoad} src={url} style={styles.picture} />
+      </div>
+    </Modal>
+  )
+}
+
+export default PictureModal

--- a/plugiamo/src/shared/video-modal.js
+++ b/plugiamo/src/shared/video-modal.js
@@ -1,30 +1,40 @@
 import Modal from './modal'
-import { compose, withHandlers } from 'recompose'
 import { h } from 'preact'
+import { useCallback, useState } from 'preact/hooks'
 
-const VideoModal = ({ url, closeModal, isOpen }) => (
-  <Modal allowBackgroundClose closeModal={closeModal} isOpen={isOpen}>
-    <div style={{ width: '100%', paddingBottom: '56.25%', position: 'relative' }}>
-      <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}>
-        <iframe
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen="1"
-          frameBorder="0"
-          height="100%"
-          src={url}
-          title="Video player"
-          width="100%"
-        />
-      </div>
-    </div>
-  </Modal>
-)
+const VideoModal = ({ url, closeModal, isOpen }) => {
+  const [isVideoLoaded, setIsVideoLoaded] = useState(false)
 
-export default compose(
-  withHandlers({
-    closeModal: ({ closeModal }) => event => {
+  const closeVideoModal = useCallback(
+    event => {
       event.stopPropagation()
       closeModal()
     },
-  })
-)(VideoModal)
+    [closeModal]
+  )
+
+  const onVideoLoad = useCallback(() => {
+    setIsVideoLoaded(true)
+  }, [setIsVideoLoaded])
+
+  return (
+    <Modal allowBackgroundClose closeModal={closeVideoModal} isOpen={isOpen} isResourceLoaded={isVideoLoaded}>
+      <div style={{ width: '100%', paddingBottom: '56.25%', position: 'relative' }}>
+        <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}>
+          <iframe
+            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen="1"
+            frameBorder="0"
+            height="100%"
+            onLoad={onVideoLoad}
+            src={url}
+            title="Video player"
+            width="100%"
+          />
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default VideoModal


### PR DESCRIPTION
[Link to Trello Card](https://trello.com/c/magjHgzH)

### Changes

- Add a spinner when loading a fullscreen picture, a picture in the carousel, or a YouTube video
- Refractor some components with Hooks
- Extract some inline styles into variables to improve readability
- Small fix to pictures carousel (the right arrow was showing on the last picture of the sequence)

### Preview

![preview](https://user-images.githubusercontent.com/24722181/58948649-80540900-8782-11e9-8c66-3647fdbd911b.gif)