### PR TITLE
Add support for gifs in pictures gallery and modal

### DIFF
--- a/backend/app/controllers/api/v1/rest_admin_controller.rb
+++ b/backend/app/controllers/api/v1/rest_admin_controller.rb
@@ -45,7 +45,12 @@ module Api
                               end)
         return sorting_by_active_state(chain, direction) if column.underscore == "active"
         return sorting_by_pictures_state(chain, direction) if column.underscore == "status"
+        return sorting_by_pictures_type(chain, direction) if column.underscore == "type"
 
+        sorting_by_column(chain, direction, column)
+      end
+
+      def sorting_by_column(chain, direction, column)
         column = ActiveRecord::Base.connection.quote_column_name(column.underscore)
         direction = direction == "asc" ? "asc" : "desc"
         chain.order("#{column} #{direction}")
@@ -59,10 +64,21 @@ module Api
       end
 
       def sorting_by_pictures_state(chain, direction)
+        return chain if params[:controller] != "api/v1/pictures"
+
         sorted_chain = chain.sort_by do |picture|
-          picture.personas.count + picture.product_picks.count
+          picture.personas.count + picture.product_picks.count + picture.simple_chat_messages.count
         end
         return sorted_chain.reverse if direction == "asc"
+
+        sorted_chain
+      end
+
+      def sorting_by_pictures_type(chain, direction)
+        return chain if params[:controller] != "api/v1/pictures"
+
+        sorted_chain = chain.sort_by { |picture| picture.url.split(".").pop }
+        return sorted_chain.reverse if direction == "desc"
 
         sorted_chain
       end

--- a/backend/app/graphql/types/persona_type.rb
+++ b/backend/app/graphql/types/persona_type.rb
@@ -13,7 +13,9 @@ Types::PersonaType = GraphQL::ObjectType.define do
   field :picRect, Types::PicRectType do
     resolve ->(obj, _args, _ctx) { obj.pic_rect }
   end
-  field :profilePicAnimationUrl, types.String do
-    resolve ->(obj, _args, _ctx) { obj.profile_pic_animation_url }
+  field :profilePicAnimation, Types::PicType do
+    resolve ->(obj, _args, _ctx) {
+      { url: obj.profile_pic_animation.url } if obj.profile_pic_animation
+    }
   end
 end

--- a/backend/app/models/persona.rb
+++ b/backend/app/models/persona.rb
@@ -8,13 +8,15 @@ class Persona < ApplicationRecord
   has_many :simple_chats, dependent: :destroy
   has_many :outros, dependent: :destroy
   belongs_to :profile_pic, class_name: "Picture"
+  belongs_to :profile_pic_animation, class_name: "Picture", optional: true
 
   validates :name, presence: true
   validates :description, presence: true
 
   def as_json(_options = {})
     attributes
-      .slice("id", "name", "description", "account_id", "graphcms_ref", "instagram_url", "profile_pic_animation_url",
-             "pic_rect", "created_at", "updated_at", "lock_version").merge(profile_pic: { url: profile_pic.url })
+      .slice("id", "name", "description", "account_id", "graphcms_ref", "instagram_url", "pic_rect",
+             "created_at", "updated_at", "lock_version")
+      .merge(profile_pic: { url: profile_pic.url }, profile_pic_animation: { url: profile_pic_animation&.url })
   end
 end

--- a/backend/app/models/picture.rb
+++ b/backend/app/models/picture.rb
@@ -5,7 +5,10 @@ class Picture < ApplicationRecord
 
   paginates_per 10
 
-  has_many :personas, foreign_key: :profile_pic_id, dependent: :restrict_with_exception, inverse_of: :profile_pic
+  has_many :personas_with_profile_pic, class_name: "Persona", foreign_key: :profile_pic_id,
+                                       dependent: :restrict_with_exception, inverse_of: :profile_pic
+  has_many :personas_with_profile_pic_animation, class_name: "Persona", foreign_key: :profile_pic_animation_id,
+                                                 dependent: :restrict_with_exception, inverse_of: :profile_pic_animation
   has_many :product_picks, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
   has_many :simple_chat_product_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
   has_many :simple_chat_picture_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
@@ -13,12 +16,20 @@ class Picture < ApplicationRecord
   validate :url_must_be_valid
   validates :url, presence: true, uniqueness: true
 
+  def personas
+    personas_with_profile_pic + personas_with_profile_pic_animation
+  end
+
+  def simple_chat_messages
+    simple_chat_product_messages + simple_chat_picture_messages
+  end
+
   def as_json(_options = {})
     attributes
       .slice("id", "url", "created_at", "updated_at")
       .merge(personas: personas,
              product_picks: product_picks,
-             simple_chat_messages: simple_chat_product_messages + simple_chat_picture_messages)
+             simple_chat_messages: simple_chat_messages)
   end
 
   def url_must_be_valid

--- a/backend/app/models/showcase.rb
+++ b/backend/app/models/showcase.rb
@@ -38,14 +38,14 @@ class Showcase < ApplicationRecord
     end
   end
 
-  def spotlight_persona_attributes(spotlight)
+  def spotlight_persona_attributes(spotlight) # rubocop:disable Metrics/AbcSize
     {
       id: spotlight.persona.id,
       name: spotlight.persona.name,
       description: spotlight.persona.description,
       instagram_url: spotlight.persona.instagram_url,
       profile_pic: { url: spotlight.persona.profile_pic.url },
-      profile_pic_animation_url: spotlight.persona.profile_pic_animation_url,
+      profile_pic_animation: { url: spotlight.persona.profile_pic_animation&.url },
       pic_rect: spotlight.persona.pic_rect,
     }
   end

--- a/backend/db/migrate/20190704152636_add_profile_pic_animation_to_personas.rb
+++ b/backend/db/migrate/20190704152636_add_profile_pic_animation_to_personas.rb
@@ -1,0 +1,6 @@
+class AddProfilePicAnimationToPersonas < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :personas, :profile_pic_animation
+    add_foreign_key :personas, :pictures, column: :profile_pic_animation_id
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -67,7 +67,9 @@ ActiveRecord::Schema.define(version: 20190712135753) do
     t.bigint "profile_pic_id"
     t.integer "lock_version", default: 1
     t.json "pic_rect", default: {}
+    t.bigint "profile_pic_animation_id"
     t.index ["account_id"], name: "index_personas_on_account_id"
+    t.index ["profile_pic_animation_id"], name: "index_personas_on_profile_pic_animation_id"
     t.index ["profile_pic_id"], name: "index_personas_on_profile_pic_id"
   end
 
@@ -254,6 +256,7 @@ ActiveRecord::Schema.define(version: 20190712135753) do
   add_foreign_key "outros", "personas"
   add_foreign_key "outros", "users", column: "owner_id"
   add_foreign_key "personas", "accounts"
+  add_foreign_key "personas", "pictures", column: "profile_pic_animation_id"
   add_foreign_key "personas", "pictures", column: "profile_pic_id"
   add_foreign_key "pictures", "accounts"
   add_foreign_key "product_picks", "accounts"

--- a/backend/lib/data_scripts/convert_animated_pictures.rb
+++ b/backend/lib/data_scripts/convert_animated_pictures.rb
@@ -1,0 +1,30 @@
+require "open-uri"
+
+@client = Aws::S3::Client.new(access_key_id: ENV["DO_SPACES_KEY_ID"], secret_access_key: ENV["DO_SECRET_ACCESS_KEY"])
+
+def digital_ocean_uri(pic_url, account_id)
+  filename = URI(pic_url).path.split("/").last
+  prefix = "https://#{ENV['DO_BUCKET']}.#{ENV['DO_SPACE_ENDPOINT']}"
+  URI("#{prefix}/uploads/account-#{account_id}/#{SecureRandom.hex(4)}-#{filename}")
+end
+
+def upload_file!(pic_url, new_pic_uri)
+  body = open(URI.encode(pic_url)) # rubocop:disable Lint/UriEscapeUnescape, Security/Open
+  content_type = body.meta["content-type"]
+  bucket = ENV["DO_BUCKET"]
+  destination_key = new_pic_uri.path[1..-1]
+  @client.put_object(bucket: bucket, key: destination_key, body: body, content_type: content_type, acl: "public-read")
+end
+
+Account.all.each do |account|
+  ActsAsTenant.default_tenant = account
+
+  Persona.where.not(profile_pic_animation_url: "").each do |persona|
+    pic_url = persona.profile_pic_animation_url
+    new_pic_uri = digital_ocean_uri(pic_url, account.id)
+    upload_file!(pic_url, new_pic_uri)
+
+    new_pic = Picture.create!(url: new_pic_uri)
+    persona.update!(profile_pic_animation: new_pic)
+  end
+end

