### PR TITLE
Make ProductMessage DisplayPrice field optional

### DIFF
--- a/backend/app/models/simple_chat_product_message.rb
+++ b/backend/app/models/simple_chat_product_message.rb
@@ -3,7 +3,6 @@ class SimpleChatProductMessage < SimpleChatMessage
 
   validates :title, presence: true
   validates :url, presence: true
-  validates :display_price, presence: true
 
   def as_json(_options = {})
     super.except(:pic_id).merge(attributes.slice("title", "url", "display_price", "group_with_adjacent", "pic_rect"))

--- a/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
+++ b/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
@@ -50,7 +50,6 @@ const ProductMessagesForm = ({
       name="displayPrice"
       onChange={onFormChange}
       onFocus={onFocus}
-      required
       value={simpleChatMessage.displayPrice || ''}
     />
     <PictureUploader


### PR DESCRIPTION
### Changes
- Made it so that now the `displayPrice` field is no longer required.

### Notes
- As the `display_price` field in the DB is optional, there was no need to create a migration.