### PR TITLE
Mark clients as ecommerce/non-ecommerce

### DIFF
--- a/backend/app/controllers/api/v1/websites_controller.rb
+++ b/backend/app/controllers/api/v1/websites_controller.rb
@@ -24,7 +24,7 @@ module Api
       private
 
       def website_params
-        params.require(:website).permit(:preview_mode, hostnames: [])
+        params.require(:website).permit(:preview_mode, :is_e_commerce, hostnames: [])
       end
     end
   end

--- a/backend/db/migrate/20190709125313_add_is_e_commerce_to_website.rb
+++ b/backend/db/migrate/20190709125313_add_is_e_commerce_to_website.rb
@@ -1,0 +1,5 @@
+class AddIsECommerceToWebsite < ActiveRecord::Migration[5.1]
+  def change
+    add_column :websites, :is_e_commerce, :boolean, null: false, default: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190628101730) do
+ActiveRecord::Schema.define(version: 20190709125313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 20190628101730) do
     t.datetime "updated_at", null: false
     t.bigint "account_id", null: false
     t.boolean "preview_mode", default: false
+    t.boolean "is_e_commerce", default: true, null: false
     t.index ["account_id"], name: "index_websites_on_account_id"
     t.index ["hostnames"], name: "index_websites_on_hostnames", using: :gin
   end

