### PR TITLE
Send email on assessment form submit

### DIFF
--- a/backend/app/graphql/fields/delius_asmt_inquiry_field.rb
+++ b/backend/app/graphql/fields/delius_asmt_inquiry_field.rb
@@ -1,0 +1,11 @@
+Fields::DeliusAsmtInquiryField = GraphQL::Field.define do
+  name "DeliusAsmtInquiry"
+  type Types::DeliusAsmtInquiryType
+  argument :fields, !Types::DeliusAsmtInquiryInputType
+  resolve Resolver.new(->(_obj, args, _ctx) {
+    form_fields = args[:fields]
+    return { errors: ["Invalid email"] } unless form_fields.email.match?(Devise.email_regexp)
+
+    DeviseSparkpostMailer.delius_asmt_inquiry(form_fields)
+  })
+end

--- a/backend/app/graphql/main/mutation_type.rb
+++ b/backend/app/graphql/main/mutation_type.rb
@@ -1,3 +1,5 @@
 Main::MutationType = GraphQL::ObjectType.define do
   name "Mutation"
+
+  field :inquiry, Fields::DeliusAsmtInquiryField
 end

--- a/backend/app/graphql/types/delius_asmt_inquiry_input_type.rb
+++ b/backend/app/graphql/types/delius_asmt_inquiry_input_type.rb
@@ -1,0 +1,9 @@
+Types::DeliusAsmtInquiryInputType = GraphQL::InputObjectType.define do
+  name "DeliusAsmtInquiryInput"
+
+  argument :name, types.String
+  argument :email, types.String
+  argument :phone, types.String
+  argument :message, types.String
+  argument :url, types.String
+end

--- a/backend/app/graphql/types/delius_asmt_inquiry_type.rb
+++ b/backend/app/graphql/types/delius_asmt_inquiry_type.rb
@@ -1,0 +1,7 @@
+Types::DeliusAsmtInquiryType = GraphQL::ObjectType.define do
+  name "DeliusAsmtInquiry"
+
+  field :errors, !types[types.String] do
+    resolve ->(obj, _args, _ctx) { obj[:errors] || [] }
+  end
+end

--- a/backend/app/mailers/devise_sparkpost_mailer.rb
+++ b/backend/app/mailers/devise_sparkpost_mailer.rb
@@ -26,6 +26,20 @@ class DeviseSparkpostMailer < Devise::Mailer
     mail(to: record.email, sparkpost_data: sparkpost_data)
   end
 
+  def delius_asmt_inquiry(record) # rubocop:disable Metrics/MethodLength
+    sparkpost_data = {
+      substitution_data: {
+        inquiry_name: record.name,
+        inquiry_phone: record.phone,
+        inquiry_message: record.message,
+        inquiry_url: record.url,
+        inquiry_email: record.email,
+      },
+      template_id: "asmt-inquiry",
+    }
+    mail(to: ENV["DELIUS_ASMT_EMAIL"], sparkpost_data: sparkpost_data)
+  end
+
   private
 
   def mail(*args)

--- a/plugiamo/src/ext/hooks/use-graphql.js
+++ b/plugiamo/src/ext/hooks/use-graphql.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'preact/hooks'
 
 export const gql = strings => strings.join('')
 
-const client = new GraphQLClient(
+export const client = new GraphQLClient(
   graphQlUrl,
   overrideAccount ? { headers: { 'Override-Account': overrideAccount } } : undefined
 )

--- a/plugin-base/src/index.js
+++ b/plugin-base/src/index.js
@@ -21,6 +21,7 @@ import {
   MESSAGE_RANDOMIZER,
   positioning,
   stringifyRect,
+  validateEmail,
 } from 'tools'
 import { history, Router, timeout, transition } from 'ext'
 import { IconAnimatedEllipsis, IconChevronLeft, IconChevronRight, IconClose, IconPlayButton } from 'icons'
@@ -69,4 +70,5 @@ export {
   SimpleChatCover,
   headerConfig,
   ProductMessage,
+  validateEmail,
 }

--- a/plugin-base/src/tools.js
+++ b/plugin-base/src/tools.js
@@ -47,6 +47,11 @@ const matchUrl = (url, route) => {
   return matches
 }
 
+const validateEmail = email => {
+  const re = /^\S+@\S+$/
+  return re.test(String(email).toLowerCase())
+}
+
 const stringifyRect = picRect => picRect && `${picRect.x},${picRect.y},${picRect.width},${picRect.height}`
 
 const imgixUrl = (url, imgixParams) => {
@@ -212,4 +217,5 @@ export {
   MESSAGE_RANDOMIZER,
   replaceExternalLinks,
   logSectionsToLogs,
+  validateEmail,
 }


### PR DESCRIPTION
### Update:
- Send an email to delius with the data submited in the assessment form.

### Todo:
- Get the actual destination email from the client.
 



[Link To Trello Card](https://trello.com/c/yPbDCVjg/1312-delius-af-form-when-user-submits-it-send-an-email)