### PR TITLE
Delius AF: Assessment Form module

### DIFF
--- a/plugiamo/src/app/content/simple-chat/chat-base.js
+++ b/plugiamo/src/app/content/simple-chat/chat-base.js
@@ -1,7 +1,7 @@
 import Cover from './cover'
 import CtaButton from 'special/cta-button'
 import ProgressBar from 'special/assessment/progress-bar'
-import { AssessmentProducts, AssessmentStepOptions } from 'special/assessment/message-types'
+import { AssessmentForm, AssessmentProducts, AssessmentStepOptions } from 'special/assessment/message-types'
 import { ChatLogUi, timeout } from 'plugin-base'
 import { Fragment, h } from 'preact'
 import { useCallback, useEffect, useState } from 'preact/hooks'
@@ -13,11 +13,13 @@ const messageFactory = ({ data, hideAll, nothingSelected, onClick, type }) => {
     )
   } else if (type === 'assessmentProducts') {
     return <AssessmentProducts data={data} onClick={onClick} />
+  } else if (type === 'assessmentForm') {
+    return <AssessmentForm data={data} onChange={onClick} />
   }
 }
 
 const getMessageMaxWidthByType = type => {
-  return ['assessmentProducts', 'assessmentStepOptions'].includes(type) ? '260px' : null
+  return ['assessmentProducts', 'assessmentStepOptions', 'assessmentForm'].includes(type) ? '260px' : null
 }
 
 const getMessageShowByType = (type, show) => {
@@ -34,6 +36,7 @@ const ChatBase = ({
   coverMinimized,
   ctaButton,
   ctaButtonClicked,
+  ctaButtonDisabled,
   data,
   FlowBackButton,
   goToPrevStep,
@@ -176,6 +179,7 @@ const ChatBase = ({
         <CtaButton
           clicked={ctaButtonClicked}
           ctaButton={ctaButton}
+          disabled={ctaButtonDisabled}
           hide={hideCtaButton}
           onClick={onCtaButtonClick}
           setClicked={setCtaButtonClicked}

--- a/plugiamo/src/app/content/simple-chat/index.js
+++ b/plugiamo/src/app/content/simple-chat/index.js
@@ -84,7 +84,7 @@ const SimpleChat = ({
     variables
   )
 
-  const { clickActions, modalsProps } = useChatActions('simpleChat')
+  const { clickActions, modalsProps } = useChatActions({ flowType: 'simpleChat' })
 
   if (!data || data.loading || data.error) return null
 

--- a/plugiamo/src/app/index.js
+++ b/plugiamo/src/app/index.js
@@ -1,6 +1,7 @@
 import AppBase from './base'
 import Assessment from 'special/assessment'
 import AssessmentCart from 'special/assessment/cart'
+import AssessmentForm from 'special/assessment/form'
 import AssessmentSizeGuide from 'special/assessment/size-guide'
 import getFrekklsConfig from 'frekkls-config'
 import googleAnalytics from 'ext/google-analytics'
@@ -11,7 +12,7 @@ import setupFlowHistory from './setup/flow-history'
 import { getScrollbarWidth, isSmall } from 'utils'
 import { gql, useGraphql } from 'ext/hooks/use-graphql'
 import { h } from 'preact'
-import { isDeliusAssessment, isPCAssessment, isPCAssessmentCart } from 'special/assessment/utils'
+import { isDeliusAssessment, isDeliusPDP, isPCAssessment, isPCAssessmentCart } from 'special/assessment/utils'
 import { location } from 'config'
 import { timeout } from 'plugin-base'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
@@ -135,6 +136,17 @@ const AppHacks = ({ data }) => {
       document.documentElement.classList.remove('trnd-open')
     }
   }, [showingContent])
+
+  if (isDeliusPDP()) {
+    return (
+      <AssessmentForm
+        setShowingContent={setShowingContent}
+        showingBubbles={showingBubbles}
+        showingContent={showingContent}
+        showingLauncher={showingLauncher}
+      />
+    )
+  }
 
   if (showAssessmentContent || isDeliusAssessment()) {
     return (

--- a/plugiamo/src/ext/hooks/use-chat-actions.js
+++ b/plugiamo/src/ext/hooks/use-chat-actions.js
@@ -3,7 +3,7 @@ import { markGoFwd } from 'app/setup/flow-history'
 import { clickAssessmentProduct as originalClickAssessmentProduct } from 'special/assessment/utils'
 import { useCallback, useMemo, useState } from 'preact/hooks'
 
-const useChatActions = flowType => {
+const useChatActions = ({ flowType, mergeAssessmentForm }) => {
   const [videoModalOpen, setVideoModalOpen] = useState(false)
   const [videoItem, setVideoItem] = useState(null)
   const [imageModalOpen, setImageModalOpen] = useState(false)
@@ -166,6 +166,13 @@ const useChatActions = flowType => {
     [flowType]
   )
 
+  const changeAssessmentForm = useCallback(
+    ({ item }) => {
+      mergeAssessmentForm(item)
+    },
+    [mergeAssessmentForm]
+  )
+
   const clickActions = useMemo(
     () => ({
       clickAssessmentProduct,
@@ -177,6 +184,7 @@ const useChatActions = flowType => {
       clickChatOption,
       clickLink,
       clickPictureMessage,
+      changeAssessmentForm,
     }),
     [
       clickAssessmentProduct,
@@ -188,6 +196,7 @@ const useChatActions = flowType => {
       clickChatOption,
       clickLink,
       clickPictureMessage,
+      changeAssessmentForm,
     ]
   )
 

--- a/plugiamo/src/special/assessment/base.js
+++ b/plugiamo/src/special/assessment/base.js
@@ -218,7 +218,7 @@ const Base = ({
     [results]
   )
 
-  const { clickActions, modalsProps } = useChatActions(module.flowType)
+  const { clickActions, modalsProps } = useChatActions({ flowType: module.flowType })
 
   const chatBaseProps = useMemo(() => ({ assessment: true, assessmentOptions: { step, goToNextStep }, ctaButton }), [
     goToNextStep,

--- a/plugiamo/src/special/assessment/cart/index.js
+++ b/plugiamo/src/special/assessment/cart/index.js
@@ -17,7 +17,7 @@ const Plugin = ({ setShowingContent, showingBubbles, showingContent, showingLaun
   const [products, setProducts] = useState([])
   const [isUnmounting, setIsUnmounting] = useState(false)
 
-  const { clickActions, modalsProps } = useChatActions(module.flowType)
+  const { clickActions, modalsProps } = useChatActions({ flowType: module.flowType })
 
   useEffect(() => {
     fetchProducts().then(results => {

--- a/plugiamo/src/special/assessment/data/delius.js
+++ b/plugiamo/src/special/assessment/data/delius.js
@@ -1766,6 +1766,75 @@ const data = {
       },
     },
   },
+  assessmentForm: {
+    flowType: 'ht-assessment-form',
+    header: {
+      title: 'Sprechen Sie mit uns',
+      subtitle: '',
+      minimized: true,
+      imageUrl: 'https://console-assets.ams3.digitaloceanspaces.com/manual/delius/Einkaufsgesellschaft.jpg',
+      animationUrl: 'https://console-assets.ams3.digitaloceanspaces.com/manual/delius/Einkaufsgesellschaft.jpg',
+      backgroundColor: '#fff',
+      textColor: '#333',
+      backButton: {
+        textColor: '#fff',
+        backgroundColor: 'rgba(0, 0, 0, 0.3)',
+      },
+    },
+    launcher: {
+      chatBubbleText: '',
+      chatBubbleExtraText: '',
+      persona: {
+        name: 'Elisa',
+        profilePic: {
+          url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/delius/Bildschirmfoto.png',
+          picRect: {},
+        },
+      },
+    },
+    closedLauncher: {
+      chatBubbleText: 'Vielen Dank!',
+      chatBubbleExtraText: 'Wir melden uns schnellstmöglich.',
+      persona: {
+        name: 'Elisa',
+        profilePic: {
+          url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/delius/Bildschirmfoto.png',
+        },
+      },
+    },
+    ctaButton: {
+      label: 'JETZT KONTAKTIERT WERDEN',
+      backgroundColor: '#ff6b02',
+      backgroundColorDisabled: '#333',
+      color: '#fff',
+      colorDisabled: '#555',
+    },
+    simpleChat: {
+      simpleChatSteps: [
+        {
+          key: 'default',
+          simpleChatMessages: [
+            {
+              id: 1,
+              type: 'SimpleChatTextMessage',
+              text:
+                'Vielen Dank, für Ihr Interesse an unserem Produkt! Schicken Sie uns gerne eine Anfrage und ein Experte wird sich mit Ihnen in Verbindung setzen.',
+            },
+            {
+              id: 2,
+              type: 'assessmentForm',
+              assessmentForm: [
+                { name: 'name', placeholder: 'Name', required: true },
+                { name: 'email', placeholder: 'E-Mail Adresse', required: true },
+                { name: 'phone', placeholder: 'Telefon', required: true },
+                { name: 'message', placeholder: 'Kommentar (optional)', multiline: true },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
 }
 
 export default data

--- a/plugiamo/src/special/assessment/form/index.js
+++ b/plugiamo/src/special/assessment/form/index.js
@@ -1,0 +1,132 @@
+import AppBase from 'app/base'
+import ChatBase from 'app/content/simple-chat/chat-base'
+import ChatModals from 'shared/chat-modals'
+import data from 'special/assessment/data/delius'
+import getFrekklsConfig from 'frekkls-config'
+import mixpanel from 'ext/mixpanel'
+import useChatActions from 'ext/hooks/use-chat-actions'
+import { h } from 'preact'
+import { isSmall } from 'utils'
+import { SimpleChat, timeout } from 'plugin-base'
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
+
+const validateForm = form => {
+  const formKeys = Object.keys(form)
+  const requiredFields = formKeys.filter(itemKey => form[itemKey].required)
+  if (requiredFields.length === 0) return
+  return requiredFields.find(itemKey => form[itemKey].value === '')
+}
+
+const Plugin = ({ setShowingContent, showingBubbles, showingContent, showingLauncher }) => {
+  const [isUnmounting, setIsUnmounting] = useState(false)
+  const [assessmentForm, setAssessmentForm] = useState({})
+  const [isMessageSent, setIsMessageSent] = useState(false)
+  const [ctaButtonDisabled, setCtaButtonDisabled] = useState(true)
+  const [pluginState, setPluginState] = useState('closed')
+  const [disappear, setDisappear] = useState(false)
+
+  const module = useMemo(
+    () => ({
+      ...data.assessmentForm,
+      launcher: isMessageSent ? data.assessmentForm.closedLauncher : data.assessmentForm.launcher,
+    }),
+    [isMessageSent]
+  )
+
+  const mergeAssessmentForm = useCallback(
+    form => {
+      const newForm = { ...assessmentForm, ...form }
+      setAssessmentForm(newForm)
+      const formIsEmpty = validateForm(newForm)
+      if (!ctaButtonDisabled && formIsEmpty) {
+        setCtaButtonDisabled(true)
+      }
+      if (ctaButtonDisabled && !formIsEmpty) {
+        setCtaButtonDisabled(false)
+      }
+    },
+    [assessmentForm, ctaButtonDisabled]
+  )
+
+  const { clickActions, modalsProps } = useChatActions({ flowType: module.flowType, mergeAssessmentForm })
+
+  useEffect(() => {
+    const assessmentOptions = localStorage.getItem('trnd-assessment-data')
+    if (assessmentOptions) setShowingContent(true)
+    mixpanel.track('Loaded Plugin', {
+      autoOpen: false,
+      flowType: module.flowType,
+      hash: location.hash,
+      hostname: location.hostname,
+    })
+
+    const finalForm = {}
+    const formMessages = []
+    module.simpleChat.simpleChatSteps.forEach(step =>
+      step.simpleChatMessages.forEach(
+        message =>
+          message.type === 'assessmentForm' && message.assessmentForm.forEach(field => formMessages.push(field))
+      )
+    )
+    formMessages.map(item => (finalForm[item.name] = { value: '', required: item.required }))
+    setAssessmentForm(finalForm)
+  }, [module.flowType, module.simpleChat.simpleChatSteps, setAssessmentForm, setShowingContent])
+
+  const onToggleContent = useCallback(() => {
+    if (isMessageSent) return
+    mixpanel.track('Toggled Plugin', { hostname: location.hostname, action: showingContent ? 'close' : 'open' })
+    mixpanel.time_event('Toggled Plugin')
+
+    if (showingContent && isSmall()) {
+      setIsUnmounting(true)
+      return timeout.set(
+        'exitOnMobile',
+        () => {
+          setIsUnmounting(false)
+          setShowingContent(false)
+        },
+        400
+      )
+    }
+    return setShowingContent(!showingContent)
+  }, [isMessageSent, setShowingContent, showingContent])
+
+  const onCtaButtonClick = useCallback(() => {
+    setIsMessageSent(true)
+    onToggleContent()
+    setPluginState('closed')
+    timeout.set('hideLauncher', () => setDisappear(true), 10000)
+  }, [onToggleContent, setDisappear])
+
+  return (
+    <div>
+      <ChatModals flowType={module.flowType} {...modalsProps} />
+      <AppBase
+        Component={
+          <SimpleChat
+            backButtonLabel={getFrekklsConfig().i18n.backButton}
+            ChatBase={ChatBase}
+            chatBaseProps={{ assessment: true }}
+            clickActions={clickActions}
+            coverMinimized={module.header.minimized}
+            ctaButton={module.ctaButton}
+            ctaButtonDisabled={ctaButtonDisabled}
+            data={module}
+            onCtaButtonClick={onCtaButtonClick}
+          />
+        }
+        data={module}
+        disappear={disappear}
+        isUnmounting={isUnmounting}
+        onToggleContent={onToggleContent}
+        persona={module.launcher.persona}
+        pluginState={pluginState}
+        showingBubbles={showingBubbles}
+        showingContent={showingContent}
+        showingLauncher={showingLauncher}
+      />
+    </div>
+  )
+}
+
+export default Plugin

--- a/plugiamo/src/special/assessment/message-types/assessment-form.js
+++ b/plugiamo/src/special/assessment/message-types/assessment-form.js
@@ -1,0 +1,77 @@
+import styled from 'styled-components'
+import { h } from 'preact'
+import { useCallback, useMemo, useState } from 'preact/hooks'
+
+const FieldInput = styled.input`
+  font-family: Roboto, sans-serif;
+  background: #fff;
+  width: 100%;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid #555;
+  padding: 5px 15px;
+  font-size: 14px;
+  color: #333;
+  outline: none;
+  margin-bottom: 4px;
+  margin-top: 4px;
+`
+
+const MultilineField = styled.textarea`
+  font-family: Roboto, sans-serif;
+  resize: none;
+  background: #fff;
+  width: 100%;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid #555;
+  padding: 0px 15px;
+  padding-top: 11px;
+  font-size: 14px;
+  color: #333;
+  outline: none;
+  margin-bottom: 4px;
+  margin-top: 4px;
+`
+
+const Container = styled.div`
+  width: 100%;
+`
+
+const Field = ({ setField, form, field }) => {
+  const currentFormValue = useMemo(() => form[field.name].value, [field.name, form])
+
+  const onChange = useCallback(event => setField(field.name, event.target.value), [field.name, setField])
+
+  if (field.multiline) {
+    return <MultilineField onChange={onChange} placeholder={field.placeholder} value={currentFormValue} />
+  }
+
+  return <FieldInput onChange={onChange} placeholder={field.placeholder} value={currentFormValue} />
+}
+
+const AssessmentForm = ({ data, onChange }) => {
+  const formObject = []
+  data.forEach(item => (formObject[item.name] = { value: '', required: item.required }))
+  const [form, setForm] = useState(formObject)
+
+  const setField = useCallback(
+    (name, value) => {
+      const newForm = { ...form }
+      newForm[name].value = value
+      setForm(newForm)
+      onChange({ type: 'changeAssessmentForm', item: newForm })
+    },
+    [form, onChange]
+  )
+
+  return (
+    <Container>
+      {data.map(field => (
+        <Field field={field} form={form} key={field.name} multiline={data.multiline} setField={setField} />
+      ))}
+    </Container>
+  )
+}
+
+export default AssessmentForm

--- a/plugiamo/src/special/assessment/message-types/index.js
+++ b/plugiamo/src/special/assessment/message-types/index.js
@@ -1,4 +1,5 @@
+import AssessmentForm from './assessment-form'
 import AssessmentProducts from './assessment-products'
 import AssessmentStepOptions from './assessment-step-options'
 
-export { AssessmentProducts, AssessmentStepOptions }
+export { AssessmentProducts, AssessmentStepOptions, AssessmentForm }

--- a/plugiamo/src/special/assessment/size-guide/index.js
+++ b/plugiamo/src/special/assessment/size-guide/index.js
@@ -29,7 +29,7 @@ const Plugin = ({ setShowingContent, showingBubbles, showingContent, showingLaun
     [pluginState, productType]
   )
 
-  const { clickActions, modalsProps } = useChatActions('asmt-size-guide')
+  const { clickActions, modalsProps } = useChatActions({ flowType: module.flowType })
 
   useEffect(() => {
     fetchProducts().then(results => {

--- a/plugiamo/src/special/assessment/utils.js
+++ b/plugiamo/src/special/assessment/utils.js
@@ -10,6 +10,8 @@ const deliusPathnames = ['/', '/en/', '/de/']
 
 const isDeliusAssessment = () => hostname === 'www.delius-contract.de' && deliusPathnames.includes(location.pathname)
 
+const isDeliusPDP = () => hostname === 'www.delius-contract.de' && location.pathname.match(/\/de\/produkte\/.+\/.+/)
+
 const rememberPersona = persona => sessionStorage.setItem('trnd-remembered-persona', JSON.stringify(persona))
 
 const cartIsNotEmpty = () => getShopcartProductIds().length > 0
@@ -91,4 +93,5 @@ export {
   isPCAssessmentCart,
   fetchProducts,
   isDeliusAssessment,
+  isDeliusPDP,
 }

--- a/plugiamo/src/special/cta-button.js
+++ b/plugiamo/src/special/cta-button.js
@@ -15,26 +15,30 @@ const Button = styled.button`
   font-family: Roboto, sans-serif;
   font-weight: 500;
   z-index: 1;
-  background-color: ${({ ctaButton }) => ctaButton.backgroundColor || '#111'};
-  color: ${({ ctaButton }) => ctaButton.color || '#fff'};
+  background-color: ${({ ctaButton, disabled }) =>
+    disabled && ctaButton.backgroundColorDisabled
+      ? ctaButton.backgroundColorDisabled
+      : ctaButton.backgroundColor || '#111'};
+  color: ${({ ctaButton, disabled }) =>
+    disabled && ctaButton.colorDisabled ? ctaButton.colorDisabled : ctaButton.color || '#fff'};
   padding: 25px 5px;
   font-size: 18px;
   line-height: 0;
   text-transform: uppercase;
   cursor: pointer;
   max-height: 50px;
-  transition: color 0.3s 0.3s, padding 0.3s, max-height 0.3s 0.3s;
+  transition: color 0.3s 0.3s, padding 0.3s, max-height 0.3s 0.3s, background-color 0.4s 0.2s;
   ${({ animation }) =>
     (animation === 'hide' || animation === 'init') &&
     `max-height: 0px;
       padding: 0;
       color: transparent;
-      transition: color 0.29s 0.01s, padding 0.3s 0.3s, max-height 0.3s 0.3s;
+      transition: color 0.29s 0.01s, padding 0.3s 0.3s, max-height 0.3s 0.3s, background-color 0.8s;
     `}
   overflow: hidden;
 `
 
-const CtaButton = ({ clicked, ctaButton, hide, onClick, setClicked }) => {
+const CtaButton = ({ clicked, ctaButton, hide, onClick, setClicked, disabled }) => {
   const [animation, setAnimation] = useState(hide ? 'remove' : 'show')
 
   useEffect(() => () => timeout.clear('ctaButtonAnimation'), [])
@@ -56,7 +60,7 @@ const CtaButton = ({ clicked, ctaButton, hide, onClick, setClicked }) => {
   if (animation === 'remove') return null
 
   return (
-    <Button animation={animation} ctaButton={ctaButton} onClick={newOnClick} type="button">
+    <Button animation={animation} ctaButton={ctaButton} disabled={disabled} onClick={newOnClick} type="button">
       {ctaButton.label}
     </Button>
   )


### PR DESCRIPTION
### Changes
- Created the "Form module" for Delius. It will send AF steps that user checked along with it's contact data to Delius / us in future;
- "Form" itself is used as one of the types of chat messages.

### Important
- `useChatActions` was changed in order for it to have access to `mergeAssessmentForm` which determines whether to show CTA button as disabled or not;
- Those changes bring logic of showing "Form module" auto-open only when coming from AF modal and having all AF steps completed. Check on `trnd-assessment-data` in `localStorage` is responsible for that and we should use it in the next steps of AF development as a reference.

### Test
Test it with url pathname "de/produkte/123/123"