### PR TITLE
Fix picture crop bug

### DIFF
--- a/backend/app/controllers/api/v1/cors_proxy_controller.rb
+++ b/backend/app/controllers/api/v1/cors_proxy_controller.rb
@@ -8,6 +8,7 @@ module Api
 
       def download
         file = Down.download(CGI.unescape(params[:url]), max_size: 20_000_000)
+        return render json: { error: "File content error" }, status: :unprocessable_entity if file.size.zero?
       rescue Down::TooLarge
         render json: { error: "File size exceed limit" }, status: :unprocessable_entity
       rescue Down::NotFound


### PR DESCRIPTION
### Bug Details
This bug is related to the [Down](https://github.com/janko/down) gem.
[Here](https://github.com/janko/down/blob/26ee46025393d12bd3a92bd041b34a2565edc6f3/lib/down/net_http.rb#L135) the `.open()` method sometimes returns a `StringIO` object with **size 0**, even if the image is there if you visit the url, such as the one below ("content-length"=>"0"):

```
<StringIO:0x00007feaec4d3878 @base_uri=#<URI::HTTPS https://picsum.photos/id/488/1200/1300>, @meta={"date"=>"Wed, 19 Jun 2019 10:20:17 GMT", "content-type"=>"image/jpeg", "content-length"=>"0", "connection"=>"keep-alive", "keep-alive"=>"timeout=20", "access-control-allow-origin"=>"*", "age"=>"0", "cache-control"=>"public, max-age=2592000", "content-disposition"=>"inline; filename=\"488-1200x1300.jpg\"", "strict-transport-security"=>"max-age=31536000", "via"=>"1.1 varnish (Varnish/6.2)", "x-beluga-cache-status"=>"Miss", "x-beluga-node"=>"35", "x-beluga-record"=>"c5f6961fbad693658ad96f32e7543b7633a7ad01", "x-beluga-response-time"=>"579 ms", "x-beluga-status"=>"000", "x-beluga-trace"=>"036c0a0d-fa3b-4c8e-aa55-bec1e2867b61", "x-varnish"=>"98353594", "server"=>"BelugaCDN/v2.43.0", "x-beluga-response-time-x"=>"0.579 sec"}, @metas={"date"=>["Wed, 19 Jun 2019 10:20:17 GMT"], "content-type"=>["image/jpeg"], "content-length"=>["0"], "connection"=>["keep-alive"], "keep-alive"=>["timeout=20"], "access-control-allow-origin"=>["*"], "age"=>["0"], "cache-control"=>["public, max-age=2592000"], "content-disposition"=>["inline; filename=\"488-1200x1300.jpg\""], "strict-transport-security"=>["max-age=31536000"], "via"=>["1.1 varnish (Varnish/6.2)"], "x-beluga-cache-status"=>["Miss"], "x-beluga-node"=>["35"], "x-beluga-record"=>["c5f6961fbad693658ad96f32e7543b7633a7ad01"], "x-beluga-response-time"=>["579 ms"], "x-beluga-status"=>["000"], "x-beluga-trace"=>["036c0a0d-fa3b-4c8e-aa55-bec1e2867b61"], "x-varnish"=>["98353594"], "server"=>["BelugaCDN/v2.43.0"], "x-beluga-response-time-x"=>["0.579 sec"]}, @status=["200", "OK"]>
``` 

**An object with size 0 is then uploaded to DO, resulting in this bug.**

As an example, a correct `StringIO` object ("content-length"=>"5004"):

```
#<StringIO:0x00007fea0264a048 @base_uri=#<URI::HTTPS https://picsum.photos/id/344/200/300>, @meta={"date"=>"Wed, 19 Jun 2019 11:00:14 GMT", "content-type"=>"image/jpeg", "content-length"=>"5004", "connection"=>"keep-alive", "keep-alive"=>"timeout=20", "access-control-allow-origin"=>"*", "age"=>"42349", "cache-control"=>"public, max-age=2592000", "content-disposition"=>"inline; filename=\"344-200x300.jpg\"", "strict-transport-security"=>"max-age=31536000", "via"=>"1.1 varnish (Varnish/6.2)", "x-beluga-cache-status"=>"Hit (1)", "x-beluga-node"=>"35", "x-beluga-record"=>"c21f84e85d5ae1b0a0d2da4d09adeac58c15c051", "x-beluga-response-time"=>"0 ms", "x-beluga-status"=>"003", "x-beluga-trace"=>"330cf497-4ed4-498c-b682-0352ef7300f2", "x-varnish"=>"259457243 252514428", "server"=>"BelugaCDN/v2.43.0", "x-beluga-response-time-x"=>"0.003 sec"}, @metas={"date"=>["Wed, 19 Jun 2019 11:00:14 GMT"], "content-type"=>["image/jpeg"], "content-length"=>["5004"], "connection"=>["keep-alive"], "keep-alive"=>["timeout=20"], "access-control-allow-origin"=>["*"], "age"=>["42349"], "cache-control"=>["public, max-age=2592000"], "content-disposition"=>["inline; filename=\"344-200x300.jpg\""], "strict-transport-security"=>["max-age=31536000"], "via"=>["1.1 varnish (Varnish/6.2)"], "x-beluga-cache-status"=>["Hit (1)"], "x-beluga-node"=>["35"], "x-beluga-record"=>["c21f84e85d5ae1b0a0d2da4d09adeac58c15c051"], "x-beluga-response-time"=>["0 ms"], "x-beluga-status"=>["003"], "x-beluga-trace"=>["330cf497-4ed4-498c-b682-0352ef7300f2"], "x-varnish"=>["259457243 252514428"], "server"=>["BelugaCDN/v2.43.0"], "x-beluga-response-time-x"=>["0.003 sec"]}, @status=["200", "OK"]>
```

### Workaround: 
- We now check if the file returned from the Down.download() call has `size` 0. If so, an `unprocessable_entity` error is rendered.

[Link To Trello Card](https://trello.com/c/7dz1i0MJ/1297-after-adding-an-image-by-url-it-isnt-available-to-be-cropped)