### PR TITLE
Restrict file types on upload

### DIFF
--- a/backend/app/controllers/api/v1/s3_controller.rb
+++ b/backend/app/controllers/api/v1/s3_controller.rb
@@ -3,6 +3,7 @@ module Api
     class S3Controller < RestAdminController
       before_action :authenticate_user!
       before_action :ensure_tenant
+      before_action :process_file
 
       def sign
         render json: {
@@ -29,6 +30,12 @@ module Api
 
       def s3_presigner
         @s3_presigner ||= Aws::S3::Presigner.new
+      end
+
+      def process_file
+        return if params[:content_type].start_with?("image")
+
+        render json: { error: "Wrong file format" }, status: :unprocessable_entity
       end
     end
   end

--- a/console-frontend/src/shared/picture-uploader/index.js
+++ b/console-frontend/src/shared/picture-uploader/index.js
@@ -149,10 +149,13 @@ const PictureUploader = ({ aspectRatio, disabled, label, onChange, required, set
 
   const onFileUpload = useCallback(
     async (files, filenames) => {
+      if (files.length === 0 || !files[0].type.includes('image')) {
+        enqueueSnackbar('Wrong file format', { variant: 'error' })
+        return setIsLoading(false)
+      }
       setDoneCropping(false)
       setPreviousValue(value)
       onChange({ url: '', picRect: null })
-      if (files.length === 0) return
       const file = files[0]
       if (!file.name) file.name = processFilename(file, filenames[0])
       const pictureUrl = await uploadPicture({
@@ -170,7 +173,7 @@ const PictureUploader = ({ aspectRatio, disabled, label, onChange, required, set
         setIsLoading(false)
       }
     },
-    [enqueueSnackbar, onChange, value, setIsLoading]
+    [value, onChange, enqueueSnackbar]
   )
 
   const onModalClose = useCallback(() => {

--- a/console-frontend/src/utils/auth-requests.js
+++ b/console-frontend/src/utils/auth-requests.js
@@ -101,6 +101,7 @@ export const apiGetSignedUrlFactory = () => (file, callback) =>
       }
     })
     .then(callback)
+    .catch(callback)
 
 export const apiPasswordChange = body => apiUpdateRequest(PASSWORD_CHANGE_URL, body)
 


### PR DESCRIPTION
### Bug description:
- User was able to upload files with any type when not uploading by url.

### Solution:
- We prevent the upload of wrong file types (`!= image/*`) in the frontend and backend.

[Link To Trello Card](https://trello.com/c/fkC5EGun/1410-picture-uploader-lets-you-upload-any-kind-of-file-from-your-computer)