### PR TITLE
Adapt tagger and plugiamo for new highlight logic

### DIFF
--- a/improv/src/tagger/components/tag.js
+++ b/improv/src/tagger/components/tag.js
@@ -35,26 +35,34 @@ const TagBase = styled.div`
   font-weight: ${({ selected }) => (selected ? '500' : 'normal')};
 `
 
-const Tag = compose(
-  withHandlers({
-    onClick: ({ onClick, tag }) => () => onClick(tag),
-  }),
-  withProps(({ currentProduct, tag }) => {
-    const selected = tag.key
-      ? currentProduct[tag.key]
-      : useMultipleTagging
-      ? currentProduct.tags && currentProduct.tags.includes(tag)
-      : currentProduct.tag === tag
-    return {
-      selected,
-      label: typeof tag === 'string' ? tag : tag.name,
-    }
-  })
-)(({ keyCode, label, onClick, selected }) => (
+const isTagSelected = ({ currentTagKey, tag, currentProduct }) => {
+  if (currentTagKey) {
+    return currentProduct[currentTagKey] && currentProduct[currentTagKey].includes(tag)
+  }
+  if (tag.key) {
+    return currentProduct[tag.key]
+  }
+  if (useMultipleTagging) {
+    return currentProduct.tags && currentProduct.tags.includes(tag)
+  }
+  return currentProduct.tag === tag
+}
+
+const TagContainer = ({ keyCode, label, onClick, selected }) => (
   <TagBase onClick={onClick} selected={selected}>
     <Key selected={selected}>{keyCode}</Key>
     <Label>{label}</Label>
   </TagBase>
-))
+)
+
+const Tag = compose(
+  withHandlers({
+    onClick: ({ onClick, tag }) => () => onClick(tag),
+  }),
+  withProps(({ currentProduct, currentTagKey, tag }) => ({
+    selected: isTagSelected({ currentTagKey, tag, currentProduct }),
+    label: typeof tag === 'string' ? tag : tag.name,
+  }))
+)(TagContainer)
 
 export default Tag

--- a/improv/src/tagger/components/tags.js
+++ b/improv/src/tagger/components/tags.js
@@ -1,7 +1,9 @@
+import Button from 'shared/button'
 import React from 'react'
 import styled from 'styled-components'
 import Tag from './tag'
 import tagList from 'tagger/tag-list'
