### PR TITLE
Improve assessment info display in delius email

### DIFF
--- a/backend/app/graphql/types/delius_asmt_inquiry_input_type.rb
+++ b/backend/app/graphql/types/delius_asmt_inquiry_input_type.rb
@@ -6,5 +6,8 @@ Types::DeliusAsmtInquiryInputType = GraphQL::InputObjectType.define do
   argument :phone, types.String
   argument :message, types.String
   argument :url, types.String
-  argument :tags, types.String
+  argument :asmt, types.Boolean
+  argument :asmtStep1Choice, types.String
+  argument :asmtStep2Choice, types.String
+  argument :asmtStep3Choices, types.String
 end

--- a/backend/app/mailers/sparkpost_mailer.rb
+++ b/backend/app/mailers/sparkpost_mailer.rb
@@ -3,7 +3,9 @@ class SparkpostMailer < ApplicationMailer
     sparkpost_data = {
       substitution_data: {
         inquiry_name: record.name, inquiry_phone: record.phone, inquiry_message: record.message,
-        inquiry_url: record.url, inquiry_email: record.email, inquiry_tags: record.tags,
+        inquiry_url: record.url, inquiry_email: record.email, inquiry_asmt: record.asmt,
+        inquiry_asmt_step1_choice: record.asmt_step1_choice, inquiry_asmt_step2_choice: record.asmt_step2_choice,
+        inquiry_asmt_step3_choices: record.asmt_step3_choices,
       },
       template_id: "asmt-inquiry",
     }

--- a/email-templates/asmt-inquiry.html
+++ b/email-templates/asmt-inquiry.html
@@ -149,7 +149,36 @@
                           </tr>
                         </table>
                         <br>
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Assessment Flow Ergebnis: {{inquiry_tags}}</p>
+                        {{if asmt}}
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Assessment Flow Ergebnis:</p>
+                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                          <tr>
+                            <td width="25%" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                              <b>Branche:</b>
+                            </td>
+                            <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                              {{inquiry_asmt_step1_choice}}
+                            </td>
+                          </tr>
+                          <tr>
+                            <td width="25%" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                              <b>Bereich:</b>
+                            </td>
+                            <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                              {{inquiry_asmt_step2_choice}}
+                            </td>
+                          </tr>
+                          <tr>
+                            <td width="25%" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                              <b>Produktkategorie:</b>
+                            </td>
+                            <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                              {{inquiry_asmt_step3_choices}}
+                            </td>
+                          </tr>
+                        </table>
+                        <br>
+                        {{end}}
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Der Kunde ist interessiert an folgendem Produkt: {{inquiry_url}}</p>
                       </td>
                     </tr>


### PR DESCRIPTION
https://trello.com/c/Ioj853O5/1336-delius-af-re-format-assessment-info-in-email

Make it so the email shows the info like this:

```
Assessment Flow Ergebnis:

Branche:		<step1_choice>
Bereich:		<step2_choice>
Produktkategorie:	<step3_choice(s)>
```

(or, shows nothing if the assessment info wasn't there)

Deploy Plan:
- [x] Update the email template in sparkpost
- [x] Deploy backend
- [x] Deploy plugin
- [x] Send emails in prod, ask DW how it was