### PR TITLE
Add arrows and gradient to carousel messages

### DIFF
--- a/plugin-base/src/simple-chat/components/message-types/carousel.js
+++ b/plugin-base/src/simple-chat/components/message-types/carousel.js
@@ -1,36 +1,175 @@
+import omit from 'lodash.omit'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
+import { IconChevronLeft } from 'icons'
 
-const Carousel = styled.div`
-  display: flex;
-  overflow: hidden;
-  overflow-x: scroll;
+const BASE_SIZE = 260
+const PRODUCT_ITEM_HEIGHT = 'auto'
+
+const isTouchDevice = 'ontouchstart' in document.documentElement
+
+const Container = styled(props => <div {...omit(props, ['carouselType'])} />)`
+  position: relative;
+  height: ${({ carouselType }) => (carouselType === 'productCarousel' ? PRODUCT_ITEM_HEIGHT : BASE_SIZE)}px;
   margin-left: -16px;
   margin-right: -16px;
-  min-height: ${({ carouselType }) => (carouselType === 'productCarousel' ? '270px' : '260px')};
 `
 
-const CarouselElement = styled.div`
-  margin: 0 5px;
-  max-height: 260px;
-  min-width: 260px;
-
-  &:hover {
-    cursor: pointer;
+const CarouselContent = styled.div`
+  position: relative;
+  display: flex;
+  flex-flow: row nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scroll-snap-stop: always;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
   }
+`
+
+const Gradient = styled.div`
+  &:before {
+    content: '';
+    position: absolute;
+    background: linear-gradient(
+      ${({ direction }) => (direction === 'right' ? -90 : 90)}deg,
+      #ebeef2,
+      rgba(255, 255, 255, 0)
+    );
+    width: 100px;
+    top: 0;
+    bottom: 0;
+    ${({ direction }) => direction}: 0;
+    pointer-events: none;
+    transition: visibility 0.4s, opacity 0.4s;
+    ${({ show }) => !show && 'opacity: 0; visibility: hidden;'}
+  }
+`
+
+const CarouselElement = styled(props => <div {...omit(props, ['carouselType', 'width'])} />)`
+  flex: none;
+  height: ${({ carouselType }) => (carouselType === 'productCarousel' ? PRODUCT_ITEM_HEIGHT : BASE_SIZE)}px;
+  width: ${({ width }) => (width ? width : BASE_SIZE)}px;
+  margin: 0 5px;
+  cursor: pointer;
+  scroll-snap-align: start;
+  scroll-margin: 15px;
+  scroll-snap-margin: 15px;
+
   &:first-child {
+    width: ${BASE_SIZE + 10}px;
     padding-left: 10px;
-    min-width: 270px;
   }
 
   &:last-child {
-    padding-right: 10px;
-    min-width: 270px;
+    width: ${BASE_SIZE + 15}px;
+    padding-right: 15px;
   }
+
   img {
-    border-radius: ${({ carouselType }) => (carouselType === 'productCarousel' ? '0' : '12px')};
     width: 100%;
     object-fit: cover;
+    ${({ carouselType }) =>
+      carouselType === 'imageCarousel' &&
+      `
+      height: 100%;
+      border-radius: 12px;
+    `}
   }
 `
+
+const ArrowContainer = styled(props => <div {...omit(props, ['direction', 'show'])} />)`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  ${({ direction }) => `${direction}: 0;`}
+  width: 60px;
+  cursor: pointer;
+  ${({ show }) => (!show ? 'opacity: 0; visibility: hidden;' : '')}
+  transition: visibility 0.4s, opacity 0.4s;
+  user-select: none;
+  &:hover {
+    svg {
+      fill: #fff;
+    }
+  }
+`
+
+const ArrowIconStyled = styled(props => <IconChevronLeft {...omit(props, ['direction'])} />)`
+  position: absolute;
+  top: 50%;
+  ${({ direction }) => direction}: 20px;
+  transform: translateY(-50%) ${({ direction }) => (direction === 'right' ? 'rotate(-180deg)' : '')};
+  width: 15px;
+  fill: rgba(255, 255, 255, 0.75);
+  filter: drop-shadow(2px ${({ direction }) => (direction === 'right' ? -3 : 3)}px 3px rgba(0, 0, 0, 0.5));
+`
+
+const Arrow = ({ direction, carouselRef, scrollLeft, show }) => {
+  const onClick = useCallback(
+    () => {
+      const elementSize = BASE_SIZE + 10
+      const distanceFromSibling =
+        direction === 'left'
+          ? scrollLeft - elementSize * Math.floor(scrollLeft / elementSize)
+          : elementSize * (Math.floor(scrollLeft / elementSize) + 1) - scrollLeft
+      const distance = distanceFromSibling === 0 ? elementSize : distanceFromSibling
+      carouselRef.current.scrollLeft += direction === 'left' ? -distance : distance
+    },
+    [carouselRef, direction, scrollLeft]
+  )
+
+  return (
+    <ArrowContainer direction={direction} onClick={onClick} show={show}>
+      <ArrowIconStyled direction={direction} />
+    </ArrowContainer>
+  )
+}
+
+const Carousel = ({ carouselType, children }) => {
+  const ref = useRef(null)
+  const [scrollLeft, setScrollLeft] = useState(0)
+
+  const showLeftArrow = useMemo(() => scrollLeft > 0, [scrollLeft])
+
+  const showRightArrow = useMemo(
+    () => scrollLeft === 0 || ref.current.scrollWidth - scrollLeft - ref.current.clientWidth > 0,
+    [scrollLeft]
+  )
+
+  const onScroll = useCallback(event => setScrollLeft(event.target.scrollLeft), [])
+
+  return (
+    <Container carouselType={carouselType}>
+      <CarouselContent onScroll={onScroll} ref={ref}>
+        {children}
+      </CarouselContent>
+      {!isTouchDevice && (
+        <div>
+          <Gradient direction="left" show={showLeftArrow} />
+          <Gradient direction="right" show={showRightArrow} />
+          <Arrow
+            carouselRef={ref}
+            carouselType={carouselType}
+            direction="left"
+            scrollLeft={scrollLeft}
+            show={showLeftArrow}
+          />
+          <Arrow
+            carouselRef={ref}
+            carouselType={carouselType}
+            direction="right"
+            scrollLeft={scrollLeft}
+            show={showRightArrow}
+          />
+        </div>
+      )}
+    </Container>
+  )
+}
 
 export { Carousel, CarouselElement }

--- a/plugin-base/src/simple-chat/components/message-types/index.js
+++ b/plugin-base/src/simple-chat/components/message-types/index.js
@@ -1,8 +1,8 @@
-import ImgCarouselMessage from './image-carousel-message'
+import PictureCarouselMessage from './picture-carousel-message'
 import PictureMessage from './picture-message'
 import ProductCarouselMessage from './product-carousel-message'
 import ProductMessage from './product-message'
 import TextMessage from './text-message'
 import VideoMessage from './video-message'
 
-export { VideoMessage, PictureMessage, ProductMessage, ProductCarouselMessage, ImgCarouselMessage, TextMessage }
+export { VideoMessage, PictureMessage, PictureCarouselMessage, ProductMessage, ProductCarouselMessage, TextMessage }

--- a/plugin-base/src/simple-chat/components/message-types/picture-carousel-message.js
+++ b/plugin-base/src/simple-chat/components/message-types/picture-carousel-message.js
@@ -1,14 +1,22 @@
 import React, { useCallback, useMemo } from 'react'
+import styled from 'styled-components'
 import { Carousel, CarouselElement } from './carousel'
 import { imgixUrl, stringifyRect } from 'tools'
 
-const ImgCarouselElement = ({ carouselType, picture, index, onClick, urlsArray }) => {
+const StyledCarouselElement = styled(CarouselElement)`
+  img {
+    cursor: zoom-in;
+  }
+`
+
+const PictureCarouselElement = ({ carouselType, picture, index, onClick, urlsArray }) => {
   const newOnClick = useCallback(
     () => {
       onClick({ type: 'clickImageCarouselItem', item: { index, urlsArray } })
     },
     [index, onClick, urlsArray]
   )
+
   const onTouchEnd = useCallback(
     () => {
       onClick({ type: 'touchImageCarousel', item: { index, urlsArray } })
@@ -17,7 +25,7 @@ const ImgCarouselElement = ({ carouselType, picture, index, onClick, urlsArray }
   )
 
   return (
-    <CarouselElement carouselType={carouselType} onClick={newOnClick} onTouchEnd={onTouchEnd}>
+    <StyledCarouselElement carouselType={carouselType} onClick={newOnClick} onTouchEnd={onTouchEnd}>
       <img
         alt=""
         src={imgixUrl(picture.url, {
@@ -27,11 +35,11 @@ const ImgCarouselElement = ({ carouselType, picture, index, onClick, urlsArray }
           h: 260,
         })}
       />
-    </CarouselElement>
+    </StyledCarouselElement>
   )
 }
 
-const ImgCarouselMessage = ({ carouselType, imageCarousel, onClick }) => {
+const PictureCarouselMessage = ({ carouselType, imageCarousel, onClick }) => {
   const pictures = useMemo(
     () =>
       imageCarousel.map(pictureData => {
@@ -44,7 +52,7 @@ const ImgCarouselMessage = ({ carouselType, imageCarousel, onClick }) => {
     <div>
       <Carousel carouselType={carouselType}>
         {pictures.map((picture, index) => (
-          <ImgCarouselElement
+          <PictureCarouselElement
             carouselType={carouselType}
             index={index}
             key={picture.id || `new-${index}`}
@@ -58,4 +66,4 @@ const ImgCarouselMessage = ({ carouselType, imageCarousel, onClick }) => {
   )
 }
 
-export default ImgCarouselMessage
+export default PictureCarouselMessage

--- a/plugin-base/src/simple-chat/components/message-types/picture-message.js
+++ b/plugin-base/src/simple-chat/components/message-types/picture-message.js
@@ -10,6 +10,7 @@ const PictureCard = styled(Card)`
 
 const Picture = styled(CardImg)`
   height: 260px;
+  cursor: zoom-in;
 `
 
 const PictureMessage = ({ onClick, pictureMessage }) => {

--- a/plugin-base/src/simple-chat/components/message-types/product-message.js
+++ b/plugin-base/src/simple-chat/components/message-types/product-message.js
@@ -51,6 +51,7 @@ const ProductCard = styled(Card)`
 const ProductImage = styled(CardImg)`
   height: 180px;
   border-radius: 12px 12px 0 0 !important;
+  user-select: none;
 `
 
 const Link = styled.a`

--- a/plugin-base/src/simple-chat/components/message.js
+++ b/plugin-base/src/simple-chat/components/message.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import timeout from 'ext/timeout'
 import { extractYoutubeId, MESSAGE_INTERVAL, MESSAGE_RANDOMIZER, replaceExternalLinks } from 'tools'
 import {
-  ImgCarouselMessage,
+  PictureCarouselMessage,
   PictureMessage,
   ProductCarouselMessage,
   ProductMessage,
@@ -140,7 +140,7 @@ const ChatMessage = ({
       ) : type === 'productCarousel' ? (
         <ProductCarouselMessage carouselType={type} onClick={onClick} productCarousel={data} />
       ) : type === 'imageCarousel' ? (
-        <ImgCarouselMessage carouselType={type} imageCarousel={data} onClick={onClick} />
+        <PictureCarouselMessage carouselType={type} imageCarousel={data} onClick={onClick} />
       ) : null}
     </MessageContainer>
   )


### PR DESCRIPTION
### Changes
- Added arrows and gradient to carousels;
- If the device isn't supporting `touch` the arrows are shown;
- Added scroll-snap effect to carousels;
- Removed margin at the bottom of products carousel.