### PR TITLE
Add anti-spam honeypot to asmt form

### DIFF
--- a/backend/app/graphql/fields/delius_asmt_inquiry_field.rb
+++ b/backend/app/graphql/fields/delius_asmt_inquiry_field.rb
@@ -6,6 +6,8 @@ Fields::DeliusAsmtInquiryField = GraphQL::Field.define do
     form_fields = args[:fields]
     return { errors: ["Invalid email"] } unless form_fields.email.match?(Devise.email_regexp)
 
+    return { errors: [] } unless form_fields.verification == ""
+
     SparkpostMailer.delius_asmt_inquiry(form_fields).deliver_now
   })
 end

--- a/backend/app/graphql/types/delius_asmt_inquiry_input_type.rb
+++ b/backend/app/graphql/types/delius_asmt_inquiry_input_type.rb
@@ -7,4 +7,5 @@ Types::DeliusAsmtInquiryInputType = GraphQL::InputObjectType.define do
   argument :message, types.String
   argument :url, types.String
   argument :tags, types.String
+  argument :verification, types.String
 end

--- a/plugiamo/src/special/assessment/data/delius.js
+++ b/plugiamo/src/special/assessment/data/delius.js
@@ -1733,6 +1733,7 @@ const data = {
                 { name: 'email', placeholder: 'E-Mail Adresse', required: true },
                 { name: 'phone', placeholder: 'Telefon', required: true },
                 { name: 'message', placeholder: 'Kommentar (optional)', multiline: true },
+                { name: 'verification', hidden: true, checkbox: true },
               ],
             },
           ],

--- a/plugiamo/src/special/assessment/message-types/assessment-form.js
+++ b/plugiamo/src/special/assessment/message-types/assessment-form.js
@@ -17,6 +17,10 @@ const FieldInput = styled.input`
   margin-top: 4px;
 `
 
+const HiddenInput = styled.input`
+  display: none;
+`
+
 const MultilineField = styled.textarea`
   font-family: Roboto, sans-serif;
   resize: none;
@@ -46,8 +50,11 @@ const Field = ({ setField, form, field }) => {
   if (field.multiline) {
     return <MultilineField onChange={onChange} placeholder={field.placeholder} value={currentFormValue} />
   }
-
-  return <FieldInput onChange={onChange} placeholder={field.placeholder} value={currentFormValue} />
+  return field.hidden ? (
+    <HiddenInput autocomplete="off" onChange={onChange} tabindex="-1" type="checkbox" value="1" />
+  ) : (
+    <FieldInput onChange={onChange} placeholder={field.placeholder} value={currentFormValue} />
+  )
 }
 
 const AssessmentForm = ({ data, onChange }) => {


### PR DESCRIPTION
## Update:
- Added hidden checkbox to the delius assessment form. If a bot "clicks" it, the `verification` field value changes from "" (default value) to "1". If the server detects `verification` values other than the default one: "", it will responds with status 200, no errors but does not send the email.

followed [this](https://stackoverflow.com/questions/36227376/better-honeypot-implementation-form-anti-spam)

[Link To Trello Card](https://trello.com/c/BhXjAbnV/1330-delius-af-protect-against-mass-email-sending)