### PR TITLE
Optimize asmt products fetch

### DIFF
--- a/plugiamo/src/special/assessment/utils.js
+++ b/plugiamo/src/special/assessment/utils.js
@@ -22,7 +22,7 @@ const recallPersona = () => JSON.parse(sessionStorage.getItem('trnd-remembered-p
 const isPCAssessmentCart = () => isPCAssessment() && location.pathname.match(/^\/checkout\/cart/) && cartIsNotEmpty()
 
 const fetchProducts = () =>
-  fetch(process.env.TAGGED_PRODUCTS_URL, {
+  fetch(`${process.env.TAGGED_PRODUCTS_URL}?hostname=${assessmentHostname}`, {
     headers: new Headers({ 'Content-Type': 'application/json' }),
   }).then(response => response.json())
 


### PR DESCRIPTION
## Description

- We now pass a `hostname` `param` in the `GET` request to the `https://api.frekkls.com/tagged_products_api/clients` endpoint, fetching the `TaggedProductsClient` from the server with hostname matching `assessmentHostname`.
- The products fetch was optimized so that it happens only once, without repeating every time the user gets to the assessment store.

**Checked**: 
- [x] PC assessment
- [x] PC size-guide (only fetches products when plugin is loaded, no optimization was needed)
- [x] PC cart (only fetches products when plugin is loaded, no optimization was needed)
- [x] Delius assessment

[Link To Trello Card](https://trello.com/c/h1zibskU/1337-af-optimize-products-fetching)
