### PR TITLE
Frontend fixes in conversion rate chart

### DIFF
--- a/console-frontend/package.json
+++ b/console-frontend/package.json
@@ -18,6 +18,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.snakecase": "^4.1.1",
     "lodash.trim": "^4.5.1",
+    "moment": "^2.24.0",
     "notistack": "^0.8.2",
     "plugin-base": "../plugin-base",
     "query-string": "^6.2.0",

--- a/console-frontend/src/app/screens/data-dashboard/conversion-rate.js
+++ b/console-frontend/src/app/screens/data-dashboard/conversion-rate.js
@@ -1,12 +1,21 @@
 import CircularProgress from 'shared/circular-progress'
+import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 import Section from 'shared/section'
+import styled from 'styled-components'
 import { apiEventList, apiRequest } from 'utils'
 import { Line } from 'react-chartjs-2'
 import { useSnackbar } from 'notistack'
 
+const ErrorMessage = styled.p`
+  color: #32333d;
+  font-size: 15px;
+  font-weight: lighter;
+  margin-top: 35px;
+  text-align: center;
+`
+
 const config = {
-  label: 'Conversion Rate',
   fill: false,
   lineTension: 0.1,
   backgroundColor: 'rgba(255, 102, 65, 0.4)',
@@ -17,6 +26,27 @@ const config = {
   pointHoverBorderColor: '#f5f5f5',
 }
 
+const options = {
+  legend: {
+    display: false,
+  },
+  scales: {
+    yAxes: [
+      {
+        ticks: {
+          callback: value => `${value}%`,
+        },
+      },
+    ],
+  },
+  tooltips: {
+    callbacks: {
+      label: tooltipItem => `${tooltipItem.yLabel}% conversion`,
+      title: tooltipItem => moment(tooltipItem[0].xLabel, 'MMM D').format('MMMM D'),
+    },
+  },
+}
+
 const dates = {
   from_date: '2019-06-01',
   to_date: '2019-07-01',
@@ -25,6 +55,7 @@ const dates = {
 const ConversionRate = () => {
   const [chartData, setChartData] = useState({})
   const [isLoading, setIsLoading] = useState(true)
+  const [hasErrors, setHasErrors] = useState(false)
 
   const { enqueueSnackbar } = useSnackbar()
 
@@ -34,18 +65,29 @@ const ConversionRate = () => {
         const { json, requestError } = await apiRequest(apiEventList, [{ dates: JSON.stringify(dates) }])
         if (requestError) {
           enqueueSnackbar(requestError, { variant: 'error' })
+          setHasErrors(true)
         } else {
-          const labels = json.map(record => +record.date.split('-').pop())
-          const data = json.map(record => Math.round(record.conversionRate * 100) / 100)
+          const labels = json.map(record => moment(record.date).format('MMM D'))
+          const data = json.map(record => Math.round(record.conversionRate * 100))
           setChartData({ labels, datasets: [{ data, ...config }] })
-          setIsLoading(false)
         }
+        setIsLoading(false)
       })()
     },
     [enqueueSnackbar]
   )
 
-  return <Section title="Conversion Rate">{isLoading ? <CircularProgress /> : <Line data={chartData} />}</Section>
+  return (
+    <Section title="Conversion Rate">
+      {isLoading ? (
+        <CircularProgress />
+      ) : hasErrors ? (
+        <ErrorMessage>{'⚠️ There was a problem loading your data, please try again or contact us.'}</ErrorMessage>
+      ) : (
+        <Line data={chartData} options={options} />
+      )}
+    </Section>
+  )
 }
 
 export default ConversionRate

--- a/console-frontend/yarn.lock
+++ b/console-frontend/yarn.lock
@@ -9285,7 +9285,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
-moment@^2.10.2:
+moment@^2.10.2, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
## Changes

- Update labels on the x-axis to be in the format MMM DD (e.g. `Sep 29`)
- Update labels on the y-axis to represent percentages
- Tooltips now show the formatted date and the percentage (e.g. `September 29, 60% conversion`)
- Show an error message when there's a network error