### PR TITLE
Navigate with account slug

### DIFF
--- a/backend/app/controllers/api/v1/accounts_controller.rb
+++ b/backend/app/controllers/api/v1/accounts_controller.rb
@@ -19,13 +19,13 @@ module Api
       end
 
       def show
-        @account = policy_scope(Account).find(params[:id])
+        @account = find_account(request.headers["X-Session-Account"])
         authorize @account
         render json: @account
       end
 
       def destroy
-        @account = policy_scope(Account).find(params[:id])
+        @account = @account = find_account(request.headers["X-Session-Account"])
         authorize @account
         if @account.destroy
           render json: { message: "Successfully removed account" }
@@ -35,6 +35,18 @@ module Api
       end
 
       private
+
+      def integer?(header)
+        !header.to_i.zero?
+      end
+
+      def find_account(header)
+        if integer?(header)
+          policy_scope(Account).find_by(id: params[:id])
+        else
+          policy_scope(Account).find_by(slug: params[:slug])
+        end
+      end
 
       def account_params
         params.require(:account).permit(:name, websites_attributes: [:name, hostnames: []])

--- a/backend/app/controllers/api/v1/rest_admin_controller.rb
+++ b/backend/app/controllers/api/v1/rest_admin_controller.rb
@@ -7,7 +7,11 @@ module Api
       private
 
       def current_tenant
-        session_account = Account.find_by(id: request.headers["X-Session-Account"])
+        session_account = if request.headers["X-Session-Account"].to_i.zero?
+                            Account.find_by(slug: request.headers["X-Session-Account"])
+                          else
+                            Account.find_by(id: request.headers["X-Session-Account"])
+                          end
         set_current_tenant(session_account)
       end
 

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -17,7 +17,7 @@ class Account < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
 
   def as_json(_options = {})
-    attributes.slice("id", "name", "slug", "last_name", "created_at", "updated_at")
+    attributes.slice("name", "slug", "last_name", "created_at", "updated_at")
               .merge(websites_attributes: websites)
   end
 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   end
 
   def mapped_roles
-    Hash[memberships.pluck(:account_id, :role)]
+    Hash[memberships.map { |membership| [membership.account.slug, membership.role] }]
   end
 
   def active_membership

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
           put "/users/onboarding", to: "mes#update_onboarding"
         end
 
-        resources :accounts, only: %i[index show create destroy]
+        resources :accounts, only: %i[index show create destroy], param: :slug
         resources :websites, only: %i[show update]
 
         get "/personas/autocomplete", to: "autocompletes#personas_autocomplete"

--- a/backend/db/migrate/20190715123605_add_slug_index_to_accounts.rb
+++ b/backend/db/migrate/20190715123605_add_slug_index_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddSlugIndexToAccounts < ActiveRecord::Migration[5.1]
+  def change
+    add_index :accounts, :slug, unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20190717110752) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.string "slug", default: "", null: false
+    t.index ["slug"], name: "index_accounts_on_slug", unique: true
   end
 
   create_table "generated_urls", force: :cascade do |t|

--- a/console-frontend/src/app/index.js
+++ b/console-frontend/src/app/index.js
@@ -86,42 +86,64 @@ const RedirectRoot = () => (
   </>
 )
 
