### PR TITLE
Add single module preview

### DIFF
--- a/console-frontend/src/app/resources/showcases/form/data-utils.js
+++ b/console-frontend/src/app/resources/showcases/form/data-utils.js
@@ -70,6 +70,7 @@ const formObjectTransformer = json => {
     subtitle: json.subtitle || '',
     chatBubbleText: json.chatBubbleText || '',
     chatBubbleExtraText: json.chatBubbleExtraText || '',
+    triggerIds: json.triggerIds || [],
     lockVersion: json.lockVersion,
     __persona: json.persona,
     spotlightsAttributes: json.spotlightsAttributes.map(spotlight => ({

--- a/console-frontend/src/app/resources/showcases/form/index.js
+++ b/console-frontend/src/app/resources/showcases/form/index.js
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import routes from 'app/routes'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
 import useForm from 'ext/hooks/use-form'
-import { Actions } from 'shared/form-elements'
+import { Actions, PreviewModal } from 'shared/form-elements'
 import { arrayMove } from 'react-sortable-hoc'
 import { formObjectTransformer } from './data-utils'
 import { Grid } from '@material-ui/core'
@@ -27,6 +27,7 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
   const formRef = useRef()
   const [isCropping, setIsCropping] = useState(false)
   const [showingContent, setShowingContent] = useState(false)
+  const [isPreviewModalOpened, setIsPreviewModalOpened] = useState(false)
 
   const {
     form,
@@ -45,6 +46,13 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
       pluginHistory.replace(pluginRoutes.showcase(form.id))
     },
     [form.id]
+  )
+
+  const onPreviewClick = useCallback(
+    () => {
+      setIsPreviewModalOpened(!isPreviewModalOpened)
+    },
+    [isPreviewModalOpened]
   )
 
   const newOnFormSubmit = useCallback(
@@ -155,6 +163,8 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
           isFormPristine={isFormPristine}
           isFormSubmitting={isFormSubmitting}
           onFormSubmit={newOnFormSubmit}
+          onPreviewClick={onPreviewClick}
+          previewEnabled={!!form.id}
           saveDisabled={isFormSubmitting || isCropping || isFormLoading || isFormPristine}
           tooltipEnabled
           tooltipText="No changes to save"
@@ -163,7 +173,17 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
       backRoute,
       title,
     }),
-    [backRoute, isCropping, isFormLoading, isFormPristine, isFormSubmitting, newOnFormSubmit, title]
+    [
+      backRoute,
+      form.id,
+      isCropping,
+      isFormLoading,
+      isFormPristine,
+      isFormSubmitting,
+      newOnFormSubmit,
+      onPreviewClick,
+      title,
+    ]
   )
   useAppBarContent(appBarContent)
 
@@ -175,41 +195,46 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
     [onSpotlightClick]
   )
 
+  const module = useMemo(() => ({ id: form.id, type: 'showcase', triggerIds: form.triggerIds }), [form])
+
   if (isFormLoading) return <CircularProgress />
 
   return (
-    <Grid container spacing={24}>
-      <Grid item md={6} xs={12}>
-        <FormContainer
-          addSpotlight={addSpotlight}
-          form={form}
-          formRef={formRef}
-          isCropping={isCropping}
-          isFormLoading={isFormLoading}
-          isFormPristine={isFormPristine}
-          onBackClick={onBackClick}
-          onFormSubmit={newOnFormSubmit}
-          onSortEnd={onSortEnd}
-          onSpotlightClick={onSpotlightClick}
-          onToggleContent={onToggleContent}
-          selectPersona={selectPersona}
-          setFieldValue={setFieldValue}
-          setIsCropping={setIsCropping}
-          setSpotlightForm={setSpotlightForm}
-          title={title}
-        />
+    <>
+      {form.id && <PreviewModal module={module} open={isPreviewModalOpened} setOpen={setIsPreviewModalOpened} />}
+      <Grid container spacing={24}>
+        <Grid item md={6} xs={12}>
+          <FormContainer
+            addSpotlight={addSpotlight}
+            form={form}
+            formRef={formRef}
+            isCropping={isCropping}
+            isFormLoading={isFormLoading}
+            isFormPristine={isFormPristine}
+            onBackClick={onBackClick}
+            onFormSubmit={newOnFormSubmit}
+            onSortEnd={onSortEnd}
+            onSpotlightClick={onSpotlightClick}
+            onToggleContent={onToggleContent}
+            selectPersona={selectPersona}
+            setFieldValue={setFieldValue}
+            setIsCropping={setIsCropping}
+            setSpotlightForm={setSpotlightForm}
+            title={title}
+          />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <PluginPreview
+            form={form}
+            onToggleContent={onToggleContent}
+            previewCallbacks={previewCallbacks}
+            routeToShowcase={routeToShowcase}
+            routeToSpotlight={routeToSpotlight}
+            showingContent={showingContent}
+          />
+        </Grid>
       </Grid>
-      <Grid item md={6} xs={12}>
-        <PluginPreview
-          form={form}
-          onToggleContent={onToggleContent}
-          previewCallbacks={previewCallbacks}
-          routeToShowcase={routeToShowcase}
-          routeToSpotlight={routeToSpotlight}
-          showingContent={showingContent}
-        />
-      </Grid>
-    </Grid>
+    </>
   )
 }
 

