### PR TITLE
Accept "http" in module preview url input

### DIFF
--- a/console-frontend/src/shared/form-elements/preview-modal.js
+++ b/console-frontend/src/shared/form-elements/preview-modal.js
@@ -71,8 +71,8 @@ const PreviewUrlBox = ({ module }) => {
 
   const onUrlChange = useCallback(event => {
     setUrl(event.target.value)
-    const hostname = event.target.value.replace(/^https:\/\//i, '').split('/')[0]
-    const isProtocolValid = event.target.value.match(/^https?:/)
+    const hostname = event.target.value.replace(/^https?:\/\//i, '').split('/')[0]
+    const isProtocolValid = event.target.value.match(/^https?:\/\//)
     setIsValidUrl(validHostnames().includes(hostname) && isProtocolValid)
   }, [])
 


### PR DESCRIPTION
## Feature Description:
The url input box in the module preview accepted only url's starting with `https://`, now accepts `http://` as well.

![image](https://user-images.githubusercontent.com/35154956/61211363-5124a600-a6f7-11e9-9703-f7b546b6af5d.png)

[Link To Trello Card](https://trello.com/c/vOTTPj2E/1417-preview-url-should-accept-http)