-const Routes = () => (
-  <Switch>
-    <PrivateRoute component={PersonasList} exact isOwnerScoped path={routes.personasList()} />
-    <PrivateRoute component={PersonaCreate} exact isOwnerScoped path={routes.personaCreate()} />
-    <PrivateRoute component={PersonaEdit} exact isOwnerScoped path={routes.personaEdit(':personaId')} />
-    <PrivateRoute component={PicturesList} exact path={routes.picturesList()} />
-    <PrivateRoute component={ShowcasesList} exact isOwnerScoped path={routes.showcasesList()} />
-    <PrivateRoute component={ShowcaseCreate} exact isOwnerScoped path={routes.showcaseCreate()} />
-    <PrivateRoute component={ShowcaseEdit} exact isOwnerScoped path={routes.showcaseEdit(':showcaseId')} />
-    <PrivateRoute component={SimpleChatsList} exact path={routes.simpleChatsList()} />
-    <PrivateRoute component={SimpleChatCreate} exact path={routes.simpleChatCreate()} />
-    <PrivateRoute component={SimpleChatEdit} exact path={routes.simpleChatEdit(':simpleChatId')} />
-    <PrivateRoute component={OutrosList} exact isOwnerScoped path={routes.outrosList()} />
-    <PrivateRoute component={OutroCreate} exact isOwnerScoped path={routes.outroCreate()} />
-    <PrivateRoute component={OutroEdit} exact isOwnerScoped path={routes.outroEdit(':outroId')} />
-    <PrivateRoute component={TriggersList} exact isOwnerScoped path={routes.triggersList()} />
-    <PrivateRoute component={TriggerCreate} exact isOwnerScoped path={routes.triggerCreate()} />
-    <PrivateRoute component={TriggerEdit} exact isOwnerScoped path={routes.triggerEdit(':triggerId')} />
-    <PrivateRoute component={Account} exact path={routes.account()} />
-    <PrivateRoute component={UserCreate} exact isAdminScoped isOwnerScoped path={routes.userCreate()} />
-    <PrivateRoute component={ChangePassword} exact isOwnerScoped path={routes.passwordChange()} />
-    <PrivateRoute component={UrlGenerator} exact isOwnerScoped path={routes.urlGenerator()} />
-    <PrivateRoute component={Accounts} exact isOwnerScoped path={routes.accounts()} />
-    <PrivateRoute component={DataDashboard} exact isAdminScoped path={routes.dataDashboard()} />
-    <ExternalRoute component={LoginPage} path={routes.login()} />
-    <ExternalRoute component={SignupPage} path={routes.signup()} />
-    <ExternalRoute component={RequestPasswordReset} path={routes.requestPasswordReset()} />
-    <ExternalRoute component={ForgotPassword} path={routes.passwordReset()} />
-    <Route
-      component={auth.isLoggedIn() && auth.getUser().onboardingStage === 0 ? WelcomePage : RedirectRoot}
-      exact
-      path={routes.root()}
-    />
-    <Route component={NotFound} />
-  </Switch>
-)
+const Routes = ({ setIsNotFoundPage }) => {
+  const NotFoundPage = useCallback(
+    () => (auth.isLoggedIn() ? <NotFound setIsNotFoundPage={setIsNotFoundPage} /> : <RedirectRoot />),
+    [setIsNotFoundPage]
+  )
+
+  return (
+    <Switch>
+      <PrivateRoute component={PersonasList} exact isOwnerScoped path={routes.personasList(':accountSlug')} />
+      <PrivateRoute component={PersonaCreate} exact isOwnerScoped path={routes.personaCreate(':accountSlug')} />
+      <PrivateRoute
+        component={PersonaEdit}
+        exact
+        isOwnerScoped
+        path={routes.personaEdit(':personaId', ':accountSlug')}
+      />
+      <PrivateRoute component={PicturesList} exact path={routes.picturesList(':accountSlug')} />
+      <PrivateRoute component={ShowcasesList} exact isOwnerScoped path={routes.showcasesList(':accountSlug')} />
+      <PrivateRoute component={ShowcaseCreate} exact isOwnerScoped path={routes.showcaseCreate(':accountSlug')} />
+      <PrivateRoute
+        component={ShowcaseEdit}
+        exact
+        isOwnerScoped
+        path={routes.showcaseEdit(':showcaseId', ':accountSlug')}
+      />
+      <PrivateRoute component={SimpleChatsList} exact path={routes.simpleChatsList(':accountSlug')} />
+      <PrivateRoute component={SimpleChatCreate} exact path={routes.simpleChatCreate(':accountSlug')} />
+      <PrivateRoute component={SimpleChatEdit} exact path={routes.simpleChatEdit(':simpleChatId', ':accountSlug')} />
+      <PrivateRoute component={OutrosList} exact isOwnerScoped path={routes.outrosList(':accountSlug')} />
+      <PrivateRoute component={OutroCreate} exact isOwnerScoped path={routes.outroCreate(':accountSlug')} />
+      <PrivateRoute component={OutroEdit} exact isOwnerScoped path={routes.outroEdit(':outroId', ':accountSlug')} />
+      <PrivateRoute component={TriggersList} exact isOwnerScoped path={routes.triggersList(':accountSlug')} />
+      <PrivateRoute component={TriggerCreate} exact isOwnerScoped path={routes.triggerCreate(':accountSlug')} />
+      <PrivateRoute
+        component={TriggerEdit}
+        exact
+        isOwnerScoped
+        path={routes.triggerEdit(':triggerId', ':accountSlug')}
+      />
+      <PrivateRoute component={Account} exact path={routes.account(':accountSlug')} />
+      <PrivateRoute component={UserCreate} exact isAdminScoped isOwnerScoped path={routes.userCreate(':accountSlug')} />
+      <PrivateRoute component={ChangePassword} exact path={routes.passwordChange()} />
+      <PrivateRoute component={UrlGenerator} exact isOwnerScoped path={routes.urlGenerator(':accountSlug')} />
+      <PrivateRoute component={Accounts} exact path={routes.accounts()} />
+      <PrivateRoute component={DataDashboard} exact isAdminScoped path={routes.dataDashboard(':accountSlug')} />
+      <ExternalRoute component={LoginPage} path={routes.login()} />
+      <ExternalRoute component={SignupPage} path={routes.signup()} />
+      <ExternalRoute component={RequestPasswordReset} path={routes.requestPasswordReset()} />
+      <ExternalRoute component={ForgotPassword} path={routes.passwordReset()} />
+      <Route
+        component={auth.isLoggedIn() && auth.getUser().onboardingStage === 0 ? WelcomePage : RedirectRoot}
+        exact
+        path={routes.root(':accountSlug')}
+      />
+      <Route render={NotFoundPage} />
+    </Switch>
+  )
+}
 
 const SortableStyle = createGlobalStyle`
   .sortable-element {
@@ -132,6 +154,8 @@ const SortableStyle = createGlobalStyle`
 const AppBase = () => {
   const { enqueueSnackbar } = useSnackbar()
   const [loading, setLoading] = useState(true)
+  const [isNotFoundPage, setIsNotFoundPage] = useState(false)
+
   useEffect(
     () => {
       apiRequest(apiGetCsrfToken, []).then(({ json, errors, requestError }) => {
@@ -148,8 +172,8 @@ const AppBase = () => {
     <>
       <CssBaseline />
       <SortableStyle />
-      <Layout>
-        <Routes />
+      <Layout isNotFoundPage={isNotFoundPage}>
+        <Routes setIsNotFoundPage={setIsNotFoundPage} />
       </Layout>
     </>
   )

--- a/console-frontend/src/app/layout/index.js
+++ b/console-frontend/src/app/layout/index.js
@@ -90,11 +90,11 @@ const FilledLayout = ({ children, location, isAccountsPage }) => {
   )
 }
 
-const Layout = ({ children, location }) => {
+const Layout = ({ children, location, isNotFoundPage }) => {
   const isLoggedIn = auth.isLoggedIn()
   const isAccountsPage = useMemo(() => location.pathname === routes.accounts(), [location.pathname])
 
-  if (!isLoggedIn || isAccountsPage) return <EmptyLayout>{children}</EmptyLayout>
+  if (!isLoggedIn || isAccountsPage || isNotFoundPage) return <EmptyLayout>{children}</EmptyLayout>
 
   return (
     <FilledLayout isAccountsPage={isAccountsPage} location={location}>

--- a/console-frontend/src/app/layout/menu.js
+++ b/console-frontend/src/app/layout/menu.js
@@ -27,49 +27,49 @@ const resources = {
     icon: BarChart,
     label: 'Data Dashboard',
     class: 'dataDashboard',
-    route: routes.dataDashboard(),
+    route: () => routes.dataDashboard(),
   },
   triggers: {
     icon: TuneOutlined,
     label: 'Triggers',
     class: 'triggers',
-    route: routes.triggersList(),
+    route: () => routes.triggersList(),
   },
   showcases: {
     icon: PersonPinOutlined,
     label: 'Showcases',
     class: 'showcases',
-    route: routes.showcasesList(),
+    route: () => routes.showcasesList(),
   },
   simpleChats: {
     icon: SmsOutlined,
     label: 'Simple Chats',
     class: 'simple-chats',
-    route: routes.simpleChatsList(),
+    route: () => routes.simpleChatsList(),
   },
   outros: {
     icon: AssignmentTurnedInOutlined,
     label: 'Outros',
     class: 'outros',
-    route: routes.outrosList(),
+    route: () => routes.outrosList(),
   },
   personas: {
     icon: AccountCircleOutlined,
     label: 'Personas',
     class: 'personas',
-    route: routes.personasList(),
+    route: () => routes.personasList(),
   },
   pictures: {
     icon: PhotoLibrary,
     label: 'Pictures',
     class: 'pictures',
-    route: routes.picturesList(),
+    route: () => routes.picturesList(),
   },
   urlGenerator: {
     icon: LinkIcon,
     label: 'Url Generator',
     class: 'urlGenerator',
-    route: routes.urlGenerator(),
+    route: () => routes.urlGenerator(),
   },
 }
 
@@ -195,11 +195,11 @@ const StyledSvgIcon = styled(props => <SvgIcon {...omit(props, ['isActive', 'sid
 `
 
 const Item = withRouter(({ location, resource, sidebarOpen }) => {
-  const isActive = useMemo(() => location.pathname.startsWith(resource.route), [location.pathname, resource.route])
+  const isActive = useMemo(() => location.pathname.startsWith(resource.route()), [location.pathname, resource])
 
   return (
     <div className={`onboard-${resource.class}`}>
-      <Link key={resource.route} to={resource.route}>
+      <Link key={resource.route()} to={resource.route()}>
         <StyledMenuItem isActive={isActive} sidebarOpen={sidebarOpen}>
           <StyledSvgIcon isActive={isActive} sidebarOpen={sidebarOpen}>
             {resource.icon ? React.createElement(resource.icon) : <DefaultIcon />}
@@ -269,7 +269,7 @@ const BaseMenu = withRouter(
                 </GroupText>
               </MenuItemGroup>
               {userRoleResourceGroups[groupName].resources.map(resource => (
-                <Item key={resource.route} resource={resource} sidebarOpen={sidebarOpen} />
+                <Item key={resource.route()} resource={resource} sidebarOpen={sidebarOpen} />
               ))}
             </div>
           ))}

--- a/console-frontend/src/app/routes.js
+++ b/console-frontend/src/app/routes.js
@@ -1,6 +1,8 @@
+import { getSlug } from 'utils/shared'
+
 const routes = {
-  account() {
-    return '/account'
+  account(accountSlug = getSlug()) {
+    return `/${accountSlug}/account`
   },
   isPasswordReset() {
     return window.location.pathname.includes('/password-reset')
@@ -12,7 +14,7 @@ const routes = {
     return '/signup'
   },
   passwordChange() {
-    return '/account/change-password'
+    return '/change-password'
   },
   passwordReset() {
     return '/password-reset'
@@ -20,71 +22,71 @@ const routes = {
   requestPasswordReset() {
     return '/request-password-reset'
   },
-  root() {
-    return '/'
+  root(accountSlug = getSlug()) {
+    return accountSlug ? `/${accountSlug}/` : '/'
   },
-  personasList() {
-    return '/personas'
+  personasList(accountSlug = getSlug()) {
+    return `/${accountSlug}/personas`
   },
-  personaCreate() {
-    return '/personas/create'
+  personaCreate(accountSlug = getSlug()) {
+    return `/${accountSlug}/personas/create`
   },
-  personaEdit(id) {
-    return `/personas/${id}/edit`
+  personaEdit(id, accountSlug = getSlug()) {
+    return `/${accountSlug}/personas/${id}/edit`
   },
-  picturesList() {
-    return '/pictures'
+  picturesList(accountSlug = getSlug()) {
+    return `/${accountSlug}/pictures`
   },
-  outrosList() {
-    return '/outros'
+  outrosList(accountSlug = getSlug()) {
+    return `/${accountSlug}/outros`
   },
-  outroCreate() {
-    return '/outros/create'
+  outroCreate(accountSlug = getSlug()) {
+    return `/${accountSlug}/outros/create`
   },
-  outroEdit(id) {
-    return `/outros/${id}/edit`
+  outroEdit(id, accountSlug = getSlug()) {
+    return `/${accountSlug}/outros/${id}/edit`
   },
-  showcasesList() {
-    return '/showcases'
+  showcasesList(accountSlug = getSlug()) {
+    return `/${accountSlug}/showcases`
   },
-  showcaseCreate() {
-    return '/showcases/create'
+  showcaseCreate(accountSlug = getSlug()) {
+    return `/${accountSlug}/showcases/create`
   },
-  showcaseEdit(id) {
-    return `/showcases/${id}/edit`
+  showcaseEdit(id, accountSlug = getSlug()) {
+    return `/${accountSlug}/showcases/${id}/edit`
   },
-  simpleChatsList() {
-    return '/simple-chats'
+  simpleChatsList(accountSlug = getSlug()) {
+    return `/${accountSlug}/simple-chats`
   },
-  simpleChatCreate() {
-    return '/simple-chats/create'
+  simpleChatCreate(accountSlug = getSlug()) {
+    return `/${accountSlug}/simple-chats/create`
   },
-  simpleChatEdit(id) {
-    return `/simple-chats/${id}/edit`
+  simpleChatEdit(id, accountSlug = getSlug()) {
+    return `/${accountSlug}/simple-chats/${id}/edit`
   },
-  triggerCreate() {
-    return '/triggers/create'
+  triggerCreate(accountSlug = getSlug()) {
+    return `/${accountSlug}/triggers/create`
   },
-  triggersList() {
-    return '/triggers'
+  triggersList(accountSlug = getSlug()) {
+    return `/${accountSlug}/triggers`
   },
-  triggerEdit(id) {
-    return `/triggers/${id}/edit`
+  triggerEdit(id, accountSlug = getSlug()) {
+    return `/${accountSlug}/triggers/${id}/edit`
   },
-  urlGenerator() {
-    return '/url-generator'
+  urlGenerator(accountSlug = getSlug()) {
+    return `/${accountSlug}/url-generator`
   },
-  userCreate() {
-    return '/account/users/create'
+  userCreate(accountSlug = getSlug()) {
+    return `/${accountSlug}/account/users/create`
   },
-  userEdit(id) {
-    return `/account/users/${id}/edit`
+  userEdit(id, accountSlug = getSlug()) {
+    return `/${accountSlug}/account/users/${id}/edit`
   },
   accounts() {
     return '/accounts'
   },
-  dataDashboard() {
-    return '/data-dashboard'
+  dataDashboard(accountSlug = getSlug()) {
+    return `/${accountSlug}/data-dashboard`
   },
   nullRoute() {
     return '/empty'

--- a/console-frontend/src/app/screens/account/users/list.js
+++ b/console-frontend/src/app/screens/account/users/list.js
@@ -29,7 +29,7 @@ const BlankState = () => (
 )
 
 const UsersRow = ({ record: { email, firstName, lastName, profilePicUrl, roles, picRect } }) => {
-  const role = useMemo(() => roles[auth.getSessionAccount().id], [roles])
+  const role = useMemo(() => roles[auth.getSessionAccount().slug], [roles])
 
   const initials = useMemo(() => (!firstName || !lastName ? null : `${firstName[0]}${lastName[0]}`), [
     firstName,

--- a/console-frontend/src/app/screens/accounts/accounts-list.js
+++ b/console-frontend/src/app/screens/accounts/accounts-list.js
@@ -54,11 +54,11 @@ const ListItem = ({ enterAccount, account, hostnames }) => {
   return (
     <ListItemContainer>
       <Tooltip placement="top" title="enter account">
-        <Link to={routes.root()}>
+        <Link to={routes.root(account.slug)}>
           <StyledListItem button onClick={enterAccount}>
             <ListItemText
               primary={account.name}
-              secondary={auth.isAdmin() ? hostnames : auth.getUser().roles[account.id]}
+              secondary={auth.isAdmin() ? hostnames : auth.getUser().roles[account.slug]}
             />
           </StyledListItem>
         </Link>
@@ -73,7 +73,7 @@ const Account = ({ account, fetchAccounts }) => {
   const enterAccount = useCallback(
     () => {
       auth.setSessionAccount(account)
-      auth.setSessionRole(auth.getUser().roles ? auth.getUser().roles[account.id] : '')
+      auth.setSessionRole(auth.getUser().roles ? auth.getUser().roles[account.slug] : '')
     },
     [account]
   )
@@ -90,14 +90,14 @@ const Account = ({ account, fetchAccounts }) => {
     () => {
       ;(async () => {
         setDialogOpen(false)
-        const { errors, requestError, json } = await apiRequest(apiAccountDestroy, [account.id])
+        const { errors, requestError, json } = await apiRequest(apiAccountDestroy, [account.slug])
         if (requestError) enqueueSnackbar(requestError, { variant: 'error' })
         if (errors) enqueueSnackbar(errors.message, { variant: 'error' })
         if (json) enqueueSnackbar(json.message, { variant: 'success' })
         fetchAccounts()
       })()
     },
-    [account.id, enqueueSnackbar, fetchAccounts]
+    [account.slug, enqueueSnackbar, fetchAccounts]
   )
 
   const handleDialogButtonClose = useCallback(() => {
@@ -132,7 +132,7 @@ const AccountsList = ({ page, setPage, totalAccountsCount, fetchAccounts, accoun
   return (
     <>
       {accounts &&
-        accounts.map(account => <Account account={account} fetchAccounts={fetchAccounts} key={account.id} />)}
+        accounts.map(account => <Account account={account} fetchAccounts={fetchAccounts} key={account.slug} />)}
       <Pagination page={page} setPage={setPage} totalRecordsCount={totalAccountsCount} />
     </>
   )

--- a/console-frontend/src/app/screens/change-password/index.js
+++ b/console-frontend/src/app/screens/change-password/index.js
@@ -1,3 +1,4 @@
+import auth from 'auth'
 import Button from 'shared/button'
 import React, { useCallback, useMemo, useState } from 'react'
 import routes from 'app/routes'
@@ -68,7 +69,12 @@ const ChangePassword1 = ({ history, ...props }) => {
         if (errors) enqueueSnackbar(errors.message, { variant: 'error' })
         if (!requestError && !errors) {
           enqueueSnackbar('Changed Password', { variant: 'Info' })
-          history.push(routes.root())
+          const user = auth.getUser()
+          const accountSlugs = !user.admin && Object.keys(user.roles)
+          if (auth.isSingleAccount()) {
+            return history.push(routes.root(accountSlugs[0]))
+          }
+          history.push(routes.accounts())
         }
       })()
     },
@@ -86,7 +92,14 @@ const ChangePassword1 = ({ history, ...props }) => {
   const appBarContent = useMemo(
     () => ({
       Actions: <Actions onFormSubmit={onFormSubmit} />,
-      backRoute: routes.account(),
+      backRoute: (() => {
+        const user = auth.getUser()
+        const accountSlugs = !user.admin && Object.keys(user.roles)
+        if (auth.isSingleAccount()) {
+          return routes.root(accountSlugs[0])
+        }
+        return routes.accounts()
+      })(),
       title: 'Change Password',
     }),
     [onFormSubmit]

--- a/console-frontend/src/app/screens/not-found/index.js
+++ b/console-frontend/src/app/screens/not-found/index.js
@@ -1,5 +1,5 @@
-import Link from 'shared/link'
-import React from 'react'
+import auth from 'auth'
+import React, { useCallback, useEffect } from 'react'
 import routes from 'app/routes'
 import styled from 'styled-components'
 import { Button, Typography } from '@material-ui/core'
@@ -40,25 +40,52 @@ const StyledButton = styled(Button)`
   padding: 12px 80px;
 `
 
-const NotFound = () => (
-  <Fullscreen>
-    <Container>
-      <BackgroundImage src="/img/background/not-found.png" />
-      <Typography gutterBottom variant="h4">
-        {'Oops! This page is not available'}
-      </Typography>
-      <Typography variant="body2">
-        {'Is something wrong? '}
-        <BoldLink href="mailto:support@trendiamo.com">{'Get in touch'}</BoldLink>
-      </Typography>
-      <Typography variant="body2">{'Or come back to home page:'}</Typography>
-      <Link to={routes.root()}>
-        <StyledButton size="large" variant="outlined">
+const NotFound = ({ setIsNotFoundPage }) => {
+  useEffect(
+    () => {
+      setIsNotFoundPage && setIsNotFoundPage(true)
+    },
+    [setIsNotFoundPage]
+  )
+
+  const navigateToRootPage = useCallback(
+    event => {
+      ;(async () => {
+        event.preventDefault()
+        setIsNotFoundPage && setIsNotFoundPage(false)
+        if (auth.isLoggedIn()) {
+          const user = auth.getUser()
+          const accountSlugs = !user.admin && Object.keys(user.roles)
+          if (auth.isSingleAccount()) {
+            return (window.location.href = routes.root(accountSlugs[0]))
+          }
+          window.location.href = routes.accounts()
+        } else {
+          window.location.href = routes.login()
+        }
+      })()
+    },
+    [setIsNotFoundPage]
+  )
+
+  return (
+    <Fullscreen>
+      <Container>
+        <BackgroundImage src="/img/background/not-found.png" />
+        <Typography gutterBottom variant="h4">
+          {'Oops! This page is not available'}
+        </Typography>
+        <Typography variant="body2">
+          {'Is something wrong? '}
+          <BoldLink href="mailto:support@trendiamo.com">{'Get in touch'}</BoldLink>
+        </Typography>
+        <Typography variant="body2">{'Or come back to home page:'}</Typography>
+        <StyledButton onClick={navigateToRootPage} size="large" variant="outlined">
           {'Go Back'}
         </StyledButton>
-      </Link>
-    </Container>
-  </Fullscreen>
-)
+      </Container>
+    </Fullscreen>
+  )
+}
 
 export default NotFound

--- a/console-frontend/src/auth/index.js
+++ b/console-frontend/src/auth/index.js
@@ -1,4 +1,5 @@
 import routes from 'app/routes'
+import { getSlug } from 'utils/shared'
 
 const auth = {
   addListener(fn) {
@@ -15,9 +16,7 @@ const auth = {
     const headers = {
       'X-CSRF-TOKEN': localStorage.getItem('CSRF-TOKEN'),
     }
-    return window.location.pathname === routes.accounts()
-      ? headers
-      : { ...headers, 'X-SESSION-ACCOUNT': this.getSessionAccount().id }
+    return window.location.pathname === routes.accounts() ? headers : { ...headers, 'X-SESSION-ACCOUNT': getSlug() }
   },
   setCsrfToken(json) {
     localStorage.setItem('CSRF-TOKEN', json.token)

--- a/console-frontend/src/auth/login/index.js
+++ b/console-frontend/src/auth/login/index.js
@@ -72,8 +72,8 @@ const Login1 = () => {
 
   const [loginForm, setLoginForm] = useState({ email: '', password: '' })
 
-  const requestSessionAccount = useCallback(async accountId => {
-    const { json } = await apiRequest(apiAccountsShow, [accountId])
+  const requestSessionAccount = useCallback(async accountSlug => {
+    const { json } = await apiRequest(apiAccountsShow, [accountSlug])
     return json
   }, [])
 
@@ -89,13 +89,13 @@ const Login1 = () => {
         if (requestError) enqueueSnackbar(requestError, { variant: 'error' })
         if (errors) enqueueSnackbar(errors.message, { variant: 'error' })
         if (!requestError && !errors) auth.setUser(json.user)
-        const accountIds = json.user && !json.user.admin && Object.keys(json.user.roles)
+        const accountSlugs = json.user && !json.user.admin && Object.keys(json.user.roles)
         if (auth.isLoggedIn()) {
           if (auth.isSingleAccount()) {
-            const account = await requestSessionAccount(accountIds[0])
+            const account = await requestSessionAccount(accountSlugs[0])
             auth.setSessionAccount(account)
-            auth.setSessionRole(json.user.roles[accountIds[0]])
-            return (window.location.href = routes.root())
+            auth.setSessionRole(json.user.roles[accountSlugs[0]])
+            return (window.location.href = routes.root(account.slug))
           }
           window.location.href = routes.accounts()
         }

--- a/console-frontend/src/utils/auth-requests.js
+++ b/console-frontend/src/utils/auth-requests.js
@@ -163,8 +163,8 @@ export const apiPathAutocomplete = query => apiGetRequest(`${PATH_URL}/autocompl
 
 export const apiAccountList = query => apiGetRequest(`${ACCOUNTS_URL}/?${stringify(query)}`)
 export const apiAccountCreate = body => apiCreateRequest(ACCOUNTS_URL, body)
-export const apiAccountsShow = id => apiGetRequest(`${ACCOUNTS_URL}/${id}`)
-export const apiAccountDestroy = id => apiDestroyRequest(`${ACCOUNTS_URL}/${id}`)
+export const apiAccountsShow = slug => apiGetRequest(`${ACCOUNTS_URL}/${slug}`)
+export const apiAccountDestroy = slug => apiDestroyRequest(`${ACCOUNTS_URL}/${slug}`)
 
 export const apiUserList = query => apiListRequest(`${USERS_URL}/?${stringify(query)}`)
 export const apiUserCreate = body => apiCreateRequest(USERS_URL, body)

--- a/console-frontend/src/utils/shared.js
+++ b/console-frontend/src/utils/shared.js
@@ -17,3 +17,5 @@ export const extractErrors = json => {
   const message = errorMessages(json)
   return { message, status: 'error' }
 }
+
+export const getSlug = () => window.location.pathname.split('/')[1]


### PR DESCRIPTION
## Feature Description:
Replaces the use of the Account's id previously stored in localStorage for the slug in location.pathname or in the authUser localStorage object.


- [x] Use the slug in the `X-Session-Account` header, instead of the id.
- [x] Every route, except for `/accounts, /login, /signup, /password-reset, /request-password-reset` now includes the account slug.
- [x] Users with multiple memberships or an Admin users are able to navigate through accounts by changing the account slug in the url.
- [x] Removed the account id from localStorage
- [x] When the user goes to the 404 page, he does not see the sidebar.


[Link To Trello Card](https://trello.com/c/dEHcVmZG/1401-use-account-slug-as-part-of-url-determine-account-by-it)