### PR TITLE
Don't allow base64 images

### DIFF
--- a/backend/app/controllers/api/v1/pictures_controller.rb
+++ b/backend/app/controllers/api/v1/pictures_controller.rb
@@ -14,7 +14,7 @@ module Api
         if @picture.save
           render json: @picture, status: :created
         else
-          render_error
+          render_error(@picture.errors[:url][0] || "Cannot create picture.")
         end
       end
 
@@ -24,7 +24,7 @@ module Api
         if destroy_all
           render json: { data: @pictures }
         else
-          render_error
+          render_error("Cannot delete at least one record.")
         end
       end
 
@@ -44,8 +44,8 @@ module Api
         !has_restriction_errors
       end
 
-      def render_error
-        errors = [{ title: "Cannot delete at least one record." }]
+      def render_error(title)
+        errors = [{ title: title }]
         render json: { errors: errors }, status: :unprocessable_entity
       end
     end

--- a/backend/app/models/picture.rb
+++ b/backend/app/models/picture.rb
@@ -10,7 +10,7 @@ class Picture < ApplicationRecord
   has_many :simple_chat_product_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
   has_many :simple_chat_picture_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
 
-  validates :url, presence: true, uniqueness: true
+  validates :url, presence: true, uniqueness: true, picture_url: true
 
   def as_json(_options = {})
     attributes

--- a/backend/app/validators/picture_url_validator.rb
+++ b/backend/app/validators/picture_url_validator.rb
@@ -1,0 +1,7 @@
+class PictureUrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value.starts_with?('http')
+      record.errors.add(:url, attribute, message: "Invalid URL")
+    end
+  end
+end

--- a/console-frontend/src/shared/picture-uploader/index.js
+++ b/console-frontend/src/shared/picture-uploader/index.js
@@ -123,6 +123,7 @@ const PictureUploader = ({ aspectRatio, disabled, label, onChange, required, set
       setDoneCropping(true)
       setModalOpen(false)
       setCrop({})
+      if (!picture) return
       onChange({ picUrl: picture, picRect: rect })
     },
     [onChange, picture, rect]
@@ -142,7 +143,7 @@ const PictureUploader = ({ aspectRatio, disabled, label, onChange, required, set
   const { enqueueSnackbar } = useSnackbar()
 
   const onFileUpload = useCallback(
-    async (files, filenames) => {
+    async (files, filenames, callback) => {
       setDoneCropping(false)
       setPreviousValue(value)
       onChange({ picUrl: '', picRect: null })
@@ -161,6 +162,7 @@ const PictureUploader = ({ aspectRatio, disabled, label, onChange, required, set
         setPicture(pictureUrl)
         setModalOpen(true)
       }
+      callback({ errors, requestError })
     },
     [enqueueSnackbar, onChange, value]
   )

--- a/console-frontend/src/shared/pictures-modal/index.js
+++ b/console-frontend/src/shared/pictures-modal/index.js
@@ -46,6 +46,15 @@ const PicturesModal = ({
     [croppingState, picture, previewPicture, progress]
   )
 
+  const safeUpload = useCallback(
+    (files, filename) =>
+      onFileUpload(files, filename, ({ errors, requestError }) => {
+        if (errors || requestError) {
+          setIsLoading(false)
+        }
+      }),
+    [onFileUpload, setIsLoading]
+  )
   const fetchRemotePicture = useCallback(
     async () => {
       if (isEmpty(pictureUrl.trim())) return enqueueSnackbar('Please enter an URL', { variant: 'error' })
@@ -57,19 +66,20 @@ const PicturesModal = ({
       if (errors || requestError) {
         enqueueSnackbar(errors.message || requestError, { variant: 'error' })
       } else {
-        onFileUpload([blob], [filename])
+        safeUpload([blob], [filename])
       }
       return { blob, response, errors, requestError, ...rest }
     },
-    [enqueueSnackbar, onFileUpload, pictureUrl]
+    [enqueueSnackbar, pictureUrl, safeUpload]
   )
 
   const handleClose = useCallback(
     () => {
       setUrlUploadState(false)
       setOpen(false)
+      onCropDoneClick()
     },
-    [setOpen, setUrlUploadState]
+    [onCropDoneClick, setOpen]
   )
 
   const fetchPictures = useCallback(
@@ -127,9 +137,9 @@ const PicturesModal = ({
   const newOnFileUpload = useCallback(
     ({ target: { files } }) => {
       if (urlUploadState) setUrlUploadState(false)
-      onFileUpload(files)
+      safeUpload(files)
     },
-    [onFileUpload, urlUploadState]
+    [safeUpload, urlUploadState]
   )
 
   const onPictureClick = useCallback(
@@ -144,7 +154,7 @@ const PicturesModal = ({
       setPictureUrl('')
       setUrlUploadState(true)
     },
-    [setPictureUrl, setUrlUploadState]
+    [setUrlUploadState]
   )
 
   const onCropKeyup = useCallback(


### PR DESCRIPTION
### Changes
- Created custom validator which only allows only picture urls that start with `http` and `https` to be uploaded;
- If url format is invalid it will reject with a message of "Invalid URL".