### PR TITLE
Fix Size Guide match logic

### DIFF
--- a/plugiamo/src/special/assessment/size-guide/index.js
+++ b/plugiamo/src/special/assessment/size-guide/index.js
@@ -73,8 +73,9 @@ export default compose(
         const products = results.find(item => item.hostname === 'www.pierre-cardin.de').products
         const product = products.find(item => item.id === id && !blacklistTags.includes(item.tag))
         setProduct(product)
-        if (product && tagSizeGuides[product.tag]) {
-          setProductType(tagSizeGuides[product.tag])
+        const foundKey = Object.keys(tagSizeGuides).find(item => product.tag.includes(item))
+        if (product && foundKey) {
+          setProductType(tagSizeGuides[foundKey])
         }
       })
     },


### PR DESCRIPTION
### Changes
- Changed function that should find items in `tagSizeGuides` so that Regular Fit, Slim Fit etc are not affecting results.