### PR TITLE
Fix welcome/onboarding

### DIFF
--- a/console-frontend/src/app/layout/menu.js
+++ b/console-frontend/src/app/layout/menu.js
@@ -248,7 +248,7 @@ const MenuLogo = ({ sidebarOpen, toggleOpen }) => (
 
 const BaseMenu = withRouter(
   memo(({ location, menuLoaded, sidebarOpen, stageIndex, toggleOpen }) => {
-    if (!menuLoaded && stageIndex === 0 && location.pathname === routes.root()) {
+    if (!menuLoaded && stageIndex === 0 && location.pathname === routes.welcome()) {
       return <DummyMenu />
     }
 

--- a/console-frontend/src/app/screens/welcome.js
+++ b/console-frontend/src/app/screens/welcome.js
@@ -26,7 +26,7 @@ const WelcomePage = ({ history, width }) => {
     () => {
       changeStage(1)
       setOnboarding({ ...onboarding, run: false, stageIndex: 1 })
-      history.push(routes.root())
+      history.push(routes.accountRoot())
     },
     [history, onboarding, setOnboarding]
   )

--- a/console-frontend/src/ext/hooks/use-onboarding.js
+++ b/console-frontend/src/ext/hooks/use-onboarding.js
@@ -1,5 +1,3 @@
-import auth from 'auth'
-import routes from 'app/routes'
 import { StoreContext } from 'ext/hooks/store'
 import { useCallback, useContext, useEffect, useMemo, useReducer } from 'react'
 
@@ -10,7 +8,7 @@ const initialOnboardingState = {
   help: { run: false },
 }
 
-export const useOnboarding = location => {
+export const useOnboarding = () => {
   const { store, setStore } = useContext(StoreContext)
 
   const [onboarding, dispatch] = useReducer((state, action) => {
@@ -25,18 +23,6 @@ export const useOnboarding = location => {
 
   const setOnboarding = useCallback(value => dispatch({ type: 'merge', value }), [dispatch])
   const setOnboardingHelp = useCallback(value => dispatch({ type: 'mergeHelp', value }), [dispatch])
-
-  useEffect(
-    () => {
-      const stageIndex = auth.getUser().onboardingStage
-      const newOnboardingState = {
-        stageIndex,
-        run: !(location.pathname === routes.root()) && stageIndex === 0,
-      }
-      setOnboarding(newOnboardingState)
-    },
-    [location, setOnboarding]
-  )
 
   useEffect(
     () => {

--- a/console-frontend/src/onboarding/stages/initial.js
+++ b/console-frontend/src/onboarding/stages/initial.js
@@ -9,7 +9,7 @@ const nonEditorRoleOrder = ['triggers', 'showcases', 'simpleChats', 'outros', 'p
 
 const order = () => (auth.getAccountRole() === 'editor' ? editorRoleOrder : nonEditorRoleOrder)
 
-const editorRoleSteps = {
+const editorRoleSteps = () => ({
   simpleChats: {
     target: '.onboard-simple-chats',
     content: <Tooltip body="Create your Simple Chats here." nextRoute={routes.picturesList()} />,
@@ -24,9 +24,9 @@ const editorRoleSteps = {
     disableBeacon: true,
     title: 'Pictures Gallery',
   },
-}
+})
 
-const nonEditorRoleSteps = {
+const nonEditorRoleSteps = () => ({
   triggers: {
     target: '.onboard-triggers',
     content: <Tooltip body="Create your Triggers here." nextRoute={routes.showcasesList()} />,
@@ -69,8 +69,8 @@ const nonEditorRoleSteps = {
     disableBeacon: true,
     title: 'Personas',
   },
-}
+})
 
-const steps = () => (auth.getAccountRole() === 'editor' ? editorRoleSteps : nonEditorRoleSteps)
+const steps = () => (auth.getAccountRole() === 'editor' ? editorRoleSteps() : nonEditorRoleSteps())
 
 export default { steps, order }


### PR DESCRIPTION
## Fixed:
**Welcome page:**
- The user was always seeing the onboarding process. Now it only shows if the user clicks the "Get Started" button.
- The dummy sidebar was not showing.
- The "Skip onboarding" button was linking to the root "/", resulting in a redirect to "/accounts" for multiple membership accounts.

**Onboarding process:**
- The links were not working.

[Link To Trello Card](https://trello.com/c/8KQ3t9AU/1427-welcome-onboarding-dont-run-immediately)