### PR TITLE
Fix enter key on pictures gallery

### DIFF
--- a/console-frontend/src/shared/pictures-modal/index.js
+++ b/console-frontend/src/shared/pictures-modal/index.js
@@ -173,9 +173,9 @@ const PicturesModal = ({
 
   const onGalleryKeyup = useCallback(
     ({ keyCode }) => {
-      if (keyCode === ENTER_KEYCODE) onDialogClose()
+      if (keyCode === ENTER_KEYCODE && activePicture) onGalleryDoneClick(activePicture)
     },
-    [onDialogClose]
+    [activePicture, onGalleryDoneClick]
   )
 
   const onDialogEntering = useCallback(


### PR DESCRIPTION
### Bug:
- When the enter key was clicked the pictures gallery was being closed. Now the user sees the crop modal with the active picture.

[Link To Trello Card](https://trello.com/c/35vLtrT3/1303-select-a-picture-from-the-modal-and-press-the-enter-key-the-picture-doesnt-actually-get-selected)