### PR TITLE
Use dynamic import for emoji

### DIFF
--- a/plugiamo/.babelrc.js
+++ b/plugiamo/.babelrc.js
@@ -16,5 +16,6 @@ module.exports = {
     ],
     ['@babel/plugin-transform-react-jsx', { pragma: 'h' }],
     '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-syntax-dynamic-import',
   ],
 }

--- a/plugiamo/bin/deploy
+++ b/plugiamo/bin/deploy
@@ -5,8 +5,10 @@ cd ../plugin-base && yarn build && cd ../plugiamo && \
 aws s3 cp s3://plugiamo/.env .env && \
 yarn build && \
 gzip -9 -c build/plugin.js | aws s3 cp - s3://plugiamo/plugin.js --quiet --content-type text/javascript --content-encoding gzip --acl public-read --cache-control 'public,max-age=600' && \
+gzip -9 -c build/vendors~emoji.js | aws s3 cp - s3://plugiamo/vendors~emoji.js --quiet --content-type text/javascript --content-encoding gzip --acl public-read --cache-control 'public,max-age=600' && \
 aws --profile do --endpoint=https://ams3.digitaloceanspaces.com s3 cp build/plugin.js s3://javascript/plugin.js --quiet --content-type text/javascript --acl public-read --cache-control 'public,max-age=600' && \
-rm build/plugin.js && \
+aws --profile do --endpoint=https://ams3.digitaloceanspaces.com s3 cp build/vendors~emoji.js s3://javascript/vendors~emoji.js --quiet --content-type text/javascript --acl public-read --cache-control 'public,max-age=600' && \
+rm build/*.js && \
 cd ../plugin-base && yarn build-dev && cd ../plugiamo
 # begin notify rollbar
 ROLLBAR_DEPLOY_TOKEN=$(grep ROLLBAR_DEPLOY_TOKEN .env | xargs)

--- a/plugiamo/package.json
+++ b/plugiamo/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-react-jsx": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/runtime": "^7.0.0",

--- a/plugiamo/src/app/launcher-bubbles/index.js
+++ b/plugiamo/src/app/launcher-bubbles/index.js
@@ -1,12 +1,12 @@
-import emojify from 'ext/emojify'
+import useEmojify from 'ext/hooks/use-emojify'
 import { h } from 'preact'
-import { LauncherBubbles as LauncherBubblesBase, timeout } from 'plugin-base'
+import { LauncherBubbles as LauncherBubblesBase } from 'plugin-base'
 import { useCallback, useEffect, useState } from 'preact/hooks'
 
 const TIME_END = 20 // 20 seconds
 
 // emojify and pass only what we want
-const convertData = (data, step) => {
+const convertData = (emojify, data, step) => {
   const newData = JSON.parse(JSON.stringify(data))
   const oldFlow = newData.flow || newData.launcher
   const flow = {
@@ -31,18 +31,22 @@ const LauncherBubbles = ({
   setDisappear,
 }) => {
   const [computedData, setComputedData] = useState(null)
+
   const newOnToggleContent = useCallback(() => {
     if (data.flow && data.flow.flowType === 'outro') return
 
     onToggleContent()
   }, [data.flow, onToggleContent])
 
+  const emojify = useEmojify()
   useEffect(() => {
-    setComputedData(convertData(data, 0))
-    timeout.set('LauncherBubblesUpdate', () => setComputedData(convertData(data, 1)), 500)
-    timeout.set('LauncherBubblesUpdate', () => setComputedData(convertData(data, 2)), 2000)
-    return () => timeout.clear('LauncherBubblesUpdate')
-  }, [data])
+    if (!emojify) return
+    let didCancel = false
+    setComputedData(convertData(emojify, data, 0))
+    setTimeout(() => didCancel || setComputedData(convertData(emojify, data, 1)), 500)
+    setTimeout(() => didCancel || setComputedData(convertData(emojify, data, 2)), 2000)
+    return () => (didCancel = true)
+  }, [data, emojify])
 
   return (
     <LauncherBubblesBase

--- a/plugiamo/src/ext/hooks/use-emojify.js
+++ b/plugiamo/src/ext/hooks/use-emojify.js
@@ -1,0 +1,11 @@
+import emojifyPromise from 'ext/emojify'
+import { useEffect, useState } from 'preact/hooks'
+
+const useEmojify = () => {
+  const [emojifyState, setEmojifyState] = useState({ fn: null })
+  useEffect(() => emojifyPromise.then(fn => setEmojifyState({ fn, loaded: true })), [])
+
+  return emojifyState.fn
+}
+
+export default useEmojify

--- a/plugiamo/webpack.config.js
+++ b/plugiamo/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = {
   entry: ['./src/index.js'],
   output: {
     path: path.resolve(__dirname, 'build'),
+    chunkFilename: '[name].js',
     filename: 'plugin.js',
   },
   module: {

--- a/plugiamo/yarn.lock
+++ b/plugiamo/yarn.lock
@@ -294,6 +294,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-dynamic-import@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
+  integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz#0d259a68090e15b383ce3710e01d5b23f3770cbd"

--- a/slack-bot/lib/services/deploy.rb
+++ b/slack-bot/lib/services/deploy.rb
@@ -43,8 +43,10 @@ PLUGIN_CMD = <<~SH.freeze
   ([ -f ~/.aws/credentials ] || cp #{ENV['AWS_CREDENTIALS_FILE']} ~/.aws/credentials) && \
   yarn build && \
   gzip -9 -c build/plugin.js | aws s3 --region eu-central-1 cp - s3://plugiamo/plugin.js --content-type text/javascript --content-encoding gzip --acl public-read --cache-control 'public,max-age=600' && \
+  gzip -9 -c build/vendors~emoji.js | aws s3 cp - s3://plugiamo/vendors~emoji.js --quiet --content-type text/javascript --content-encoding gzip --acl public-read --cache-control 'public,max-age=600' && \
   aws --profile do --endpoint=https://ams3.digitaloceanspaces.com s3 cp build/plugin.js s3://javascript/plugin.js --content-type text/javascript --acl public-read --cache-control 'public,max-age=600' && \
-  rm build/plugin.js
+  aws --profile do --endpoint=https://ams3.digitaloceanspaces.com s3 cp build/vendors~emoji.js s3://javascript/vendors~emoji.js --quiet --content-type text/javascript --acl public-read --cache-control 'public,max-age=600' && \
+  rm build/*.js
 SH
 
 CONSOLE_FRONTEND_CMD = <<~SH.freeze


### PR DESCRIPTION
https://trello.com/c/EuxFutkJ/1124-dynamically-require-emojijs

Why? Because this is 40kb gzipped, 20% of our current total  (plus it requires an extra large image), and it's only useful in some platforms.

So, only include it if we're in one of those platforms, by using the dynamic import.

https://webpack.js.org/guides/code-splitting/
https://medium.com/front-end-weekly/webpack-and-dynamic-imports-doing-it-right-72549ff49234

Note that this means the deploy process is changed, as now multiple files must be deployed, rather than one.