### PR TITLE
Show resource ids in index pages

### DIFF
--- a/console-frontend/src/app/resources/personas/list.js
+++ b/console-frontend/src/app/resources/personas/list.js
@@ -7,6 +7,7 @@ import { EnhancedList, TableCell } from 'shared/table-elements'
 import { imgixUrl, stringifyRect } from 'plugin-base'
 
 const columns = [
+  { name: 'id', label: 'id', sortable: true },
   { name: 'avatar' },
   { name: 'name', label: 'name', sortable: true },
   { name: 'description', label: 'description' },

--- a/console-frontend/src/app/resources/pictures/list.js
+++ b/console-frontend/src/app/resources/pictures/list.js
@@ -4,6 +4,7 @@ import { ActiveColumn, EnhancedList, Picture, TableCell, Text } from 'shared/tab
 import { apiPictureDestroy, apiPictureList } from 'utils'
 
 const columns = [
+  { name: 'id', label: 'id', sortable: true },
   { name: 'picture' },
   { name: 'url', label: 'url', sortable: true },
   { name: 'status', label: 'status', sortable: true },

--- a/console-frontend/src/app/resources/triggers/list-base.js
+++ b/console-frontend/src/app/resources/triggers/list-base.js
@@ -43,6 +43,7 @@ const StyledReorderIcon = styled(ReorderIcon)`
 `
 
 const columns = [
+  { name: 'id', label: 'id' },
   { name: 'module', padding: 'none', label: 'module' },
   { name: 'urlMatchers', padding: 'none', label: 'Url Matchers' },
 ]
@@ -91,6 +92,7 @@ const TriggerRow = ({ trigger, selectedIds, setSelectedIds, highlightEnabled, hi
           style={{ color: highlightEnabled ? '#fff' : '' }}
         />
       </TableCell>
+      <TableCell>{trigger.id}</TableCell>
       <TableCell style={{ whiteSpace: 'nowrap' }} width="50%">
         <InlineTypography highlight={highlightEnabled} variant="subtitle2">{`${trigger.flowType}: '${
           trigger.flow.name

--- a/console-frontend/src/shared/table-elements/columns.js
+++ b/console-frontend/src/shared/table-elements/columns.js
@@ -1,4 +1,5 @@
 const columns = [
+  { name: 'id', label: 'id', sortable: true },
   { name: 'persona', padding: 'none', label: 'persona' },
   { name: 'name', sortable: true, label: 'name' },
   { name: 'active', label: 'active', sortable: true },

--- a/console-frontend/src/shared/table-elements/table-row.js
+++ b/console-frontend/src/shared/table-elements/table-row.js
@@ -60,6 +60,7 @@ const TableRow = ({
           onChange={handleSelect}
         />
       </TableCell>
+      <TableCell>{resource.id}</TableCell>
       {React.cloneElement(children, { highlightInactive })}
       <TableCell style={{ whiteSpace: 'nowrap' }}>
         {resourceEditPath && (


### PR DESCRIPTION
## Updates:
- Triggers list (shows ids)
- Showcases list (shows ids; enables sort by id)
- Simple Chats list (shows ids; enables sort by id)
- Outros list (shows ids; enables sort by id)
- Pictures list (shows ids; enables sort by id)
- Personas list (shows ids; enables sort by id)


[Link To Trello Card](https://trello.com/c/JQFp1VA0/1299-show-resource-ids-in-index-views)