### PR TITLE
Vertically center 404 page content

### DIFF
--- a/console-frontend/src/app/screens/not-found/index.js
+++ b/console-frontend/src/app/screens/not-found/index.js
@@ -9,7 +9,7 @@ const Fullscreen = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  flex-grow: 1;
 `
 
 const Container = styled.div`
@@ -18,6 +18,7 @@ const Container = styled.div`
   max-width: 60%;
   flex: none;
   margin: auto;
+  padding: 50px 0;
 `
 
 const BackgroundImage = styled.img`


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/KYwkzrCp)

## Changes

- Vertically center 404 page content
- Add some vertical padding to page content to leave some space top and bottom when the device screen has a smaller height (i.e. tablet landscape mode)

## Preview

![image](https://user-images.githubusercontent.com/24722181/61383051-d64dbd80-a8a5-11e9-9e11-e4e28bcc74cb.png)