### PR TITLE
Integrate with rollbar

### DIFF
--- a/plugiamo/src/app/content/content-frame.js
+++ b/plugiamo/src/app/content/content-frame.js
@@ -1,4 +1,5 @@
 import CloseButton from './close-button'
+import ErrorBoundaries from 'ext/recompose/error-boundaries'
 import styled from 'styled-components'
 import withHotkeys, { escapeKey } from 'ext/recompose/with-hotkeys'
 import { compose } from 'recompose'
@@ -71,10 +72,12 @@ const ContentFrame = ({
       skipEntry={skipEntry}
     >
       <IFrame onToggleContent={onToggleContent} styleStr={frameStyleStr}>
-        <div>
-          {children}
-          <CloseButton onToggleContent={onToggleContent} />
-        </div>
+        <ErrorBoundaries>
+          <div>
+            {children}
+            <CloseButton onToggleContent={onToggleContent} />
+          </div>
+        </ErrorBoundaries>
       </IFrame>
     </StyledDiv>
   )

--- a/plugiamo/src/ext/google-analytics.js
+++ b/plugiamo/src/ext/google-analytics.js
@@ -1,14 +1,6 @@
 import { GApropertyId, GOcontainerId, GOexperimentId } from 'config'
 
-const loadGAFrame = () => {
-  const iframe = document.createElement('iframe')
-  iframe.title = 'loading-ga-frame'
-  iframe.style.width = '0'
-  iframe.style.height = '0'
-  iframe.style.border = '0'
-  iframe.style.display = 'none'
-  iframe.style.position = 'absolute'
-  document.body.appendChild(iframe)
+const loadGoogle = iframe => {
   return { promises: [loadGA(iframe), loadGO(iframe)], iframe }
 }
 
@@ -49,7 +41,7 @@ const googleAnalytics = {
   active: false,
   cxApi: null,
   ga(...args) {
-    return document.querySelector('[title="loading-ga-frame"]').contentWindow.ga(...args)
+    return document.querySelector('[title="frekkls-loading-frame"]').contentWindow.ga(...args)
   },
   iframeRef: null,
   init(iframe) {
@@ -91,5 +83,5 @@ const googleAnalytics = {
   },
 }
 
-export { loadGAFrame }
+export { loadGoogle }
 export default googleAnalytics

--- a/plugiamo/src/ext/recompose/error-boundaries.js
+++ b/plugiamo/src/ext/recompose/error-boundaries.js
@@ -1,0 +1,10 @@
+import { compose, lifecycle } from 'recompose'
+import { Rollbar } from 'ext/rollbar'
+
+export default compose(
+  lifecycle({
+    componentDidCatch(error) {
+      Rollbar.error(error)
+    },
+  })
+)(({ children }) => children)

--- a/plugiamo/src/ext/rollbar.js
+++ b/plugiamo/src/ext/rollbar.js
@@ -1,7 +1,19 @@
 /* eslint-disable max-lines */
 import { rollbarToken } from 'config'
 
-export default () => {
+export const Rollbar = {
+  error(...args) {
+    return document.querySelector('[title="frekkls-loading-frame"]').contentWindow.Rollbar.error(...args)
+  },
+  warning(...args) {
+    return document.querySelector('[title="frekkls-loading-frame"]').contentWindow.Rollbar.warning(...args)
+  },
+  critical(...args) {
+    return document.querySelector('[title="frekkls-loading-frame"]').contentWindow.Rollbar.critical(...args)
+  },
+}
+
+export const loadRollbar = iframe => {
   /* eslint-disable sort-vars,no-empty,no-unused-vars */
   var _rollbarConfig = {
     enabled: !!rollbarToken,
@@ -13,6 +25,8 @@ export default () => {
     },
   }
 
+  const window = iframe.contentWindow
+  const document = iframe.contentDocument
   // Rollbar Snippet
   !(function(r) {
     function e(n) {

--- a/plugiamo/src/special/assessment/store-modal/index.js
+++ b/plugiamo/src/special/assessment/store-modal/index.js
@@ -1,4 +1,5 @@
 import Content from './content'
+import ErrorBoundaries from 'ext/recompose/error-boundaries'
 import Header from './header'
 import Wrapper from 'shared/modal'
 import { compose, lifecycle, withHandlers, withState } from 'recompose'
@@ -25,7 +26,9 @@ const FrameChild = ({ step, results, goToPrevStep, flowType }) => (
 const Modal = ({ onCloseModal, isOpen, results, goToPrevStep, step, module }) => (
   <Wrapper allowBackgroundClose closeModal={onCloseModal} isOpen={isOpen}>
     <Frame style={iframeStyle}>
-      <FrameChild flowType={module && module.flowType} goToPrevStep={goToPrevStep} results={results} step={step} />
+      <ErrorBoundaries>
+        <FrameChild flowType={module && module.flowType} goToPrevStep={goToPrevStep} results={results} step={step} />
+      </ErrorBoundaries>
     </Frame>
   </Wrapper>
 )


### PR DESCRIPTION
## Update:
- Plugin's errors are now caught in `componentDidCatch` and sent to [rollbar](https://rollbar.com/). 
- Rollbar's library is included though "loading" iframe (which is now detached from `ext/google-analytics.js`).
- Page errors are not caught since `rollbar` is not defined globally.

**Note**: To make sure the production environment is not polluted when in development (only happens if a `ROLLBAR_TOKEN` env var is defined), use `NODE_ENV=development`.

[Link To Trello Card](https://trello.com/c/j3arlGlo/826-make-sure-we-report-js-errors)