### PR TITLE
Change date selector design in data dashboard page

### DIFF
--- a/console-frontend/src/app/screens/account/edit-website.js
+++ b/console-frontend/src/app/screens/account/edit-website.js
@@ -7,8 +7,9 @@ import React, { useCallback, useMemo } from 'react'
 import Section from 'shared/section'
 import styled from 'styled-components'
 import useForm from 'ext/hooks/use-form'
+import WhiteButton from 'shared/white-button'
 import { apiRequest, apiWebsiteShow, apiWebsiteUpdate, atLeastOneNonBlankCharInputProps } from 'utils'
-import { Checkbox, FormControlLabel, Button as MuiButton, TextField } from '@material-ui/core'
+import { Checkbox, FormControlLabel, TextField } from '@material-ui/core'
 import { FormHelperText } from 'shared/form-elements'
 import { Prompt } from 'react-router'
 import { useSnackbar } from 'notistack'
@@ -138,24 +139,14 @@ const EditWebsite = () => {
         {form.previewMode && (
           <>
             <PreviewButtonsContainer>
-              <MuiButton
-                href={`http://${form.hostnames[0]}/#trnd:preview:1`}
-                size="small"
-                target="_blank"
-                variant="contained"
-              >
+              <WhiteButton href={`http://${form.hostnames[0]}/#trnd:preview:1`} target="_blank" variant="contained">
                 {'Enable preview mode'}
                 <StyledOpenInNewIcon />
-              </MuiButton>
-              <MuiButton
-                href={`http://${form.hostnames[0]}/#trnd:preview:0`}
-                size="small"
-                target="_blank"
-                variant="contained"
-              >
+              </WhiteButton>
+              <WhiteButton href={`http://${form.hostnames[0]}/#trnd:preview:0`} target="_blank" variant="contained">
                 {'Disable preview mode'}
                 <StyledOpenInNewIcon />
-              </MuiButton>
+              </WhiteButton>
             </PreviewButtonsContainer>
             <FormHelperText>
               {

--- a/console-frontend/src/app/screens/data-dashboard/index.js
+++ b/console-frontend/src/app/screens/data-dashboard/index.js
@@ -4,9 +4,9 @@ import React, { useCallback, useState } from 'react'
 import Section from 'shared/section'
 import styled from 'styled-components'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
+import WhiteButton from 'shared/white-button'
 import { DatePicker } from 'material-ui-pickers'
 import { differenceInMonths, endOfMonth, format, startOfMonth, subMonths } from 'date-fns'
-import { FormControl } from '@material-ui/core'
 
 const appBarContent = { title: 'Data Dashboard' }
 
@@ -16,21 +16,32 @@ const ChartContainer = styled.div``
 const minDate = () =>
   differenceInMonths(Date.now(), new Date('2019-06-01')) >= 4 ? subMonths(Date.now(), 4) : new Date('2019-06-01')
 
+const DatePickerValue = styled.div`
+  color: #ff6641;
+  padding-left: 5px;
+`
+
+const DatePickerComponent = ({ onClick, label, value }) => {
+  return (
+    <WhiteButton onClick={onClick} variant="contained">
+      <div>{`${label}:`}</div>
+      <DatePickerValue>{value}</DatePickerValue>
+    </WhiteButton>
+  )
+}
+
 const DateSelector = ({ dates, handleDateChange }) => (
-  <FormControl style={{ flex: '1', textAlign: 'right' }}>
-    <div className="picker">
-      <DatePicker
-        disableFuture
-        format="MMMM"
-        label="Month"
-        maxDate={Date.now()}
-        minDate={minDate()}
-        onChange={handleDateChange}
-        value={dates.from_date}
-        views={['year', 'month']}
-      />
-    </div>
-  </FormControl>
+  <DatePicker
+    disableFuture
+    format="MMMM"
+    label="Month"
+    maxDate={Date.now()}
+    minDate={minDate()}
+    onChange={handleDateChange}
+    TextFieldComponent={DatePickerComponent}
+    value={dates.from_date}
+    views={['year', 'month']}
+  />
 )
 
 const DataDashboard = styled(({ className }) => {

--- a/console-frontend/src/shared/white-button.js
+++ b/console-frontend/src/shared/white-button.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { Button } from '@material-ui/core'
+
+const WhiteButton = styled(Button)`
+  background: #fff;
+  &:hover {
+    background: #f3f3f3;
+  }
+`
+
+export default WhiteButton


### PR DESCRIPTION
### Changes
- Date selector in dashboard page is now using a button component instead of a text field;

### Notes
- The buttons in the account page are now using the same component as for the Date Selector component;
- The button component design was changed in this PR as well.