--- a/console-frontend/src/app/resources/personas/create.js
+++ b/console-frontend/src/app/resources/personas/create.js
@@ -9,8 +9,9 @@ const loadFormObject = () => {
     name: '',
     description: '',
     profilePic: { url: '' },
+    profilePicAnimation: { url: '' },
     instagramUrl: '',
-    picRect: '',
+    picRect: {},
   }
 }
 

--- a/console-frontend/src/app/resources/pictures/list.js
+++ b/console-frontend/src/app/resources/pictures/list.js
@@ -1,25 +1,17 @@
 import BlankStateTemplate from 'shared/blank-state'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { ActiveColumn, EnhancedList, Picture, TableCell, Text } from 'shared/table-elements'
 import { apiPictureDestroy, apiPictureList } from 'utils'
 
 const columns = [
   { name: 'id', label: 'id', sortable: true },
   { name: 'picture' },
+  { name: 'type', label: 'type', sortable: true },
   { name: 'url', label: 'url', sortable: true },
   { name: 'status', label: 'status', sortable: true },
 ]
 
-const BlankState = () => (
-  <BlankStateTemplate
-    // buttonText="Upload new"
-    // description="You don't have any picture yet. Let's add some?"
-    imageSource="/img/background/img-welcome.png"
-    // route={routes.pictureCreate()}
-    // title="Add new pictures"
-    title="No pictures yet"
-  />
-)
+const BlankState = () => <BlankStateTemplate imageSource="/img/background/img-welcome.png" title="No pictures yet" />
 
 const tooltipTextActive = ({ personas, productPicks, simpleChatMessages }) => {
   const itemsInUse = []
@@ -33,25 +25,39 @@ const tooltipTextActive = ({ personas, productPicks, simpleChatMessages }) => {
   )}`
 }
 
-const PicturesRow = ({ record, highlightInactive }) => (
-  <>
-    <TableCell>
-      <Picture disabled={highlightInactive} src={record.url} />
-    </TableCell>
-    <TableCell width="100%">
-      <Text disabled={highlightInactive} style={{ wordBreak: 'break-all' }}>
-        {record.url}
-      </Text>
-    </TableCell>
-    <ActiveColumn
-      highlightInactive={highlightInactive}
-      symbolTextActive="In use"
-      symbolTextInactive="Not in use"
-      tooltipTextActive={tooltipTextActive(record)}
-      tooltipTextInactive="Not used yet"
-    />
-  </>
-)
+const PicturesRow = ({ record, highlightInactive }) => {
+  const recordType = useMemo(
+    () =>
+      record.url
+        .split('.')
+        .pop()
+        .toUpperCase(),
+    [record.url]
+  )
+
+  return (
+    <>
+      <TableCell width="5%">
+        <Picture disabled={highlightInactive} src={record.url} />
+      </TableCell>
+      <TableCell width="10%">
+        <Text disabled={highlightInactive}>{recordType}</Text>
+      </TableCell>
+      <TableCell width="85%">
+        <Text disabled={highlightInactive} style={{ wordBreak: 'break-all' }}>
+          {record.url}
+        </Text>
+      </TableCell>
+      <ActiveColumn
+        highlightInactive={highlightInactive}
+        symbolTextActive="In use"
+        symbolTextInactive="Not in use"
+        tooltipTextActive={tooltipTextActive(record)}
+        tooltipTextInactive="Not used yet"
+      />
+    </>
+  )
+}
 
 const api = { fetch: apiPictureList, destroy: apiPictureDestroy }
 const picturesRoutes = {}

--- a/console-frontend/src/app/resources/showcases/create.js
+++ b/console-frontend/src/app/resources/showcases/create.js
@@ -22,7 +22,7 @@ const loadFormObject = () => {
             description: '',
             displayPrice: '',
             picture: { url: '' },
-            picRect: '',
+            picRect: {},
             __key: 'new-0',
           },
         ],

--- a/console-frontend/src/app/resources/showcases/form/data-utils.js
+++ b/console-frontend/src/app/resources/showcases/form/data-utils.js
@@ -85,7 +85,7 @@ const formObjectTransformer = json => {
             description: productPick.description || '',
             displayPrice: productPick.displayPrice || '',
             picture: productPick.picture || { url: '' },
-            picRect: productPick.picRect || '',
+            picRect: productPick.picRect || {},
             __key: productPick.__key,
           }))
         : [
@@ -95,7 +95,7 @@ const formObjectTransformer = json => {
               description: '',
               displayPrice: '',
               picture: { url: '' },
-              picRect: '',
+              picRect: {},
               __key: 'new-0',
             },
           ],

--- a/console-frontend/src/app/resources/showcases/form/form-container.js
+++ b/console-frontend/src/app/resources/showcases/form/form-container.js
@@ -5,29 +5,32 @@ import Spotlights from './spotlights'
 import { AddItemContainer, Form } from 'shared/form-elements'
 
 const FormContainer = ({
-  selectPersona,
-  onSpotlightClick,
+  addSpotlight,
   form,
   formRef,
+  isCropping,
   isFormLoading,
   isFormPristine,
-  onFormSubmit,
-  setFieldValue,
-  setSpotlightForm,
-  addSpotlight,
-  isCropping,
-  setIsCropping,
+  isUploaderLoading,
   onBackClick,
-  title,
+  onFormSubmit,
   onSortEnd,
-  personas,
   onToggleContent,
+  onSpotlightClick,
+  personas,
+  selectPersona,
+  setFieldValue,
+  setIsCropping,
+  setIsUploaderLoading,
+  setSpotlightForm,
+  title,
 }) => (
   <Form formRef={formRef} isFormPristine={isFormPristine} onSubmit={onFormSubmit}>
     <MainForm
       form={omit(form, ['spotlightsAttributes'])}
       isCropping={isCropping}
       isFormLoading={isFormLoading}
+      isUploaderLoading={isUploaderLoading}
       onBackClick={onBackClick}
       onToggleContent={onToggleContent}
       selectPersona={selectPersona}
@@ -38,16 +41,22 @@ const FormContainer = ({
       helperClass="sortable-element"
       isCropping={isCropping}
       isFormLoading={isFormLoading}
+      isUploaderLoading={isUploaderLoading}
       onSortEnd={onSortEnd}
       onSpotlightClick={onSpotlightClick}
       onToggleContent={onToggleContent}
       personas={personas}
       setIsCropping={setIsCropping}
+      setIsUploaderLoading={setIsUploaderLoading}
       setSpotlightForm={setSpotlightForm}
       spotlightsAttributes={form.spotlightsAttributes}
       useDragHandle
     />
-    <AddItemContainer disabled={isCropping || isFormLoading} message="Add new spotlight" onClick={addSpotlight} />
+    <AddItemContainer
+      disabled={isCropping || isFormLoading || isUploaderLoading}
+      message="Add new spotlight"
+      onClick={addSpotlight}
+    />
   </Form>
 )
 

--- a/console-frontend/src/app/resources/showcases/form/index.js
+++ b/console-frontend/src/app/resources/showcases/form/index.js
@@ -26,8 +26,9 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
 
   const formRef = useRef()
   const [isCropping, setIsCropping] = useState(false)
-  const [showingContent, setShowingContent] = useState(false)
   const [isPreviewModalOpened, setIsPreviewModalOpened] = useState(false)
+  const [isUploaderLoading, setIsUploaderLoading] = useState(false)
+  const [showingContent, setShowingContent] = useState(false)
 
   const {
     form,
@@ -82,7 +83,7 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
                 description: '',
                 displayPrice: '',
                 picture: { url: '' },
-                picRect: '',
+                picRect: {},
                 __key: 'new-0',
               },
             ],
@@ -165,7 +166,7 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
           onFormSubmit={newOnFormSubmit}
           onPreviewClick={onPreviewClick}
           previewEnabled={!!form.id}
-          saveDisabled={isFormSubmitting || isCropping || isFormLoading || isFormPristine}
+          saveDisabled={isFormSubmitting || isCropping || isFormLoading || isFormPristine || isUploaderLoading}
           tooltipEnabled
           tooltipText="No changes to save"
         />
@@ -180,6 +181,7 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
       isFormLoading,
       isFormPristine,
       isFormSubmitting,
+      isUploaderLoading,
       newOnFormSubmit,
       onPreviewClick,
       title,
@@ -211,6 +213,7 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
             isCropping={isCropping}
             isFormLoading={isFormLoading}
             isFormPristine={isFormPristine}
+            isUploaderLoading={isUploaderLoading}
             onBackClick={onBackClick}
             onFormSubmit={newOnFormSubmit}
             onSortEnd={onSortEnd}
@@ -219,6 +222,7 @@ const ShowcaseForm = ({ backRoute, history, loadFormObject, location, saveFormOb
             selectPersona={selectPersona}
             setFieldValue={setFieldValue}
             setIsCropping={setIsCropping}
+            setIsUploaderLoading={setIsUploaderLoading}
             setSpotlightForm={setSpotlightForm}
             title={title}
           />

--- a/console-frontend/src/app/resources/showcases/form/main-form.js
+++ b/console-frontend/src/app/resources/showcases/form/main-form.js
@@ -8,14 +8,15 @@ import { Field, FormHelperText } from 'shared/form-elements'
 const options = { suggestionItem: 'withAvatar' }
 
 const MainForm = ({
-  title,
-  isCropping,
-  setFieldValue,
-  onBackClick,
   form,
+  isCropping,
   isFormLoading,
-  selectPersona,
+  isUploaderLoading,
+  onBackClick,
   onToggleContent,
+  selectPersona,
+  setFieldValue,
+  title,
 }) => {
   const onFocus = useCallback(() => onToggleContent(false), [onToggleContent])
 
@@ -27,7 +28,7 @@ const MainForm = ({
     <Section title={title}>
       <Field
         autoFocus
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Name"
@@ -42,7 +43,7 @@ const MainForm = ({
       <Autocomplete
         autocomplete={apiPersonasAutocomplete}
         defaultPlaceholder="Choose a persona"
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         initialSelectedItem={initialSelectedItem}
         label="Persona"
@@ -53,7 +54,7 @@ const MainForm = ({
       />
       <FormHelperText>{'The persona will appear in the launcher, and in the cover.'}</FormHelperText>
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Title"
@@ -67,7 +68,7 @@ const MainForm = ({
       />
       <FormHelperText>{'The title is shown in the cover.'}</FormHelperText>
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Subtitle"
@@ -81,7 +82,7 @@ const MainForm = ({
       />
       <FormHelperText>{'The subtitle is shown in the cover, below the title.'}</FormHelperText>
       <Field
-        disabled={isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         label="Chat Bubble Text"
         margin="normal"
@@ -93,7 +94,7 @@ const MainForm = ({
       />
       <FormHelperText>{'Shows as a text bubble next to the plugin launcher.'}</FormHelperText>
       <Field
-        disabled={isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         label="Extra Chat Bubble Text"
         margin="normal"

--- a/console-frontend/src/app/resources/showcases/form/product-pick.js
+++ b/console-frontend/src/app/resources/showcases/form/product-pick.js
@@ -6,14 +6,16 @@ import { Cancel, Field, FormHelperText, FormSection } from 'shared/form-elements
 
 const ProductPick = ({
   allowDelete,
+  folded,
+  index,
   isCropping,
   isFormLoading,
-  index,
-  setProductPickForm,
+  isUploaderLoading,
   onFocus,
-  folded,
   productPick,
   setIsCropping,
+  setIsUploaderLoading,
+  setProductPickForm,
 }) => {
   const onChange = useCallback(
     newProductPickCallback => {
@@ -49,7 +51,13 @@ const ProductPick = ({
   return (
     <FormSection
       actions={
-        allowDelete && <Cancel disabled={isCropping || isFormLoading} index={index} onClick={deleteProductPick} />
+        allowDelete && (
+          <Cancel
+            disabled={isCropping || isFormLoading || isUploaderLoading}
+            index={index}
+            onClick={deleteProductPick}
+          />
+        )
       }
       backgroundColor="#fff"
       dragHandle
@@ -61,7 +69,7 @@ const ProductPick = ({
       title={productPick.id ? productPick.name : 'New Product Pick'}
     >
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Url"
@@ -79,7 +87,7 @@ const ProductPick = ({
         }
       </FormHelperText>
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Name"
@@ -92,7 +100,7 @@ const ProductPick = ({
         value={productPick.name}
       />
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Description"
@@ -105,7 +113,7 @@ const ProductPick = ({
         value={productPick.description}
       />
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Display Price"
@@ -118,11 +126,12 @@ const ProductPick = ({
       />
       <PictureUploader
         aspectRatio={1}
-        disabled={isCropping}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         label="Picture"
         onChange={setPicture}
         required
         setDisabled={setIsCropping}
+        setIsUploaderLoading={setIsUploaderLoading}
         value={{ url: productPick.picture.url, picRect: productPick.picRect }}
       />
     </FormSection>

--- a/console-frontend/src/app/resources/showcases/form/product-picks.js
+++ b/console-frontend/src/app/resources/showcases/form/product-picks.js
@@ -5,13 +5,15 @@ import { SortableContainer, SortableElement } from 'shared/sortable-elements'
 const SortableProductPick = SortableElement(ProductPick)
 
 const ProductPicks = ({
-  isFormLoading,
   isCropping,
-  setIsCropping,
-  productPicksAttributes,
-  setProductPickForm,
+  isFormLoading,
+  isUploaderLoading,
   onFocus,
   personaId,
+  productPicksAttributes,
+  setIsCropping,
+  setIsUploaderLoading,
+  setProductPickForm,
 }) => {
   const allowDelete = useMemo(() => productPicksAttributes.filter(productPick => !productPick._destroy).length > 1, [
     productPicksAttributes,
@@ -27,11 +29,13 @@ const ProductPicks = ({
             index={index}
             isCropping={isCropping}
             isFormLoading={isFormLoading}
+            isUploaderLoading={isUploaderLoading}
             key={productPick.id || productPick.__key}
             onFocus={onFocus}
             personaId={personaId}
             productPick={productPick}
             setIsCropping={setIsCropping}
+            setIsUploaderLoading={setIsUploaderLoading}
             setProductPickForm={setProductPickForm}
             sortIndex={index}
           />

--- a/console-frontend/src/app/resources/showcases/form/spotlight.js
+++ b/console-frontend/src/app/resources/showcases/form/spotlight.js
@@ -14,8 +14,10 @@ const Spotlight = ({
   index,
   isCropping,
   isFormLoading,
+  isUploaderLoading,
   onSpotlightClick,
   setIsCropping,
+  setIsUploaderLoading,
   setSpotlightForm,
   spotlight,
 }) => {
@@ -48,7 +50,7 @@ const Spotlight = ({
             description: '',
             displayPrice: '',
             picture: { url: '' },
-            picRect: '',
+            picRect: {},
             __key: `new-${spotlight.productPicksAttributes.length}`,
           },
         ],
@@ -101,7 +103,13 @@ const Spotlight = ({
     <Section>
       <FormSection
         actions={
-          allowDelete && <Cancel disabled={isCropping || isFormLoading} index={index} onClick={deleteSpotlight} />
+          allowDelete && (
+            <Cancel
+              disabled={isCropping || isFormLoading || isUploaderLoading}
+              index={index}
+              onClick={deleteSpotlight}
+            />
+          )
         }
         dragHandle
         ellipsize
@@ -113,7 +121,7 @@ const Spotlight = ({
         <Autocomplete
           autocomplete={apiPersonasAutocomplete}
           defaultPlaceholder="Choose a persona"
-          disabled={isCropping || isFormLoading}
+          disabled={isCropping || isFormLoading || isUploaderLoading}
           fullWidth
           initialSelectedItem={initialSelectedItem}
           label="Persona"
@@ -129,16 +137,22 @@ const Spotlight = ({
                 helperClass="sortable-element"
                 isCropping={isCropping}
                 isFormLoading={isFormLoading}
+                isUploaderLoading={isUploaderLoading}
                 onFocus={onFocus}
                 onSortEnd={onSortEnd}
                 personaId={spotlight.personaId}
                 productPicksAttributes={spotlight.productPicksAttributes}
                 setIsCropping={setIsCropping}
+                setIsUploaderLoading={setIsUploaderLoading}
                 setProductPickForm={setProductPickForm}
                 useDragHandle
               />
             )}
-            <AddItemButton disabled={isCropping || isFormLoading} message="Add Product Pick" onClick={addProductPick} />{' '}
+            <AddItemButton
+              disabled={isCropping || isFormLoading || isUploaderLoading}
+              message="Add Product Pick"
+              onClick={addProductPick}
+            />{' '}
           </FormSection>
         </div>
       </FormSection>

--- a/console-frontend/src/app/resources/showcases/form/spotlights.js
+++ b/console-frontend/src/app/resources/showcases/form/spotlights.js
@@ -5,13 +5,15 @@ import { SortableContainer, SortableElement } from 'shared/sortable-elements'
 const SortableSpotlight = SortableElement(Spotlight)
 
 const Spotlights = ({
-  isFormLoading,
   isCropping,
-  setIsCropping,
-  spotlightsAttributes,
-  personas,
-  setSpotlightForm,
+  isFormLoading,
+  isUploaderLoading,
   onSpotlightClick,
+  personas,
+  setIsCropping,
+  setIsUploaderLoading,
+  setSpotlightForm,
+  spotlightsAttributes,
 }) => {
   const allowDelete = useMemo(() => spotlightsAttributes.filter(spotlight => !spotlight._destroy).length > 1, [
     spotlightsAttributes,
@@ -27,10 +29,12 @@ const Spotlights = ({
             index={index}
             isCropping={isCropping}
             isFormLoading={isFormLoading}
+            isUploaderLoading={isUploaderLoading}
             key={spotlight.id || spotlight.__key}
             onSpotlightClick={onSpotlightClick}
             personas={personas}
             setIsCropping={setIsCropping}
+            setIsUploaderLoading={setIsUploaderLoading}
             setSpotlightForm={setSpotlightForm}
             sortIndex={index}
             spotlight={spotlight}

--- a/console-frontend/src/app/resources/simple-chats/form/form-container.js
+++ b/console-frontend/src/app/resources/simple-chats/form/form-container.js
@@ -14,12 +14,14 @@ const FormContainer = ({
   isFormLoading,
   isFormPristine,
   isFormSubmitting,
+  isUploaderLoading,
   onFormSubmit,
   onSortEnd,
   onToggleContent,
   selectPersona,
   setFieldValue,
   setIsCropping,
+  setIsUploaderLoading,
   setSimpleChatStepsForm,
   title,
 }) => {
@@ -30,7 +32,7 @@ const FormContainer = ({
           isFormPristine={isFormPristine}
           isFormSubmitting={isFormSubmitting}
           onFormSubmit={onFormSubmit}
-          saveDisabled={isFormSubmitting || isFormLoading || isFormPristine}
+          saveDisabled={isFormSubmitting || isFormLoading || isFormPristine || isUploaderLoading}
           tooltipEnabled
           tooltipText="No changes to save"
         />
@@ -38,7 +40,7 @@ const FormContainer = ({
       backRoute,
       title,
     }),
-    [backRoute, isFormLoading, isFormPristine, isFormSubmitting, onFormSubmit, title]
+    [backRoute, isFormLoading, isFormPristine, isFormSubmitting, isUploaderLoading, onFormSubmit, title]
   )
   useAppBarContent(appBarContent)
 
@@ -50,6 +52,7 @@ const FormContainer = ({
         form={mainForm}
         isCropping={isCropping}
         isFormLoading={isFormLoading}
+        isUploaderLoading={isUploaderLoading}
         onToggleContent={onToggleContent}
         selectPersona={selectPersona}
         setFieldValue={setFieldValue}
@@ -60,10 +63,12 @@ const FormContainer = ({
         helperClass="sortable-element"
         isCropping={isCropping}
         isFormLoading={isFormLoading}
+        isUploaderLoading={isUploaderLoading}
         onChange={setSimpleChatStepsForm}
         onSortEnd={onSortEnd}
         onToggleContent={onToggleContent}
         setIsCropping={setIsCropping}
+        setIsUploaderLoading={setIsUploaderLoading}
         simpleChatSteps={form.simpleChatStepsAttributes}
         useDragHandle
       />

--- a/console-frontend/src/app/resources/simple-chats/form/index.js
+++ b/console-frontend/src/app/resources/simple-chats/form/index.js
@@ -21,8 +21,9 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
 
   const formRef = useRef()
   const [isCropping, setIsCropping] = useState(false)
-  const [showingContent, setShowingContent] = useState(false)
   const [isPreviewModalOpened, setIsPreviewModalOpened] = useState(false)
+  const [isUploaderLoading, setIsUploaderLoading] = useState(false)
+  const [showingContent, setShowingContent] = useState(false)
 
   const {
     form,
@@ -122,7 +123,7 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
           onFormSubmit={newOnFormSubmit}
           onPreviewClick={onPreviewClick}
           previewEnabled={!!form.id}
-          saveDisabled={isFormSubmitting || isFormLoading || isFormPristine}
+          saveDisabled={isFormSubmitting || isFormLoading || isFormPristine || isUploaderLoading}
           tooltipEnabled
           tooltipText="No changes to save"
         />
@@ -130,7 +131,17 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
       backRoute,
       title,
     }),
-    [backRoute, form.id, isFormLoading, isFormPristine, isFormSubmitting, newOnFormSubmit, onPreviewClick, title]
+    [
+      backRoute,
+      form.id,
+      isFormLoading,
+      isFormPristine,
+      isFormSubmitting,
+      isUploaderLoading,
+      newOnFormSubmit,
+      onPreviewClick,
+      title,
+    ]
   )
   useAppBarContent(appBarContent)
 
@@ -152,12 +163,14 @@ const SimpleChatForm = ({ backRoute, history, location, loadFormObject, saveForm
             isFormLoading={isFormLoading}
             isFormPristine={isFormPristine}
             isFormSubmitting={isFormSubmitting}
+            isUploaderLoading={isUploaderLoading}
             onFormSubmit={newOnFormSubmit}
             onSortEnd={onSortEnd}
             onToggleContent={onToggleContent}
             selectPersona={selectPersona}
             setFieldValue={setFieldValue}
             setIsCropping={setIsCropping}
+            setIsUploaderLoading={setIsUploaderLoading}
             setSimpleChatStepsForm={setSimpleChatStepsForm}
             title={title}
           />

--- a/console-frontend/src/app/resources/simple-chats/form/main-form.js
+++ b/console-frontend/src/app/resources/simple-chats/form/main-form.js
@@ -7,7 +7,16 @@ import { Field, FormHelperText } from 'shared/form-elements'
 
 const options = { suggestionItem: 'withAvatar' }
 
-const MainForm = ({ title, isFormLoading, form, setFieldValue, selectPersona, onToggleContent, isCropping }) => {
+const MainForm = ({
+  form,
+  isCropping,
+  isFormLoading,
+  isUploaderLoading,
+  onToggleContent,
+  selectPersona,
+  setFieldValue,
+  title,
+}) => {
   const onFocus = useCallback(() => onToggleContent(false), [onToggleContent])
   const onTitleFocus = useCallback(() => onToggleContent(true), [onToggleContent])
 
@@ -18,7 +27,7 @@ const MainForm = ({ title, isFormLoading, form, setFieldValue, selectPersona, on
   return (
     <Section title={title}>
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Name"
@@ -32,7 +41,7 @@ const MainForm = ({ title, isFormLoading, form, setFieldValue, selectPersona, on
       <Autocomplete
         autocomplete={apiPersonasAutocomplete}
         defaultPlaceholder="Choose a persona"
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         initialSelectedItem={initialSelectedItem}
         label="Persona"
@@ -42,7 +51,7 @@ const MainForm = ({ title, isFormLoading, form, setFieldValue, selectPersona, on
       />
       <FormHelperText>{'The persona that will appear for this chat.'}</FormHelperText>
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}
         label="Title"
@@ -55,7 +64,7 @@ const MainForm = ({ title, isFormLoading, form, setFieldValue, selectPersona, on
       />
       <FormHelperText>{'The title will appear at the top of the chat.'}</FormHelperText>
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         label="Chat Bubble"
         margin="normal"
@@ -67,7 +76,7 @@ const MainForm = ({ title, isFormLoading, form, setFieldValue, selectPersona, on
       />
       <FormHelperText>{'Shows as a text bubble next to the plugin launcher.'}</FormHelperText>
       <Field
-        disabled={isCropping || isFormLoading}
+        disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         label="Extra Chat Bubble Text"
         margin="normal"

--- a/console-frontend/src/app/resources/simple-chats/form/picture-message-field.js
+++ b/console-frontend/src/app/resources/simple-chats/form/picture-message-field.js
@@ -5,23 +5,26 @@ import { Checkbox, FormControlLabel } from '@material-ui/core'
 const PictureMessageForm = ({
   isCropping,
   isFormLoading,
-  progress,
-  setIsCropping,
-  setPicture,
   isNextSameType,
   isPreviousSameType,
+  isUploaderLoading,
+  progress,
+  setIsCropping,
+  setIsUploaderLoading,
+  setPicture,
   simpleChatMessage,
   onFormChange,
 }) => (
   <>
     <PictureUploader
       aspectRatio={1}
-      disabled={isCropping}
+      disabled={isCropping || isFormLoading || isUploaderLoading}
       label="Picture"
       name="picUrl"
       onChange={setPicture}
       required
       setDisabled={setIsCropping}
+      setIsUploaderLoading={setIsUploaderLoading}
       value={{ url: simpleChatMessage.picture.url, picRect: simpleChatMessage.picRect }}
     />
     {progress && <ProgressBar progress={progress} />}
@@ -42,11 +45,14 @@ const PictureMessageForm = ({
 )
 
 const PictureMessageField = ({
-  onChange,
-  setIsCropping,
-  simpleChatMessage,
+  isCropping,
   isNextSameType,
   isPreviousSameType,
+  isUploaderLoading,
+  onChange,
+  setIsCropping,
+  setIsUploaderLoading,
+  simpleChatMessage,
   simpleChatMessageIndex,
 }) => {
   const onFormChange = useCallback(
@@ -72,10 +78,13 @@ const PictureMessageField = ({
 
   return (
     <PictureMessageForm
+      isCropping={isCropping}
       isNextSameType={isNextSameType}
       isPreviousSameType={isPreviousSameType}
+      isUploaderLoading={isUploaderLoading}
       onFormChange={onFormChange}
       setIsCropping={setIsCropping}
+      setIsUploaderLoading={setIsUploaderLoading}
       setPicture={setPicture}
       simpleChatMessage={simpleChatMessage}
     />

--- a/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
+++ b/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
@@ -6,18 +6,20 @@ import { Field, FormHelperText } from 'shared/form-elements'
 const ProductMessagesForm = ({
   isCropping,
   isFormLoading,
+  isNextSameType,
+  isPreviousSameType,
+  isUploaderLoading,
   onFocus,
   onFormChange,
   progress,
   setIsCropping,
-  isNextSameType,
-  isPreviousSameType,
-  simpleChatMessage,
+  setIsUploaderLoading,
   setPicture,
+  simpleChatMessage,
 }) => (
   <>
     <Field
-      disabled={isCropping || isFormLoading}
+      disabled={isCropping || isFormLoading || isUploaderLoading}
       fullWidth
       label="Title"
       margin="normal"
@@ -28,7 +30,7 @@ const ProductMessagesForm = ({
       value={simpleChatMessage.title || ''}
     />
     <Field
-      disabled={isCropping || isFormLoading}
+      disabled={isCropping || isFormLoading || isUploaderLoading}
       fullWidth
       label="Url"
       margin="normal"
@@ -41,7 +43,7 @@ const ProductMessagesForm = ({
     />
     <FormHelperText>{'Use the whole url, eg: https://www.example.com/page1'}</FormHelperText>
     <Field
-      disabled={isCropping || isFormLoading}
+      disabled={isCropping || isFormLoading || isUploaderLoading}
       fullWidth
       label="Display Price"
       margin="normal"
@@ -52,12 +54,13 @@ const ProductMessagesForm = ({
       value={simpleChatMessage.displayPrice || ''}
     />
     <PictureUploader
-      disabled={isCropping}
+      disabled={isCropping || isFormLoading || isUploaderLoading}
       label="Picture"
       name="picUrl"
       onChange={setPicture}
       required
       setDisabled={setIsCropping}
+      setIsUploaderLoading={setIsUploaderLoading}
       value={{ url: simpleChatMessage.picture.url, picRect: simpleChatMessage.picRect }}
     />
     {progress && <ProgressBar progress={progress} />}
@@ -78,12 +81,15 @@ const ProductMessagesForm = ({
 )
 
 const ProductMessageFields = ({
+  isCropping,
   isFormLoading,
+  isNextSameType,
+  isPreviousSameType,
+  isUploaderLoading,
   onChange,
   onFocus,
   setIsCropping,
-  isNextSameType,
-  isPreviousSameType,
+  setIsUploaderLoading,
   simpleChatMessage,
   simpleChatMessageIndex,
 }) => {
@@ -112,12 +118,15 @@ const ProductMessageFields = ({
 
   return (
     <ProductMessagesForm
+      isCropping={isCropping}
       isFormLoading={isFormLoading}
       isNextSameType={isNextSameType}
       isPreviousSameType={isPreviousSameType}
+      isUploaderLoading={isUploaderLoading}
       onFocus={onFocus}
       onFormChange={onFormChange}
       setIsCropping={setIsCropping}
+      setIsUploaderLoading={setIsUploaderLoading}
       setPicture={setPicture}
       simpleChatMessage={simpleChatMessage}
     />

--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-message.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-message.js
@@ -27,11 +27,13 @@ const setSimpleChatMessageTitle = simpleChatMessage => {
 const MessageField = ({
   isCropping,
   isFormLoading,
+  isNextSameType,
+  isPreviousSameType,
+  isUploaderLoading,
   onFocus,
   onSimpleChatMessageEdit,
   setIsCropping,
-  isNextSameType,
-  isPreviousSameType,
+  setIsUploaderLoading,
   simpleChatMessage,
   simpleChatMessageIndex,
 }) => {
@@ -39,7 +41,7 @@ const MessageField = ({
     case 'SimpleChatTextMessage':
       return (
         <TextMessageFields
-          disabled={isFormLoading}
+          disabled={isFormLoading || isUploaderLoading}
           name="simpleChatMessage_text"
           onChange={onSimpleChatMessageEdit}
           onFocus={onFocus}
@@ -54,10 +56,12 @@ const MessageField = ({
           isFormLoading={isFormLoading}
           isNextSameType={isNextSameType}
           isPreviousSameType={isPreviousSameType}
+          isUploaderLoading={isUploaderLoading}
           name="simpleChatMessage_product"
           onChange={onSimpleChatMessageEdit}
           onFocus={onFocus}
           setIsCropping={setIsCropping}
+          setIsUploaderLoading={setIsUploaderLoading}
           simpleChatMessage={simpleChatMessage}
           simpleChatMessageIndex={simpleChatMessageIndex}
         />
@@ -65,7 +69,7 @@ const MessageField = ({
     case 'SimpleChatVideoMessage':
       return (
         <VideoMessageField
-          isFormLoading={isFormLoading}
+          disabled={isFormLoading || isUploaderLoading}
           name="simpleChatMessage_video"
           onChange={onSimpleChatMessageEdit}
           onFocus={onFocus}
@@ -79,9 +83,11 @@ const MessageField = ({
           isCropping={isCropping}
           isNextSameType={isNextSameType}
           isPreviousSameType={isPreviousSameType}
+          isUploaderLoading={isUploaderLoading}
           name="simpleChatMessage_picture"
           onChange={onSimpleChatMessageEdit}
           setIsCropping={setIsCropping}
+          setIsUploaderLoading={setIsUploaderLoading}
           simpleChatMessage={simpleChatMessage}
           simpleChatMessageIndex={simpleChatMessageIndex}
         />
@@ -95,9 +101,11 @@ const SimpleChatMessage = ({
   allowDelete,
   isCropping,
   isFormLoading,
+  isUploaderLoading,
   onChange,
   onFocus,
   setIsCropping,
+  setIsUploaderLoading,
   simpleChatMessage,
   activeSimpleChatMessages,
   simpleChatMessageIndex,
@@ -178,9 +186,11 @@ const SimpleChatMessage = ({
         isFormLoading={isFormLoading}
         isNextSameType={isNextSameType}
         isPreviousSameType={isPreviousSameType}
+        isUploaderLoading={isUploaderLoading}
         onFocus={onFocus}
         onSimpleChatMessageEdit={onSimpleChatMessageEdit}
         setIsCropping={setIsCropping}
+        setIsUploaderLoading={setIsUploaderLoading}
         simpleChatMessage={simpleChatMessage}
         simpleChatMessageIndex={simpleChatMessageIndex}
       />

--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
@@ -60,13 +60,15 @@ const StyledMenu = styled(Menu)`
 const SortableSimpleChatMessage = SortableElement(SimpleChatMessage)
 
 const SimpleChatMessages = ({
+  activeSimpleChatMessages,
   allowDelete,
   isCropping,
+  isUploaderLoading,
   onChange,
   onFocus,
   setIsCropping,
+  setIsUploaderLoading,
   simpleChatMessages,
-  activeSimpleChatMessages,
 }) => (
   <div>
     {simpleChatMessages.map((simpleChatMessage, index) =>
@@ -76,10 +78,12 @@ const SimpleChatMessages = ({
           allowDelete={allowDelete}
           index={index}
           isCropping={isCropping}
+          isUploaderLoading={isUploaderLoading}
           key={simpleChatMessage.id || simpleChatMessage.__key}
           onChange={onChange}
           onFocus={onFocus}
           setIsCropping={setIsCropping}
+          setIsUploaderLoading={setIsUploaderLoading}
           simpleChatMessage={simpleChatMessage}
           simpleChatMessageIndex={index}
         />
@@ -96,9 +100,11 @@ const SimpleChatStep = ({
   folded,
   isCropping,
   isFormLoading,
+  isUploaderLoading,
   onChange,
   onToggleContent,
   setIsCropping,
+  setIsUploaderLoading,
   simpleChatStep,
   simpleChatStepIndex,
 }) => {
@@ -159,10 +165,10 @@ const SimpleChatStep = ({
         messageType === 'SimpleChatTextMessage'
           ? { html: '' }
           : messageType === 'SimpleChatProductMessage'
-          ? { title: '', picture: { url: '' }, picRect: '', url: '', displayPrice: '', groupWithAdjacent: false }
+          ? { title: '', picture: { url: '' }, picRect: {}, url: '', displayPrice: '', groupWithAdjacent: false }
           : messageType === 'SimpleChatVideoMessage'
           ? { videoUrl: '' }
-          : { picture: { url: '' }, picRect: '', groupWithAdjacent: false }
+          : { picture: { url: '' }, picRect: {}, groupWithAdjacent: false }
       onChange(
         {
           ...simpleChatStep,
@@ -193,7 +199,11 @@ const SimpleChatStep = ({
       <FormSection
         actions={
           allowDelete && (
-            <Cancel disabled={isCropping || isFormLoading} index={simpleChatStepIndex} onClick={deleteSimpleChatStep} />
+            <Cancel
+              disabled={isCropping || isFormLoading || isUploaderLoading}
+              index={simpleChatStepIndex}
+              onClick={deleteSimpleChatStep}
+            />
           )
         }
         dragHandle
@@ -208,7 +218,7 @@ const SimpleChatStep = ({
         <>
           {simpleChatStep.key !== 'default' && (
             <Field
-              disabled={isCropping || isFormLoading}
+              disabled={isCropping || isFormLoading || isUploaderLoading}
               fullWidth
               inputProps={atLeastOneNonBlankCharInputProps}
               label="Option"
@@ -227,10 +237,12 @@ const SimpleChatStep = ({
               helperClass="sortable-element"
               isCropping={isCropping}
               isFormLoading={isFormLoading}
+              isUploaderLoading={isUploaderLoading}
               onChange={setSimpleChatMessagesForm}
               onFocus={onFocus}
               onSortEnd={onSimpleChatMessagesSortEnd}
               setIsCropping={setIsCropping}
+              setIsUploaderLoading={setIsUploaderLoading}
               simpleChatMessages={simpleChatStep.simpleChatMessagesAttributes}
               useDragHandle
             />
@@ -242,7 +254,7 @@ const SimpleChatStep = ({
             }
             aria-haspopup="true"
             aria-owns={anchorEl ? 'new-message-menu' : undefined}
-            disabled={isFormLoading}
+            disabled={isFormLoading || isUploaderLoading}
             message="Add Message"
             onClick={onAddMessageClick}
           />

--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-steps.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-steps.js
@@ -4,14 +4,25 @@ import { SortableContainer, SortableElement } from 'shared/sortable-elements'
 
 const SortableSimpleChatStep = SortableElement(SimpleChatStep)
 
-const SimpleChatSteps = ({ allowDelete, isCropping, onChange, onToggleContent, setIsCropping, simpleChatSteps }) => (
+const SimpleChatSteps = ({
+  allowDelete,
+  isCropping,
+  isUploaderLoading,
+  onChange,
+  onToggleContent,
+  setIsCropping,
+  setIsUploaderLoading,
+  simpleChatSteps,
+}) => (
   <div>
     <SimpleChatStep
       allowDelete={false}
       isCropping={isCropping}
+      isUploaderLoading={isUploaderLoading}
       onChange={onChange}
       onToggleContent={onToggleContent}
       setIsCropping={setIsCropping}
+      setIsUploaderLoading={setIsUploaderLoading}
       simpleChatStep={simpleChatSteps[0]}
       simpleChatStepIndex={0}
     />
@@ -23,10 +34,12 @@ const SimpleChatSteps = ({ allowDelete, isCropping, onChange, onToggleContent, s
             allowDelete={allowDelete}
             index={index + 1}
             isCropping={isCropping}
+            isUploaderLoading={isUploaderLoading}
             key={simpleChatStep.id || simpleChatStep.__key}
             onChange={onChange}
             onToggleContent={onToggleContent}
             setIsCropping={setIsCropping}
+            setIsUploaderLoading={setIsUploaderLoading}
             simpleChatStep={simpleChatStep}
             simpleChatStepIndex={index + 1}
           />

--- a/console-frontend/src/app/resources/simple-chats/form/video-message-field.js
+++ b/console-frontend/src/app/resources/simple-chats/form/video-message-field.js
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import { Field } from 'shared/form-elements'
 import { youtubeInputProps } from 'utils'
 
-const VideoMessageField = ({ isFormLoading, name, onChange, onFocus, simpleChatMessage, simpleChatMessageIndex }) => {
+const VideoMessageField = ({ disabled, name, onChange, onFocus, simpleChatMessage, simpleChatMessageIndex }) => {
   const onValueChange = useCallback(
     event => {
       onChange({ ...simpleChatMessage, videoUrl: event.target.value || '' }, simpleChatMessageIndex)
@@ -12,7 +12,7 @@ const VideoMessageField = ({ isFormLoading, name, onChange, onFocus, simpleChatM
 
   return (
     <Field
-      disabled={isFormLoading}
+      disabled={disabled}
       fullWidth
       inputProps={youtubeInputProps}
       label="YouTube URL"

--- a/console-frontend/src/app/screens/account/edit-me.js
+++ b/console-frontend/src/app/screens/account/edit-me.js
@@ -18,7 +18,7 @@ const formObjectTransformer = json => {
     firstName: json.firstName || '',
     lastName: json.lastName || '',
     profilePicUrl: json.profilePicUrl || '',
-    picRect: json.picRect || '',
+    picRect: json.picRect || {},
   }
 }
 
@@ -28,6 +28,7 @@ const EditMe = () => {
   const { enqueueSnackbar } = useSnackbar()
 
   const [isCropping, setIsCropping] = useState(false)
+  const [isUploaderLoading, setIsUploaderLoading] = useState(false)
 
   const saveFormObject = useCallback(
     async form => {
@@ -78,10 +79,11 @@ const EditMe = () => {
         <PictureUploader
           aspectRatio={1}
           circle
-          disabled={isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           label="Picture"
           onChange={setPicture}
           setDisabled={setIsCropping}
+          setIsUploaderLoading={setIsUploaderLoading}
           value={{ url: form.profilePicUrl, picRect: form.picRect }}
         />
         <TextField
@@ -95,7 +97,7 @@ const EditMe = () => {
           value={form.email}
         />
         <TextField
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           inputProps={atLeastOneNonBlankCharInputProps}
           label="First Name"
@@ -106,7 +108,7 @@ const EditMe = () => {
           value={form.firstName}
         />
         <TextField
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           inputProps={atLeastOneNonBlankCharInputProps}
           label="Last Name"
@@ -119,7 +121,7 @@ const EditMe = () => {
         <div style={{ marginTop: '1rem' }}>
           <Button
             color="primaryGradient"
-            disabled={isFormLoading || isCropping || isFormPristine || isFormSubmitting}
+            disabled={isFormLoading || isCropping || isFormPristine || isFormSubmitting || isUploaderLoading}
             isFormPristine={isFormPristine}
             isFormSubmitting={isFormSubmitting}
             tooltipEnabled

--- a/console-frontend/src/app/screens/account/users/create.js
+++ b/console-frontend/src/app/screens/account/users/create.js
@@ -14,6 +14,7 @@ const formObjectTransformer = json => {
   return {
     id: json.id,
     profilePicUrl: json.profilePicUrl || '',
+    picRect: json.picRect || {},
     firstName: json.firstName || '',
     lastName: json.lastName || '',
     role: json.role || '',
@@ -27,6 +28,7 @@ const formObjectTransformer = json => {
 const loadFormObject = () => {
   return {
     profilePicUrl: '',
+    picRect: {},
     firstName: '',
     lastName: '',
     role: '',
@@ -44,6 +46,7 @@ const UserCreate = ({ history }) => {
 
   const formRef = useRef()
   const [isCropping, setIsCropping] = useState(false)
+  const [isUploaderLoading, setIsUploaderLoading] = useState(false)
   const [profilePic, setProfilePic] = useState(null)
   const [progress, setProgress] = useState(null)
 
@@ -102,9 +105,9 @@ const UserCreate = ({ history }) => {
     [history, onFormSubmit, setIsFormSubmitting]
   )
 
-  const setProfilePicUrl = useCallback(
-    profilePicUrl => {
-      mergeForm({ profilePicUrl })
+  const setPicture = useCallback(
+    picture => {
+      mergeForm({ profilePicUrl: picture.url, picRect: picture.picRect })
     },
     [mergeForm]
   )
@@ -116,13 +119,13 @@ const UserCreate = ({ history }) => {
           isFormPristine={isFormPristine}
           isFormSubmitting={isFormSubmitting}
           onFormSubmit={newOnFormSubmit}
-          saveDisabled={isFormSubmitting || isFormLoading || isCropping || isFormPristine}
+          saveDisabled={isFormSubmitting || isFormLoading || isCropping || isFormPristine || isUploaderLoading}
         />
       ),
       backRoute: routes.account(),
       title: 'Add User',
     }),
-    [isCropping, isFormLoading, isFormPristine, isFormSubmitting, newOnFormSubmit]
+    [isCropping, isFormLoading, isFormPristine, isFormSubmitting, isUploaderLoading, newOnFormSubmit]
   )
   useAppBarContent(appBarContent)
 
@@ -132,17 +135,19 @@ const UserCreate = ({ history }) => {
     <Section title="Add User">
       <Form formRef={formRef} isFormPristine={isFormPristine} onSubmit={newOnFormSubmit}>
         <PictureUploader
+          aspectRatio={1}
           circle
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           label="Picture"
-          onChange={setProfilePicUrl}
+          onChange={setPicture}
           setDisabled={setIsCropping}
+          setIsUploaderLoading={setIsUploaderLoading}
           setPic={setProfilePic}
-          value={form.profilePicUrl}
+          value={{ url: form.profilePicUrl, picRect: form.picRect }}
         />
         {progress && <ProgressBar progress={progress} />}
         <Field
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           inputProps={atLeastOneNonBlankCharInputProps}
           label="First Name"
@@ -154,7 +159,7 @@ const UserCreate = ({ history }) => {
           value={form.firstName}
         />
         <Field
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           inputProps={atLeastOneNonBlankCharInputProps}
           label="Last Name"
@@ -166,7 +171,7 @@ const UserCreate = ({ history }) => {
           value={form.lastName}
         />
         <Select
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           label="Role"
           margin="normal"
@@ -177,7 +182,7 @@ const UserCreate = ({ history }) => {
           value={form.role}
         />
         <Field
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           label="Email"
           margin="normal"
@@ -188,7 +193,7 @@ const UserCreate = ({ history }) => {
           value={form.email}
         />
         <Field
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           inputProps={passwordInputProps}
           label="Password"
@@ -200,7 +205,7 @@ const UserCreate = ({ history }) => {
           value={form.password}
         />
         <Field
-          disabled={isFormLoading || isCropping}
+          disabled={isFormLoading || isCropping || isUploaderLoading}
           fullWidth
           label="Password Confirmation"
           margin="normal"

--- a/console-frontend/src/shared/pictures-modal/cropping-dialog.js
+++ b/console-frontend/src/shared/pictures-modal/cropping-dialog.js
@@ -1,12 +1,14 @@
 import Button from 'shared/button'
 import Dialog from 'shared/dialog'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import ReactCrop from 'react-image-crop'
 import styled from 'styled-components'
+import { CircularProgress } from '@material-ui/core'
 import { DialogActionsContainer, StyledButton } from './shared'
 
 // max-height: 253px = dialog's margin (96px) + dialog title height (76px) + dialog action height (81px)
 const DialogCroppingContainer = styled.div`
+  min-height: 200px;
   max-height: calc(100vh - 253px);
   display: flex;
   justify-content: center;
@@ -24,21 +26,51 @@ const HiddenImg = styled.img`
   display: none;
 `
 
-const DialogContentCropping = ({ crop, onCropChange, onCropComplete, onPictureLoaded, picture, picturePreviewRef }) => (
-  <DialogCroppingContainer crop={crop}>
-    <HiddenImg alt="" ref={picturePreviewRef} src={picture} />
-    <StyledReactCrop
-      crop={crop}
-      keepSelection
-      minHeight={20}
-      minWidth={20}
-      onChange={onCropChange}
-      onComplete={onCropComplete}
-      onImageLoaded={onPictureLoaded}
-      src={picture}
-    />
-  </DialogCroppingContainer>
-)
+const CircularProgressContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const DialogContentCropping = ({ crop, onCropChange, onCropComplete, onPictureLoaded, picture, picturePreviewRef }) => {
+  const [isPictureLoading, setIsPictureLoading] = useState(true)
+
+  const newOnPictureLoaded = useCallback(
+    picture => {
+      onPictureLoaded(picture)
+      setIsPictureLoading(false)
+    },
+    [onPictureLoaded]
+  )
+
+  return (
+    <>
+      <DialogCroppingContainer crop={crop}>
+        <HiddenImg alt="" ref={picturePreviewRef} src={picture} />
+        <StyledReactCrop
+          crop={crop}
+          keepSelection
+          minHeight={20}
+          minWidth={20}
+          onChange={onCropChange}
+          onComplete={onCropComplete}
+          onImageLoaded={newOnPictureLoaded}
+          src={picture}
+        />
+      </DialogCroppingContainer>
+      {isPictureLoading && (
+        <CircularProgressContainer>
+          <CircularProgress size={80} />
+        </CircularProgressContainer>
+      )}
+    </>
+  )
+}
 
 const DialogActionsCropping = ({ onCancelCropping, onDoneCropping }) => (
   <DialogActionsContainer>

--- a/console-frontend/src/shared/pictures-modal/empty-dialog.js
+++ b/console-frontend/src/shared/pictures-modal/empty-dialog.js
@@ -1,6 +1,6 @@
 import Dialog from 'shared/dialog'
 import FileUploader from 'shared/file-uploader'
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import { StyledButton } from './shared'
 import { Typography } from '@material-ui/core'
@@ -22,13 +22,17 @@ const DialogEmptyIcon = styled.img`
   margin-bottom: 10px;
 `
 
-const DialogContentEmpty = () => (
-  <DialogEmptyContainer>
-    <DialogEmptyIcon alt="" src="/img/icons/ic_emoji_thinking.png" />
-    <Typography variant="h5">{'No pictures found'}</Typography>
-    <Typography variant="subtitle1">{"You don't have any picture in your gallery. Let's upload one?"}</Typography>
-  </DialogEmptyContainer>
-)
+const DialogContentEmpty = ({ type }) => {
+  const resource = useMemo(() => (type === 'animationsModal' ? 'animation' : 'picture'), [type])
+
+  return (
+    <DialogEmptyContainer>
+      <DialogEmptyIcon alt="" src="/img/icons/ic_emoji_thinking.png" />
+      <Typography variant="h5">{`No ${resource}s found`}</Typography>
+      <Typography variant="subtitle1">{`You don't have any ${resource} in your gallery. Let's upload one?`}</Typography>
+    </DialogEmptyContainer>
+  )
+}
 
 const DialogActionsEmpty = ({ handleClose, onFileUpload, onUrlUploadClick }) => (
   <DialogActionsEmptyContainer>
@@ -41,9 +45,9 @@ const DialogActionsEmpty = ({ handleClose, onFileUpload, onUrlUploadClick }) => 
   </DialogActionsEmptyContainer>
 )
 
-const EmptyDialog = ({ handleClose, onFileUpload, onUrlUploadClick, open }) => (
+const EmptyDialog = ({ handleClose, onFileUpload, onUrlUploadClick, open, type }) => (
   <Dialog
-    content={<DialogContentEmpty />}
+    content={<DialogContentEmpty type={type} />}
     dialogActions={<DialogActionsEmpty onFileUpload={onFileUpload} onUrlUploadClick={onUrlUploadClick} />}
     handleClose={handleClose}
     open={open}

--- a/console-frontend/src/shared/pictures-modal/gallery-dialog.js
+++ b/console-frontend/src/shared/pictures-modal/gallery-dialog.js
@@ -2,7 +2,7 @@ import AspectRatio from 'react-aspect-ratio'
 import Button from 'shared/button'
 import Dialog from 'shared/dialog'
 import FileUploader from 'shared/file-uploader'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import routes from 'app/routes'
 import styled from 'styled-components'
 import { DialogActionsContainer, StyledButton } from './shared'
@@ -115,33 +115,42 @@ const GalleryDialog = ({
   onDialogClose,
   onEntering,
   onFileUpload,
+  onGalleryDoneClick,
   onKeyUp,
   onPictureClick,
   onUrlUploadClick,
   open,
   pictures,
-  onGalleryDoneClick,
-}) => (
-  <Dialog
-    content={<DialogContentGallery activePicture={activePicture} onPictureClick={onPictureClick} pictures={pictures} />}
-    dialogActions={
-      <DialogActionsGallery
-        activePicture={activePicture}
-        onDialogClose={onDialogClose}
-        onFileUpload={onFileUpload}
-        onGalleryDoneClick={onGalleryDoneClick}
-        onUrlUploadClick={onUrlUploadClick}
-      />
-    }
-    fullWidth
-    handleClose={handleClose}
-    maxWidth="lg"
-    onEntering={onEntering}
-    onKeyUp={onKeyUp}
-    open={open}
-    subtitle={<DialogSubtitleLink to={routes.picturesList()}>{'Or go to your pictures gallery >'}</DialogSubtitleLink>}
-    title="Select a picture from the gallery:"
-  />
-)
+  type,
+}) => {
+  const title = useMemo(() => `Select a${type === 'animationsModal' ? 'n animation' : ' picture'} from the gallery:`, [type])
+
+  return (
+    <Dialog
+      content={
+        <DialogContentGallery activePicture={activePicture} onPictureClick={onPictureClick} pictures={pictures} />
+      }
+      dialogActions={
+        <DialogActionsGallery
+          activePicture={activePicture}
+          onDialogClose={onDialogClose}
+          onFileUpload={onFileUpload}
+          onGalleryDoneClick={onGalleryDoneClick}
+          onUrlUploadClick={onUrlUploadClick}
+        />
+      }
+      fullWidth
+      handleClose={handleClose}
+      maxWidth="lg"
+      onEntering={onEntering}
+      onKeyUp={onKeyUp}
+      open={open}
+      subtitle={
+        <DialogSubtitleLink to={routes.picturesList()}>{'Or go to your pictures gallery >'}</DialogSubtitleLink>
+      }
+      title={title}
+    />
+  )
+}
 
 export default GalleryDialog

--- a/console-frontend/src/shared/pictures-modal/url-upload-dialog.js
+++ b/console-frontend/src/shared/pictures-modal/url-upload-dialog.js
@@ -2,11 +2,10 @@ import Button from 'shared/button'
 import CircularProgress from 'app/layout/loading'
 import Dialog from 'shared/dialog'
 import FileUploader from 'shared/file-uploader'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { DialogActionsContainer, StyledButton } from './shared'
 import { Input } from '@material-ui/core'
-// import { Link } from 'react-router-dom'
 import { Link as LinkIcon } from '@material-ui/icons'
 
 const UrlInputContainer = styled.div`
@@ -39,7 +38,7 @@ const UrlIcon = styled(LinkIcon)`
   height: 24px;
 `
 
-const DialogContentUrlUpload = ({ isPictureLoading, setPictureUrl }) => {
+const DialogContentUrlUpload = ({ isPictureLoading, resource, setPictureUrl }) => {
   const [isFocused, setIsFocused] = useState(null)
 
   const onChange = useCallback(
@@ -67,7 +66,7 @@ const DialogContentUrlUpload = ({ isPictureLoading, setPictureUrl }) => {
           onBlur={onBlur}
           onChange={onChange}
           onFocus={onFocus}
-          placeholder="Paste the URL of the picture to upload:"
+          placeholder={`Paste the URL of the ${resource} to upload:`}
         />
         <UrlIconContainer>
           <UrlIcon />
@@ -103,23 +102,30 @@ const UrlUploadDialog = ({
   onKeyUp,
   open,
   setPictureUrl,
-}) => (
-  <Dialog
-    content={<DialogContentUrlUpload isPictureLoading={isPictureLoading} setPictureUrl={setPictureUrl} />}
-    dialogActions={
-      <DialogActionsUrlUpload
-        onCancelUrlUpload={onCancelUrlUpload}
-        onDoneUrlUpload={onDoneUrlUpload}
-        onFileUpload={onFileUpload}
-      />
-    }
-    fullWidth
-    handleClose={handleClose}
-    maxWidth="lg"
-    onKeyUp={onKeyUp}
-    open={open}
-    title="Upload picture from URL:"
-  />
-)
+  type,
+}) => {
+  const resource = useMemo(() => (type === 'animationsModal' ? 'animation' : 'picture'), [type])
+
+  return (
+    <Dialog
+      content={
+        <DialogContentUrlUpload isPictureLoading={isPictureLoading} resource={resource} setPictureUrl={setPictureUrl} />
+      }
+      dialogActions={
+        <DialogActionsUrlUpload
+          onCancelUrlUpload={onCancelUrlUpload}
+          onDoneUrlUpload={onDoneUrlUpload}
+          onFileUpload={onFileUpload}
+        />
+      }
+      fullWidth
+      handleClose={handleClose}
+      maxWidth="lg"
+      onKeyUp={onKeyUp}
+      open={open}
+      title={`Upload ${resource} from URL:`}
+    />
+  )
+}
 
 export default UrlUploadDialog

--- a/console-frontend/src/shared/table-elements/picture.js
+++ b/console-frontend/src/shared/table-elements/picture.js
@@ -9,6 +9,7 @@ const Img = styled.img`
   vertical-align: middle;
   opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   margin-right: 8px;
+  object-fit: cover;
 `
 
 const Picture = ({ src, disabled }) => <Img alt="" disabled={disabled} src={src} />

--- a/plugiamo/src/app/content/showcase/index.js
+++ b/plugiamo/src/app/content/showcase/index.js
@@ -165,8 +165,10 @@ const ShowcaseGraphql = ({ id, ...props }) => {
                 width
                 height
               }
+              profilePicAnimation {
+                url
+              }
               instagramUrl
-              profilePicAnimationUrl
             }
             productPicks {
               id

--- a/plugin-base/src/shared/list.js
+++ b/plugin-base/src/shared/list.js
@@ -191,9 +191,10 @@ const AnimatedImage = styled.img`
   left: 0;
   right: 0;
   height: 100%;
+  width: 100%;
+  object-fit: cover;
   opacity: 0;
   transition: opacity 1s;
-  opacity: 1;
   animation: _frekkls_item_img_shared_animation 1s;
   animation-fill-mode: forwards;
   li:hover & {

--- a/plugin-base/src/showcase/components/spotlight-item.js
+++ b/plugin-base/src/showcase/components/spotlight-item.js
@@ -47,7 +47,7 @@ const SpotlightItem = ({ spotlight, onClick, setListSelected, listSelected, with
     <ListItem bordered={bordered} listSelected={listSelected} onClick={newOnClick} setListSelected={setListSelected}>
       {!withoutPicture && (
         <ListImg
-          animation={spotlight.persona.profilePicAnimationUrl}
+          animation={spotlight.persona.profilePicAnimation && spotlight.persona.profilePicAnimation.url}
           picture={imgixUrl(spotlight.persona.profilePic.url, {
             rect: stringifyRect(spotlight.persona.profilePic.picRect || spotlight.persona.picRect),
             fit: 'crop',


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/bb6D3Cbu)

## Changes

- Add a new column `profile_pic_animation_id` to personas, and connect it to the pictures table
- Add `convert_animated_pics` script
- Add animation uploader: when clicked, it opens the pictures modal with all the animated pictures present in the gallery
- Implement different logic to deal with animations: when an animation is uploaded or selected, the cropping dialog is not shown and the modal closes
- Add "add animation" button to reveal the UI of the animation uploader
- Add a loader to picture uploader and a new `isUploaderLoading` state to the forms using it: when the picture in the uploader is loading, the form is disabled
- Add loader to cropping dialog, shown before the picture to crop gets fully loaded
- Add a `type` column to pictures gallery, sortable
- Fix `status` column in pictures gallery (simple chat messages were not counted)
- Fix bug in forms with uploader, see https://trello.com/c/0eTyhREq
- Minor style fixes for animations in plugin base

## Deployment

1. Deploy the backend (the `profile_pic_animation_url` field is still present and the front-end won't be affected)
2. Run the script in `backend/lib/data_scripts/convert_animated_pictures.rb` 
3. Deploy the front-end (console + plugin-base)