--- a/console-frontend/src/app/resources/simple-chats/form/data-utils.js
+++ b/console-frontend/src/app/resources/simple-chats/form/data-utils.js
@@ -34,6 +34,7 @@ const formObjectTransformer = json => {
     chatBubbleText: json.chatBubbleText || '',
     chatBubbleExtraText: json.chatBubbleExtraText || '',
     personaId: (json.persona && json.persona.id) || '',
+    triggerIds: json.triggerIds || [],
     lockVersion: json.lockVersion,
     __persona: json.persona,
     simpleChatStepsAttributes: json.simpleChatStepsAttributes

--- a/console-frontend/src/app/resources/simple-chats/form/index.js
+++ b/console-frontend/src/app/resources/simple-chats/form/index.js
@@ -5,7 +5,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react'
 import routes from 'app/routes'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
 import useForm from 'ext/hooks/use-form'
-import { Actions } from 'shared/form-elements'
+import { Actions, PreviewModal } from 'shared/form-elements'
 import { arrayMove } from 'react-sortable-hoc'
 import { formObjectTransformer } from './data-utils'
 import { Grid } from '@material-ui/core'
@@ -22,6 +22,7 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
   const formRef = useRef()
   const [isCropping, setIsCropping] = useState(false)
   const [showingContent, setShowingContent] = useState(false)
+  const [isPreviewModalOpened, setIsPreviewModalOpened] = useState(false)
 
   const {
     form,
@@ -34,6 +35,13 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
     setFieldValue,
     setIsFormSubmitting,
   } = useForm({ formObjectTransformer, loadFormObject, saveFormObject })
+
+  const onPreviewClick = useCallback(
+    () => {
+      setIsPreviewModalOpened(!isPreviewModalOpened)
+    },
+    [isPreviewModalOpened]
+  )
 
   const newOnFormSubmit = useCallback(
     async event => {
@@ -112,6 +120,8 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
           isFormPristine={isFormPristine}
           isFormSubmitting={isFormSubmitting}
           onFormSubmit={newOnFormSubmit}
+          onPreviewClick={onPreviewClick}
+          previewEnabled={!!form.id}
           saveDisabled={isFormSubmitting || isFormLoading || isFormPristine}
           tooltipEnabled
           tooltipText="No changes to save"
@@ -120,38 +130,43 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
       backRoute,
       title,
     }),
-    [backRoute, isFormLoading, isFormPristine, isFormSubmitting, newOnFormSubmit, title]
+    [backRoute, form.id, isFormLoading, isFormPristine, isFormSubmitting, newOnFormSubmit, onPreviewClick, title]
   )
   useAppBarContent(appBarContent)
+
+  const module = useMemo(() => ({ id: form.id, type: 'simple-chat', triggerIds: form.triggerIds }), [form])
 
   if (isFormLoading) return <CircularProgress />
 
   return (
-    <Grid container spacing={24}>
-      <Grid item md={6} xs={12}>
-        <FormContainer
-          addSimpleChatStep={addSimpleChatStep}
-          backRoute={backRoute}
-          form={form}
-          formRef={formRef}
-          isCropping={isCropping}
-          isFormLoading={isFormLoading}
-          isFormPristine={isFormPristine}
-          isFormSubmitting={isFormSubmitting}
-          onFormSubmit={newOnFormSubmit}
-          onSortEnd={onSortEnd}
-          onToggleContent={onToggleContent}
-          selectPersona={selectPersona}
-          setFieldValue={setFieldValue}
-          setIsCropping={setIsCropping}
-          setSimpleChatStepsForm={setSimpleChatStepsForm}
-          title={title}
-        />
+    <>
+      {form.id && <PreviewModal module={module} open={isPreviewModalOpened} setOpen={setIsPreviewModalOpened} />}
+      <Grid container spacing={24}>
+        <Grid item md={6} xs={12}>
+          <FormContainer
+            addSimpleChatStep={addSimpleChatStep}
+            backRoute={backRoute}
+            form={form}
+            formRef={formRef}
+            isCropping={isCropping}
+            isFormLoading={isFormLoading}
+            isFormPristine={isFormPristine}
+            isFormSubmitting={isFormSubmitting}
+            onFormSubmit={newOnFormSubmit}
+            onSortEnd={onSortEnd}
+            onToggleContent={onToggleContent}
+            selectPersona={selectPersona}
+            setFieldValue={setFieldValue}
+            setIsCropping={setIsCropping}
+            setSimpleChatStepsForm={setSimpleChatStepsForm}
+            title={title}
+          />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <PluginPreview form={form} onToggleContent={onToggleContent} showingContent={showingContent} />
+        </Grid>
       </Grid>
-      <Grid item md={6} xs={12}>
-        <PluginPreview form={form} onToggleContent={onToggleContent} showingContent={showingContent} />
-      </Grid>
-    </Grid>
+    </>
   )
 }
 

