### PR TITLE
Support special assessment cases in development

### DIFF
--- a/plugiamo/src/special/assessment/size-guide/index.js
+++ b/plugiamo/src/special/assessment/size-guide/index.js
@@ -34,7 +34,7 @@ const Plugin = ({ setShowingContent, showingBubbles, showingContent, showingLaun
   useEffect(() => {
     fetchProducts().then(results => {
       const pathArray = location.pathname.split('/')
-      const id = pathArray[pathArray.length - 1]
+      const id = process.env.ASSESSMENT_PRODUCT_ID || pathArray[pathArray.length - 1]
       const products = results.find(item => item.hostname === 'www.pierre-cardin.de').products
       const product = products.find(item => item.id === id && !blacklistTags.includes(item.tag))
       setProduct(product)

--- a/plugiamo/src/special/assessment/utils.js
+++ b/plugiamo/src/special/assessment/utils.js
@@ -31,13 +31,15 @@ const shuffle = a => {
 }
 
 const getShopcartProductIds = () =>
-  dataGathering
-    .getProductsFromCart()
-    .map((key, value) => value.id)
-    .toArray()
+  process.env.ASSESSMENT_PRODUCT_ID
+    ? [process.env.ASSESSMENT_PRODUCT_ID]
+    : dataGathering
+        .getProductsFromCart()
+        .map((key, value) => value.id)
+        .toArray()
 
 const recommendedProducts = results => {
-  const productReferences = results.find(item => item.hostname === location.hostname).products
+  const productReferences = results.find(item => item.hostname === hostname).products
   const shopcartProductIds = getShopcartProductIds()
   const shopcartProducts = productReferences.filter(product => shopcartProductIds.includes(product.id))
 


### PR DESCRIPTION
Updates:
- Add support to see locally the assessment size-guide in any pathname other than `/`; `checkout/cart`.
- Add support to see locally the assessment cart in `checkout/cart`
- The processed products in the assessment store and cart now relate to the `hostname` set in the `.env`.

Add a `ASSESSMENT_PRODUCT_ID` `.env` variable, for example:
`ASSESSMENT_PRODUCT_ID=airtouch-leinen-hose-tony-74439-000-79321-2900`

[Link To Trello Card](https://trello.com/c/sBpJOZWU/1281-make-it-so-we-can-run-locally-some-cases-which-are-currently-hard-to)