### PR TITLE
Make launcher disappear after first closing of content

### DIFF
--- a/plugiamo/src/special/assessment/index.js
+++ b/plugiamo/src/special/assessment/index.js
@@ -39,21 +39,24 @@ const Plugin = ({
     setShowingCtaButton(false)
   }, [])
 
+  const isDelius = useMemo(() => assessmentHostname === 'www.delius-contract.de', [])
+
   const onCloseModal = useCallback(() => {
     setShowingLauncher(true)
     setShowingContent(false)
     setShowAssessmentContent(false)
     setPluginState('closed')
-    timeout.set('hideLauncher', () => setDisappear(true), 10000)
-  }, [setShowAssessmentContent, setShowingContent, setShowingLauncher])
+    timeout.set('hideLauncher', () => setDisappear(true), isDelius ? 500 : 10000)
+  }, [isDelius, setShowAssessmentContent, setShowingContent, setShowingLauncher])
 
   const onToggleContent = useCallback(() => {
+    if (isDelius && pluginState === 'closed') return
     mixpanel.track('Toggled Plugin', { hostname: location.hostname, action: showingContent ? 'close' : 'open' })
     mixpanel.time_event('Toggled Plugin')
     if (showingContent) {
       resetAssessment()
       setPluginState('closed')
-      timeout.set('hideLauncher', () => setDisappear(true), 10000)
+      timeout.set('hideLauncher', () => setDisappear(true), isDelius ? 500 : 10000)
     } else {
       setPluginState('opened')
       timeout.clear('hideLauncher')
@@ -76,11 +79,20 @@ const Plugin = ({
     if (showingContent) setShowAssessmentContent(false)
 
     setShowingBubbles(false)
-  }, [disappear, resetAssessment, setShowAssessmentContent, setShowingBubbles, setShowingContent, showingContent])
+  }, [
+    disappear,
+    isDelius,
+    pluginState,
+    resetAssessment,
+    setShowAssessmentContent,
+    setShowingBubbles,
+    setShowingContent,
+    showingContent,
+  ])
 
   useEffect(() => {
-    if (showingContent && assessmentHostname === 'www.delius-contract.de') setShowAssessmentContent(true)
-  }, [setShowAssessmentContent, showingContent])
+    if (showingContent && isDelius) setShowAssessmentContent(true)
+  }, [setShowAssessmentContent, isDelius, showingContent])
 
   if (!module) return
 
@@ -88,7 +100,7 @@ const Plugin = ({
     <AppBase
       Component={
         <AssessmentBase
-          assessmentIsMainFlow={assessmentHostname === 'www.delius-contract.de'}
+          assessmentIsMainFlow={isDelius}
           assessmentState={assessmentState}
           currentStepKey={currentStepKey}
           endNodeTags={endNodeTags}


### PR DESCRIPTION
### Changes
- Launcher disappears after first time the content was closed;
- Additional: converted `assessmentHostname === 'www.delius-contract.de'` to `isDelius` `useMemo` to make it more consistent.

### Note
- `900ms` timeout was set in order to have smooth animation of launcher. It's not affecting usability, e.g: when you try to close it during that interval, it's not opening content and not sending `mixpanel` event "Toggled Plugin".