--- a/console-frontend/src/app/index.js
+++ b/console-frontend/src/app/index.js
@@ -43,7 +43,9 @@ const PrivateRoute = ({ component, isAdminScoped, isOwnerScoped, path, ...props 
   const render = useCallback(
     ({ match }) =>
       auth.isLoggedIn() ? (
-        (isOwnerScoped && auth.isRole('editor')) || (isAdminScoped && !auth.isAdmin()) ? (
+        (isOwnerScoped && auth.isRole('editor')) ||
+        (isAdminScoped && !auth.isAdmin()) ||
+        (path === routes.dataDashboard() && !auth.getSessionAccount().websitesAttributes[0].isECommerce) ? (
           React.createElement(NotFound, { match })
         ) : (
           React.createElement(component, { match })
@@ -51,7 +53,7 @@ const PrivateRoute = ({ component, isAdminScoped, isOwnerScoped, path, ...props 
       ) : (
         <Redirect to={routes.login()} />
       ),
-    [component, isAdminScoped, isOwnerScoped]
+    [component, isAdminScoped, isOwnerScoped, path]
   )
 
   return <Route {...props} path={path} render={render} />

--- a/console-frontend/src/app/layout/menu.js
+++ b/console-frontend/src/app/layout/menu.js
@@ -73,40 +73,48 @@ const resources = {
   },
 }
 
-const resourceGroups = {
-  main: {
-    name: 'Main',
-    showTitle: false,
-    resources: auth.isAdmin() ? [resources.dataDashboard, resources.triggers] : [resources.triggers],
-  },
-  modules: {
-    name: 'Modules',
-    showTitle: true,
-    resources: [resources.showcases, resources.simpleChats, resources.outros],
-  },
-  basic: {
-    name: 'Basic',
-    showTitle: true,
-    resources: [resources.pictures, resources.personas],
-  },
-  tools: {
-    name: 'Tools',
-    showTitle: true,
-    resources: [resources.urlGenerator],
-  },
+const resourceGroups = () => {
+  return {
+    main: {
+      name: 'Main',
+      showTitle: false,
+      resources: auth.isAdmin()
+        ? auth.getSessionAccount().websitesAttributes[0].isECommerce
+          ? [resources.dataDashboard, resources.triggers]
+          : [resources.triggers]
+        : [resources.triggers],
+    },
+    modules: {
+      name: 'Modules',
+      showTitle: true,
+      resources: [resources.showcases, resources.simpleChats, resources.outros],
+    },
+    basic: {
+      name: 'Basic',
+      showTitle: true,
+      resources: [resources.pictures, resources.personas],
+    },
+    tools: {
+      name: 'Tools',
+      showTitle: true,
+      resources: [resources.urlGenerator],
+    },
+  }
 }
 
-const editorResourceGroups = {
-  modules: {
-    name: 'Modules',
-    showTitle: true,
-    resources: [resources.simpleChats],
-  },
-  basic: {
-    name: 'Basic',
-    showTitle: true,
-    resources: [resources.pictures],
-  },
+const editorResourceGroups = () => {
+  return {
+    modules: {
+      name: 'Modules',
+      showTitle: true,
+      resources: [resources.simpleChats],
+    },
+    basic: {
+      name: 'Basic',
+      showTitle: true,
+      resources: [resources.pictures],
+    },
+  }
 }
 
 const fade = keyframes`
@@ -244,7 +252,10 @@ const BaseMenu = withRouter(
       return <DummyMenu />
     }
 
-    const userRoleResourceGroups = useMemo(() => (auth.isRole('editor') ? editorResourceGroups : resourceGroups), [])
+    const userRoleResourceGroups = useMemo(
+      () => (auth.isRole('editor') ? editorResourceGroups() : resourceGroups()),
+      []
+    )
 
     return (
       <Container>

--- a/console-frontend/src/app/screens/account/edit-website.js
+++ b/console-frontend/src/app/screens/account/edit-website.js
@@ -16,6 +16,7 @@ const formObjectTransformer = json => {
     hostnames: json.hostnames || [''],
     name: json.name || '',
     previewMode: json.previewMode,
+    isECommerce: json.isECommerce,
   }
 }
 
@@ -83,9 +84,9 @@ const EditWebsite = () => {
     [mergeFormCallback]
   )
 
-  const setPreviewMode = useCallback(
-    (event, checked) => {
-      mergeForm({ previewMode: !checked })
+  const toggleCheckbox = useCallback(
+    formFieldName => event => {
+      mergeForm({ [formFieldName]: event.target.checked })
     },
     [mergeForm]
   )
@@ -107,11 +108,17 @@ const EditWebsite = () => {
           value={form.name}
         />
         <FormControlLabel
-          control={<Checkbox checked={!form.previewMode} color="primary" onChange={setPreviewMode} />}
+          control={<Checkbox checked={form.previewMode} color="primary" onChange={toggleCheckbox('previewMode')} />}
           disabled={isFormLoading}
           label="Live"
         />
         <FormHelperText>{'Dangerous: this controls whether or not the plugin appears on your website.'}</FormHelperText>
+        <FormControlLabel
+          control={<Checkbox checked={form.isECommerce} color="primary" onChange={toggleCheckbox('isECommerce')} />}
+          disabled={isFormLoading}
+          label="E-Commerce"
+        />
+        <FormHelperText>{'Controls whether or not the data from your sales funnel is processed.'}</FormHelperText>
         <HostnamesForm
           addHostnameSelect={addHostnameSelect}
           deleteHostname={deleteHostname}


### PR DESCRIPTION
## Feature description
The data dashboard should not exist for non-ecommerce clients.
### Solution:
**Backend:**
- Added `is_e_commerce` field to `website` model, of type `boolean`, with default to `true`.

**Admin:** 
- Added Checkbox to control the new `isECommerce` field of the `EditWebsite` form. 
- Include the `/data-dashboard` route only if the `sessionAccount`stored in `localStorage` contains a `website` with `isECommerce: true`.
- `resourceGroups` was being called before the menu was rendered, resulting in an exception due to `sessionAccount` not being yet set. It was fixed so that the previous icon would work. 
### Preview:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/35154956/60962113-7b482380-a305-11e9-98fa-512bb1b9b1c2.gif)

[Link To Trello Card](https://trello.com/c/81WebtQV/1387-dd-ability-to-mark-clients-as-ecommerce-non-ecommerce)