+import { compose, withHandlers, withProps, withState } from 'recompose'
 
 const Container = styled.div`
   max-height: 300px;
@@ -26,10 +28,11 @@ const GroupContainer = styled.div`
   }
 `
 
-const getGroupedTags = data => {
+const getGroupedTags = ({ tagList, currentTagKey }) => {
   let groupName
-  const groups = data
+  const groups = tagList
     .map(tag => {
+      if (currentTagKey === tag.key) return
       const tagGroupName = typeof tag === 'string' ? tag.split('>')[0] : '_additional'
       if (!groupName || groupName !== tagGroupName) {
         groupName = tagGroupName
@@ -39,26 +42,66 @@ const getGroupedTags = data => {
     .filter(e => e)
   const groupedTags = groups.map(group => {
     if (group === '_additional') {
-      const tags = data.filter(tag => typeof tag !== 'string')
+      const tags = tagList.filter(tag => typeof tag !== 'string')
       return { name: 'Additional', tags }
     }
-    const tags = data.filter(tag => typeof tag === 'string' && tag.split('>')[0] === group)
+    const tags = tagList.filter(tag => typeof tag === 'string' && tag.split('>')[0] === group)
     return { name: group, tags }
   })
   return groupedTags
 }
 
-const Tags = ({ currentProduct, toggleTag }) => (
-  <Container>
-    {getGroupedTags(tagList).map(group => (
-      <GroupContainer key={group.name}>
-        <Title>{group.name}</Title>
-        {group.tags.map(tag => (
-          <Tag currentProduct={currentProduct} key={tag} onClick={toggleTag} tag={tag} />
-        ))}
-      </GroupContainer>
-    ))}
-  </Container>
+const BackButton = styled(Button)`
+  margin-top: 20px;
+`
+
+const TagsContainer = ({ currentProduct, currentTagList, currentTagKey, onTagClick, goBackToMainList }) => (
+  <div>
+    <Container>
+      {currentTagList.map(group => (
+        <GroupContainer key={group.name}>
+          <Title>{group.name}</Title>
+          {group.tags.map(tag => (
+            <Tag
+              currentProduct={currentProduct}
+              currentTagKey={currentTagKey}
+              key={tag}
+              onClick={onTagClick}
+              tag={tag}
+            />
+          ))}
+        </GroupContainer>
+      ))}
+    </Container>
+    {currentTagKey && (
+      <BackButton onClick={goBackToMainList} type="button">
+        {'< Back'}
+      </BackButton>
+    )}
+  </div>
 )
+
+const Tags = compose(
+  withState('currentTagKey', 'setCurrentTagKey', null),
+  withProps(({ currentTagKey }) => ({
+    currentTagList: getGroupedTags({ tagList, currentTagKey }),
+  })),
+  withHandlers({
+    onTagClick: ({ currentTagKey, setCurrentTagKey, toggleTag }) => tag => {
+      if (tag.splitByTags) {
+        setCurrentTagKey(tag.key)
+      } else {
+        if (currentTagKey) {
+          const newTag = { key: currentTagKey, splitByTags: true, tag }
+          return toggleTag(newTag)
+        }
+        toggleTag(tag)
+      }
+    },
+    goBackToMainList: ({ setCurrentTagKey }) => () => {
+      setCurrentTagKey(null)
+    },
+  })
+)(TagsContainer)
 
 export default Tags

--- a/improv/src/tagger/index.js
+++ b/improv/src/tagger/index.js
@@ -56,6 +56,22 @@ const Tagger = ({ onCopyResult, ...props }) => (
   </Flex>
 )
 
+const switchTagsInArray = ({ tagsArray, tag }) => {
+  const productHasTags = !!tagsArray
+  let newTags = []
+  if (productHasTags) {
+    const productHasExactTag = tagsArray.includes(tag)
+    if (productHasExactTag) {
+      newTags = tagsArray.map(productTag => productTag !== tag && productTag).filter(e => e)
+    } else {
+      newTags = [...tagsArray, tag]
+    }
+  } else {
+    newTags = [tag]
+  }
+  return newTags
+}
+
 export default compose(
   withState('products', 'setProducts', () => parseProducts()),
   withState('pageProducts', 'setPageProducts', []),
@@ -70,22 +86,15 @@ export default compose(
   withHandlers({
     changeTag: () => ({ product, tag }) => {
       if (tag.key) {
+        if (tag.splitByTags) {
+          const tags = switchTagsInArray({ tagsArray: product[tag.key], tag: tag.tag })
+          return { ...product, [tag.key]: tags }
+        }
         return { ...product, [tag.key]: !product[tag.key] }
       }
       if (useMultipleTagging) {
-        const productHasTags = !!product.tags
-        let newTags = []
-        if (productHasTags) {
-          const productHasExactTag = product.tags.includes(tag)
-          if (productHasExactTag) {
-            newTags = product.tags.map(productTag => productTag !== tag && productTag).filter(e => e)
-          } else {
-            newTags = [...product.tags, tag]
-          }
-        } else {
-          newTags = [tag]
-        }
-        return { ...product, tags: newTags }
+        const tags = switchTagsInArray({ tagsArray: product.tags, tag })
+        return { ...product, tags }
       }
       return { ...product, tag: product.tag === tag ? '' : tag || product.tag }
     },

--- a/improv/src/tagger/tag-list/delius-contract.js
+++ b/improv/src/tagger/tag-list/delius-contract.js
@@ -79,7 +79,7 @@ const tagList = [
   'Wohnheim>Wandbeläge',
   'Wohnheim>Sonnenschutz',
 
-  { key: 'highlight', name: 'Highlight' },
+  { key: 'highlight', name: 'Highlight', splitByTags: true },
 ]
 
 export default tagList

--- a/plugiamo/src/special/assessment/base.js
+++ b/plugiamo/src/special/assessment/base.js
@@ -1,30 +1,17 @@
 import ChatBase from 'app/content/simple-chat/chat-base'
 import ChatModals from 'shared/chat-modals'
 import data from './data'
-import flatten from 'lodash.flatten'
 import getFrekklsConfig from 'frekkls-config'
 import mixpanel from 'ext/mixpanel'
 import StoreModal from './store-modal'
 import useChatActions from 'ext/hooks/use-chat-actions'
 import { assessmentHostname } from 'config'
+import { assessProducts, rememberPersona } from './utils'
 import { fetchProducts } from 'special/assessment/utils'
 import { h } from 'preact'
 import { isSmall } from 'utils'
-import { rememberPersona } from './utils'
 import { SimpleChat, timeout } from 'plugin-base'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
-
-const assessProducts = (products, tags) => {
-  const productsResult =
-    assessmentHostname === 'www.delius-contract.de'
-      ? flatten(
-          tags.map(tag =>
-            products.filter(product => product.tags && product.tags.find(productTag => tag.includes(productTag)))
-          )
-        )
-      : flatten(tags.map(tag => products.filter(product => product.tag && tag === product.tag)))
-  return productsResult.sort((a, b) => !!b.highlight - !!a.highlight)
-}
 
 const ctaButton = { label: 'Ergebnisse anzeigen' }
 


### PR DESCRIPTION
### Changes
- Moved `assessProducts` and relative to that functions to `utils`;
- Improv tool shows list of all tags if some tag is an object and has `splitByTags` key. "Fresh" list shows tags related to that tag and `Back` button to return to main tag list;
- The `highlight` key in product object can be a `boolean` as well as an array of strings (tags).

### Notes
- Text "Best Seller" wasn't changed, as it's frequently used in German (feedback by DW).