--- a/console-frontend/src/shared/form-elements/actions.js
+++ b/console-frontend/src/shared/form-elements/actions.js
@@ -1,4 +1,5 @@
 import ActionsMenu from './simple-menu'
+import PreviewButton from './preview-button'
 import React, { useCallback } from 'react'
 import SaveButton from './save-button'
 import styled from 'styled-components'
@@ -48,7 +49,9 @@ const Actions = ({
   isFormPristine,
   tooltipText,
   saveAndCreateNewEnabled,
+  previewEnabled,
   width,
+  onPreviewClick,
 }) => (
   <>
     {saveAndCreateNewEnabled ? (
@@ -77,14 +80,23 @@ const Actions = ({
         </Container>
       )
     ) : (
-      <SaveButton
-        disabled={saveDisabled}
-        isFormPristine={isFormPristine}
-        isFormSubmitting={isFormSubmitting}
-        onClick={onFormSubmit}
-        tooltipEnabled={tooltipEnabled}
-        tooltipText={tooltipText}
-      />
+      <Container>
+        {previewEnabled && (
+          <FlexDiv>
+            <PreviewButton color="actions" onClick={onPreviewClick} />
+          </FlexDiv>
+        )}
+        <FlexDiv>
+          <SaveButton
+            disabled={saveDisabled}
+            isFormPristine={isFormPristine}
+            isFormSubmitting={isFormSubmitting}
+            onClick={onFormSubmit}
+            tooltipEnabled={tooltipEnabled}
+            tooltipText={tooltipText}
+          />
+        </FlexDiv>
+      </Container>
     )}
   </>
 )

--- a/console-frontend/src/shared/form-elements/index.js
+++ b/console-frontend/src/shared/form-elements/index.js
@@ -10,6 +10,8 @@ import FormHelperText from './form-helper-text'
 import FormSection from './form-section'
 import Header from './header'
 import InlineTypography from './inline-typography'
+import PreviewButton from './preview-button'
+import PreviewModal from './preview-modal'
 import Prompt from './prompt'
 import SaveButton from './save-button'
 import Select from './select'
@@ -30,4 +32,6 @@ export {
   SaveButton,
   Field,
   Select,
+  PreviewButton,
+  PreviewModal,
 }

--- a/console-frontend/src/shared/form-elements/preview-button.js
+++ b/console-frontend/src/shared/form-elements/preview-button.js
@@ -1,0 +1,16 @@
+import Button from 'shared/button'
+import React from 'react'
+
+const PreviewButton = ({ color, onClick, isFormSubmitting, message, disabled }) => (
+  <Button
+    color={color || 'primaryGradient'}
+    disabled={disabled}
+    isFormSubmitting={isFormSubmitting}
+    onClick={onClick}
+    type="submit"
+  >
+    {message || 'Preview'}
+  </Button>
+)
+
+export default PreviewButton

--- a/console-frontend/src/shared/form-elements/preview-modal.js
+++ b/console-frontend/src/shared/form-elements/preview-modal.js
@@ -1,0 +1,164 @@
+import auth from 'auth'
+import Dialog from 'shared/dialog'
+import omit from 'lodash.omit'
+import React, { useCallback, useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { apiRequest, apiTriggerShow } from 'utils'
+import { Button, Input, Link, Typography } from '@material-ui/core'
+
+const StyledButton = styled(Button)`
+  border-radius: 0;
+  box-shadow: none;
+  height: 40px;
+`
+
+const StyledLink = styled(Link)`
+  text-decoration: 'none';
+
+  &:focus,
+  &:hover,
+  &:visited,
+  &:link,
+  &:active {
+    text-decoration: none;
+  }
+`
+
+const UrlInput = styled(Input)`
+  flex: 4;
+  margin-left: 0.8rem;
+`
+
+const ButtonDiv = styled.div`
+  flex: 1;
+`
+
+const UrlDiv = styled.div`
+  border-style: solid;
+  border-width: 1px;
+  border-color: rgba(239, 239, 242);
+  margin: 1.5rem;
+  border-radius: 3px;
+  display: flex;
+  overflow: hidden;
+`
+
+const handleUrlFocus = event => event.target.select()
+
+const validHostnames = () => auth.getSessionAccount().websitesAttributes[0].hostnames
+
+const PreviewUrlBox = ({ module }) => {
+  const [url, setUrl] = useState('')
+  const [isValidUrl, setIsValidUrl] = useState(true)
+  const [isLoading, setIsLoading] = useState(true)
+  const [triggerUrl, setTriggerUrl] = useState(null)
+
+  const fetchTrigger = async module => {
+    const { json, requestError } = await apiRequest(apiTriggerShow, [module.triggerIds[0]])
+    setIsLoading(false)
+    if (requestError) {
+      setUrl(`https://${validHostnames()[0]}`)
+    } else {
+      setUrl(`https://${validHostnames()[0] + json.urlMatchers[0]}`)
+      setTriggerUrl(`https://${validHostnames()[0] + json.urlMatchers[0]}`)
+    }
+  }
+
+  const moduleToFragment = () => {
+    if (!module.type || !module.id || url === triggerUrl) return ''
+    return `#trnd:path:/${module.type}/${module.id}`
+  }
+
+  const onUrlChange = useCallback(event => {
+    setUrl(event.target.value)
+    const hostname = event.target.value.replace(/^https:\/\//i, '').split('/')[0]
+    const isProtocolValid = event.target.value.match(/^https?:/)
+    setIsValidUrl(validHostnames().includes(hostname) && isProtocolValid)
+  }, [])
+
+  useEffect(
+    () => {
+      if (module.triggerIds.length > 0) {
+        fetchTrigger(module)
+      } else {
+        setIsLoading(false)
+        setUrl(`https://${validHostnames()[0]}`)
+      }
+    },
+    [module, module.triggerIds]
+  )
+
+  return (
+    <UrlDiv>
+      <UrlInput
+        disabled={isLoading}
+        disableUnderline
+        fullWidth
+        onChange={onUrlChange}
+        onFocus={handleUrlFocus}
+        value={url}
+      />
+      <ButtonDiv>
+        {isValidUrl ? (
+          <StyledLink href={url + moduleToFragment(module, url)} rel="noopener noreferrer" target="_blank">
+            <StyledButton color="primary" fullWidth variant="contained">
+              {'Go'}
+            </StyledButton>
+          </StyledLink>
+        ) : (
+          <StyledButton color="primary" disabled fullWidth variant="contained">
+            {'Go'}
+          </StyledButton>
+        )}
+      </ButtonDiv>
+    </UrlDiv>
+  )
+}
+
+const FilteredTypography = props => <Typography {...omit(props, ['fontSize', 'fontWeight'])} />
+
+const StyledTypography = styled(FilteredTypography)`
+  font-size: ${({ fontSize }) => fontSize};
+  font-weight: ${({ fontWeight }) => fontWeight};
+  color: black;
+`
+
+const ContentContainer = styled.div`
+  text-align: center;
+`
+
+const DialogContent = ({ module }) => (
+  <ContentContainer>
+    <StyledTypography fontSize="2.1rem" fontWeight="300">
+      {'Preview this Module'}
+    </StyledTypography>
+    <StyledTypography fontSize="1.1rem" fontWeight="500">
+      {'Insert the url of the page where you want to see this module.'}
+    </StyledTypography>
+    <PreviewUrlBox module={module} />
+  </ContentContainer>
+)
+
+const DialogActions = ({ handleClose }) => (
+  <Button color="primary" onClick={handleClose} variant="text">
+    {'Done'}
+  </Button>
+)
+
+const PreviewModal = ({ open, setOpen, module }) => {
+  const handleClose = useCallback(() => setOpen(false), [setOpen])
+
+  return (
+    <Dialog
+      content={<DialogContent module={module} />}
+      dialogActions={<DialogActions handleClose={handleClose} />}
+      fullWidth
+      handleClose={handleClose}
+      maxWidth="sm"
+      open={open}
+      title=""
+    />
+  )
+}
+
+export default PreviewModal


### PR DESCRIPTION
## Feature description
On the **edit form** for `Showcases/SimpleChats/Outros` a "Preview" button was added next to the "Save" one, opening a modal that allows the user to input the url where he wants to see the current module. After inserting the url, a new tab is opened with the module in that page.

### Considerations:
- Default url:  If the module has a trigger, it's the first trigger url, using the first hostname. If doesn't have a trigger, it's just the the first hostname.
- If the user inserts one hostname that is not one of the hostnames configured, the button is disabled.

### Screenshots:
![image](https://user-images.githubusercontent.com/35154956/61056776-deac8100-a3eb-11e9-81d2-be2227a2fc2d.png)

![image](https://user-images.githubusercontent.com/35154956/61056752-d3f1ec00-a3eb-11e9-842c-5ce0a1775446.png)


[Link To Trello Card](https://trello.com/c/Wtg6kwZA/1396-single-module-preview)