### PR TITLE
Don't use recompose for ErrorBoundaries

### DIFF
--- a/plugiamo/src/app/content/content-frame.js
+++ b/plugiamo/src/app/content/content-frame.js
@@ -1,5 +1,5 @@
 import CloseButton from './close-button'
-import ErrorBoundaries from 'ext/recompose/error-boundaries'
+import ErrorBoundaries from 'ext/error-boundaries'
 import styled from 'styled-components'
 import withHotkeys, { escapeKey } from 'ext/hooks/with-hotkeys'
 import { compose } from 'recompose'

--- a/plugiamo/src/ext/error-boundaries.js
+++ b/plugiamo/src/ext/error-boundaries.js
@@ -1,0 +1,15 @@
+import { Component } from 'preact'
+import { Rollbar } from 'ext/rollbar'
+
+class ErrorBoundaries extends Component {
+  componentDidCatch(error) {
+    Rollbar.error(error)
+  }
+
+  render() {
+    const { children } = this.props
+    return children
+  }
+}
+
+export default ErrorBoundaries

--- a/plugiamo/src/index.js
+++ b/plugiamo/src/index.js
@@ -1,5 +1,5 @@
 import App from 'app'
-import ErrorBoundaries from 'ext/recompose/error-boundaries'
+import ErrorBoundaries from 'ext/error-boundaries'
 import getFrekklsConfig from 'frekkls-config'
 import googleAnalytics, { loadGoogle } from 'ext/google-analytics'
 import mixpanel from 'ext/mixpanel'

--- a/plugiamo/src/special/assessment/store-modal/index.js
+++ b/plugiamo/src/special/assessment/store-modal/index.js
@@ -1,5 +1,5 @@
 import Content from './content'
-import ErrorBoundaries from 'ext/recompose/error-boundaries'
+import ErrorBoundaries from 'ext/error-boundaries'
 import Header from './header'
 import Wrapper from 'shared/modal'
 import { compose, lifecycle, withHandlers, withState } from 'recompose'


### PR DESCRIPTION
Part of https://trello.com/c/dasp39YF/1279-get-rid-of-recompose-use-hooks