### PR TITLE
Make pampling show plugin only from our links

### DIFF
--- a/plugiamo/src/frekkls-config/pampling.js
+++ b/plugiamo/src/frekkls-config/pampling.js
@@ -14,6 +14,15 @@ export default {
     if (persona && path) {
       localStorage.setItem('trnd-pampling', JSON.stringify({ path, persona }))
     }
+    if (
+      !document.referrer.startsWith('https://pampling.com') &&
+      !persona &&
+      !path &&
+      localStorage.getItem('trnd-pampling')
+    ) {
+      localStorage.removeItem('trnd-pampling')
+      return options
+    }
     const pamplingStorageItem = localStorage.getItem('trnd-pampling')
     if (!pamplingStorageItem) return options
     const pamplingObject = JSON.parse(pamplingStorageItem)


### PR DESCRIPTION
### Changes
- When user comes to pampling from an external source and not directly through our "magic" link, then it doesn't sees the plugin again (localStorage is reset).