### PR TITLE
Adapt improv to use our DB rather than inprov.io

### DIFF
--- a/backend/app/controllers/tagged_products_api/clients_controller.rb
+++ b/backend/app/controllers/tagged_products_api/clients_controller.rb
@@ -3,7 +3,11 @@ module TaggedProductsApi
     before_action :authenticate
 
     def index
-      @clients = TaggedProductsClient.all
+      if params[:hostname]
+        @clients = TaggedProductsClient.where(hostname: params[:hostname])
+      else
+        @clients = TaggedProductsClient.all
+      end
       chain = @clients
       render json: chain
     end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -9,6 +9,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "*"
     resource "/graphql", headers: :any, methods: :post
+    resource "/tagged_products_api/clients*", headers: :any, methods: %i[get post put patch delete options head]
   end
 
   allow do

--- a/improv/src/tagger/index.js
+++ b/improv/src/tagger/index.js
@@ -110,7 +110,7 @@ export default compose(
       copyToClipboard(JSON.stringify({ products: newProducts }))
       setIsLoading(true)
       if (client) {
-        await updateClientRecords(client._id, { products: newProducts })
+        await updateClientRecords(client.id, { client: { payload: { products: newProducts } } })
         setChangedProducts([])
       } else {
         const json = await createClientRecord({ hostname, products: newProducts })
@@ -178,8 +178,8 @@ export default compose(
       if (client.length > 0) {
         setClient(client[0])
         products.forEach(product => {
-          const clientProduct = client[0].products.find(o => o.id === product.id)
-          const clientProductIndex = client[0].products.findIndex(o => o.id === product.id)
+          const clientProduct = client[0].payload.products.find(o => o.id === product.id)
+          const clientProductIndex = client[0].payload.products.findIndex(o => o.id === product.id)
           if (clientProduct) {
             if (clientProduct.tags) {
               product.tags = clientProduct.tags || []
@@ -187,10 +187,10 @@ export default compose(
               product.tag = clientProduct.tag || ''
             }
             product.highlight = clientProduct.highlight
-            client[0].products.splice(clientProductIndex, 1)
+            client[0].payload.products.splice(clientProductIndex, 1)
           }
         })
-        setProducts([...products, ...client[0].products])
+        setProducts([...products, ...client[0].payload.products])
       }
       setIsLoading(false)
     },

--- a/improv/src/utils/index.js
+++ b/improv/src/utils/index.js
@@ -311,7 +311,7 @@ const authFetch = async (url, options) =>
   await fetch(url, {
     headers: new Headers({
       'Content-Type': 'application/json',
-      'x-apikey': `${process.env.RESTDB_KEY}`,
+      Authorization: `Plain ${process.env.RESTDB_KEY}`,
     }),
     ...options,
   })
@@ -339,8 +339,7 @@ const apiUpdateRequest = async (url, body) => {
   return await response.json()
 }
 
-export const getClient = hostname =>
-  apiGetRequest(`${process.env.RESTDB_CLIENTS_ENDPOINT}?q={"hostname": "${hostname}"}`)
+export const getClient = hostname => apiGetRequest(`${process.env.RESTDB_CLIENTS_ENDPOINT}/?hostname=${hostname}`)
 export const getClientRecords = id => apiGetRequest(process.env.RESTDB_CLIENTS_ENDPOINT + '/' + id)
 export const createClientRecord = body => apiCreateRequest(process.env.RESTDB_CLIENTS_ENDPOINT, body)
 export const updateClientRecords = (id, body) => apiUpdateRequest(process.env.RESTDB_CLIENTS_ENDPOINT + '/' + id, body)


### PR DESCRIPTION
### Changes
- Improv uses our DB;
- Changed `index` method in `Clients` controller to accept `hostname` parameter and filter clients based on it, just as in previous setup.