### PR TITLE
Add plugin-base watcher

### DIFF
--- a/console-frontend/bin/deploy
+++ b/console-frontend/bin/deploy
@@ -12,7 +12,7 @@ REACT_APP_NODE_ENV=production
 REACT_APP_API_ENDPOINT=https://api.frekkls.com
 EOL
 
-cd ../plugin-base && yarn build && cd ../console-frontend && mkdir -p plugin-base && cp ../plugin-base/dist/plugin-base.js plugin-base/
+cd ../plugin-base && yarn build
 
 yarn build
 
@@ -32,4 +32,4 @@ EOL
 rsync -azh -e $SSH --delete-after --ignore-errors build/ root@139.59.128.112:/var/www/admin.frekkls.com/html
 
 rm -rf build/
-cd ../plugin-base && yarn build-dev && cd ../console-frontend && mkdir -p plugin-base && cp ../plugin-base/dist/plugin-base.js plugin-base/
+cd ../plugin-base && yarn build-dev

--- a/plugiamo/bin/deploy
+++ b/plugiamo/bin/deploy
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cd ../plugin-base && yarn build && cd ../plugiamo && mkdir -p plugin-base && cp ../plugin-base/dist/plugin-base.js plugin-base/ && \
+cd ../plugin-base && yarn build && \
 ([ -f .env ] && cp .env .env~ || true) && \
 aws s3 cp s3://plugiamo/.env .env && \
 yarn build && \
@@ -8,7 +8,7 @@ yarn build && \
 gzip -9 -c build/plugin.js | aws s3 cp - s3://plugiamo/plugin.js --quiet --content-type text/javascript --content-encoding gzip --acl public-read --cache-control 'public,max-age=600' && \
 aws --profile do --endpoint=https://ams3.digitaloceanspaces.com s3 cp build/plugin.js s3://javascript/plugin.js --quiet --content-type text/javascript --acl public-read --cache-control 'public,max-age=600' && \
 rm build/plugin.js && \
-cd ../plugin-base && yarn build-dev && cd ../plugiamo && mkdir -p plugin-base && cp ../plugin-base/dist/plugin-base.js plugin-base/
+cd ../plugin-base && yarn build-dev
 # begin notify rollbar
 # ROLLBAR_DEPLOY_TOKEN=$(grep ROLLBAR_DEPLOY_TOKEN .env | xargs)
 # IFS='=' read -ra ROLLBAR_DEPLOY_TOKEN <<< "$ROLLBAR_DEPLOY_TOKEN"

--- a/plugin-base/README.md
+++ b/plugin-base/README.md
@@ -11,6 +11,14 @@ yarn add -P react@^16.0.0 styled-components@^4.2.0 lodash.isequal@^4.5.0 react-d
 
 ## Build
 
+To build on every file change run:
+
+```
+yarn watch
+```
+
+To build only once, run:
+
 ```
 yarn 🚄
 ```

--- a/plugin-base/package.json
+++ b/plugin-base/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build-dev": "webpack --progress --config webpack.config.js",
     "build": "webpack -p --progress --config webpack.prod.js",
-    "🚄": "yarn build-dev && mkdir -p ../console-frontend/plugin-base && cp dist/plugin-base.js ../console-frontend/plugin-base && mkdir -p ../plugiamo/plugin-base && cp dist/plugin-base.js ../plugiamo/plugin-base"
+    "watch": "webpack --progress --watch --config webpack.config.js",
+    "🚄": "yarn build-dev"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/plugin-base/webpack.config.js
+++ b/plugin-base/webpack.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 const path = require('path')
+const exec = require('child_process').exec
 
 module.exports = {
   entry: ['./src/index.js'],
@@ -50,6 +51,21 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    {
+      apply: compiler => {
+        compiler.hooks.afterEmit.tap('AfterEmitPlugin', compilation => {
+          exec(
+            'mkdir -p ../console-frontend/plugin-base && cp dist/plugin-base.js ../console-frontend/plugin-base && mkdir -p ../plugiamo/plugin-base && cp dist/plugin-base.js ../plugiamo/plugin-base',
+            (err, stdout, stderr) => {
+              if (stdout) process.stdout.write(stdout)
+              if (stderr) process.stderr.write(stderr)
+            }
+          )
+        })
+      },
+    },
+  ],
   resolve: {
     modules: [path.resolve(__dirname, 'src'), 'node_modules'],
   },

--- a/slack-bot/lib/services/deploy.rb
+++ b/slack-bot/lib/services/deploy.rb
@@ -37,7 +37,7 @@ SH
 PLUGIN_CMD = <<~SH.freeze
   cd #{ENV['BUILD_FOLDER']}/core/plugiamo && \
   yarn install --silent --no-progress && \
-  cd ../plugin-base && yarn build && cd ../plugiamo && mkdir -p plugin-base && cp ../plugin-base/dist/plugin-base.js plugin-base/ && \
+  cd ../plugin-base && yarn build && \
   cp #{ENV['PLUGIN_ENV_FILE']} . && \
   mkdir -p ~/.aws && \
   ([ -f ~/.aws/credentials ] || cp #{ENV['AWS_CREDENTIALS_FILE']} ~/.aws/credentials) && \
@@ -50,7 +50,7 @@ SH
 CONSOLE_FRONTEND_CMD = <<~SH.freeze
   cd #{ENV['BUILD_FOLDER']}/core/console-frontend && \
   yarn install --silent --no-progress && \
-  cd ../plugin-base && yarn build && cd ../console-frontend && mkdir -p plugin-base && cp ../plugin-base/dist/plugin-base.js plugin-base/ && \
+  cd ../plugin-base && yarn build && \
   bin/deploy 'ssh -o "StrictHostKeyChecking=no" -i #{ENV['STATIC_KEY_FILE']}'
 SH
 


### PR DESCRIPTION
### Changes
- Added a `watch` option to the `plugin-base` which can be used in case of active development process in that part of the project;
### Important
- The script is run upon every `yarn build` or `yarn build-dev` so it is removed from deploy scripts.

### UPDATE
source of solution: https://stackoverflow.com/a/49786887/7321917