### PR TITLE
Add hostname to google analytics events

### DIFF
--- a/plugiamo/src/ext/google-analytics.js
+++ b/plugiamo/src/ext/google-analytics.js
@@ -66,6 +66,7 @@ const googleAnalytics = {
       storeGac: true,
     })
     this.ga('frekkls_tracker.set', 'checkProtocolTask', null)
+    this.ga('frekkls_tracker.set', 'hostname', location.hostname)
     this.event({
       hitType: 'pageview',
       eventCategory: 'Page',


### PR DESCRIPTION
## Updates:
- Hostname was added to GA events

**Note**: GA's library has the option to set the hostname by doing: `ga('set', 'hostname', 'foo.com');`
[see here](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference)

[Link To Trello Card](https://trello.com/c/qJdWxuNK/1262-send-hostname-as-custom-param-in-our-google-a-b-test)