### PR TITLE
Add slug field to account model

### DIFF
--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -11,12 +11,21 @@ class Account < ApplicationRecord
 
   accepts_nested_attributes_for :websites, allow_destroy: true
 
+  before_validation :set_slug, on: :create
+
+  validates :name, presence: true, uniqueness: true
+  validates :slug, presence: true, uniqueness: true
+
   def as_json(_options = {})
-    attributes.slice("id", "name", "last_name", "created_at", "updated_at")
+    attributes.slice("id", "name", "slug", "last_name", "created_at", "updated_at")
               .merge(websites_attributes: websites)
   end
 
   def duplicate(name, hostnames)
     DuplicateAccount.new(self, name, hostnames).perform
+  end
+
+  def set_slug
+    self.slug = name.parameterize
   end
 end

--- a/backend/db/migrate/20190712135753_add_slug_to_account.rb
+++ b/backend/db/migrate/20190712135753_add_slug_to_account.rb
@@ -1,0 +1,5 @@
+class AddSlugToAccount < ActiveRecord::Migration[5.1]
+  def change
+    add_column :accounts, :slug, :string, null: false, default: ''
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190709125313) do
+ActiveRecord::Schema.define(version: 20190712135753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 20190709125313) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.string "slug", default: "", null: false
   end
 
   create_table "generated_urls", force: :cascade do |t|

--- a/backend/lib/data_scripts/set_accounts_slug.rb
+++ b/backend/lib/data_scripts/set_accounts_slug.rb
@@ -1,0 +1,1 @@
+Account.where(slug: "").each { |account| account.update!(slug: account.name.parameterize) }


### PR DESCRIPTION
## Feature Description:
Add slug string field to Account model, defaults to `""`, must be unique and must be present.
The slug is generated based on the `Account` `name` field, using the [parameterize](https://apidock.com/rails/v5.2.3/String/parameterize) method.

**Note:**
Added a script to update the slug value for the existing accounts.


[Link To Trello Card](https://trello.com/c/WBx1HhZf/1411-add-slug-to-account)