### PR TITLE
Fix HTML editor bug

### DIFF
--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-message.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-message.js
@@ -36,6 +36,7 @@ const MessageField = ({
   setIsUploaderLoading,
   simpleChatMessage,
   simpleChatMessageIndex,
+  simpleChatStep,
 }) => {
   switch (simpleChatMessage.type) {
     case 'SimpleChatTextMessage':
@@ -47,6 +48,7 @@ const MessageField = ({
           onFocus={onFocus}
           simpleChatMessage={simpleChatMessage}
           simpleChatMessageIndex={simpleChatMessageIndex}
+          simpleChatStep={simpleChatStep}
         />
       )
     case 'SimpleChatProductMessage':
@@ -98,6 +100,7 @@ const MessageField = ({
 }
 
 const SimpleChatMessage = ({
+  activeSimpleChatMessages,
   allowDelete,
   isCropping,
   isFormLoading,
@@ -107,8 +110,8 @@ const SimpleChatMessage = ({
   setIsCropping,
   setIsUploaderLoading,
   simpleChatMessage,
-  activeSimpleChatMessages,
   simpleChatMessageIndex,
+  simpleChatStep,
 }) => {
   const onSimpleChatMessageEdit = useCallback(
     simpleChatMessage => {
@@ -193,6 +196,7 @@ const SimpleChatMessage = ({
         setIsUploaderLoading={setIsUploaderLoading}
         simpleChatMessage={simpleChatMessage}
         simpleChatMessageIndex={simpleChatMessageIndex}
+        simpleChatStep={simpleChatStep}
       />
     </FormSection>
   )

--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
@@ -68,10 +68,10 @@ const SimpleChatMessages = ({
   onFocus,
   setIsCropping,
   setIsUploaderLoading,
-  simpleChatMessages,
+  simpleChatStep,
 }) => (
   <div>
-    {simpleChatMessages.map((simpleChatMessage, index) =>
+    {simpleChatStep.simpleChatMessagesAttributes.map((simpleChatMessage, index) =>
       simpleChatMessage._destroy ? null : (
         <SortableSimpleChatMessage
           activeSimpleChatMessages={activeSimpleChatMessages}
@@ -86,6 +86,7 @@ const SimpleChatMessages = ({
           setIsUploaderLoading={setIsUploaderLoading}
           simpleChatMessage={simpleChatMessage}
           simpleChatMessageIndex={index}
+          simpleChatStep={simpleChatStep}
         />
       )
     )}
@@ -243,7 +244,7 @@ const SimpleChatStep = ({
               onSortEnd={onSimpleChatMessagesSortEnd}
               setIsCropping={setIsCropping}
               setIsUploaderLoading={setIsUploaderLoading}
-              simpleChatMessages={simpleChatStep.simpleChatMessagesAttributes}
+              simpleChatStep={simpleChatStep}
               useDragHandle
             />
           )}

--- a/console-frontend/src/app/resources/simple-chats/form/text-message-fields.js
+++ b/console-frontend/src/app/resources/simple-chats/form/text-message-fields.js
@@ -212,12 +212,22 @@ const beautifyHTML = value => {
   })
 }
 
-const TextMessageFields = ({ disabled, onChange, onFocus, simpleChatMessage, simpleChatMessageIndex }) => {
+const TextMessageFields = ({
+  disabled,
+  onChange,
+  onFocus,
+  simpleChatMessage,
+  simpleChatMessageIndex,
+  simpleChatStep,
+}) => {
   const textEditorRef = useRef(null)
   const [isHTMLMode, setIsHTMLMode] = useState(false)
   const [value, setValue] = useState(simpleChatMessage.html)
 
-  const toolbarId = useMemo(() => `toolbar-${simpleChatMessage.id || simpleChatMessage.__key}`, [simpleChatMessage])
+  const toolbarId = useMemo(
+    () => `toolbar-${simpleChatStep.__key || simpleChatStep.key}-${simpleChatMessage.id || simpleChatMessage.__key}`,
+    [simpleChatMessage, simpleChatStep]
+  )
 
   const textEditorModules = useMemo(() => ({ toolbar: `#${toolbarId}`, ...textEditorConfig.modules }), [toolbarId])
 


### PR DESCRIPTION
## Changes

Fix bug with HTML editor toolbar: the `id` of the toolbar was related to the `SimpleChatMessage` key, causing duplicate ids (there can be different messages with the same key, in different steps). It is now related also to the `SImpleChatStep`.

## Preview

![image](https://user-images.githubusercontent.com/24722181/61446796-ae169b00-a947-11e9-9a1a-943da84196a2.png)