### PR TITLE
Style adjustments to signup/hostnames

### DIFF
--- a/console-frontend/src/auth/components.js
+++ b/console-frontend/src/auth/components.js
@@ -61,4 +61,20 @@ const AuthStyledForm = styled.form`
   }
 `
 
-export { AuthButton, AuthLink, AuthStyledForm, AuthTitle, AuthText, AuthMessage }
+const AuthFormFooter = styled.div`
+  padding-top: 2rem;
+
+  button,
+  p {
+    margin: 0 0 1rem;
+  }
+
+  @media (max-width: 900px) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+`
+
+export { AuthButton, AuthLink, AuthStyledForm, AuthFormFooter, AuthTitle, AuthText, AuthMessage }

--- a/console-frontend/src/auth/login/index.js
+++ b/console-frontend/src/auth/login/index.js
@@ -5,7 +5,7 @@ import Link from 'shared/link'
 import React, { useCallback, useEffect, useState } from 'react'
 import routes from 'app/routes'
 import { apiRequest, apiSignIn } from 'utils'
-import { AuthStyledForm } from 'auth/components'
+import { AuthFormFooter, AuthStyledForm } from 'auth/components'
 import { FormControl, Input, InputLabel } from '@material-ui/core'
 import { useSnackbar } from 'notistack'
 
@@ -37,22 +37,20 @@ const Login = ({ loginForm, loginSubmit, setLoginValue }) => (
           value={loginForm.password}
         />
       </FormControl>
-      <div style={{ marginTop: '2rem', width: '70%' }}>
+      <AuthFormFooter>
         <Button color="primaryGradient" fullWidth type="submit" variant="contained">
           {'Login'}
         </Button>
-      </div>
-      <div style={{ marginTop: '1rem' }}>
         <Link to={routes.requestPasswordReset()}>
           <Button color="primaryText" variant="text">
             {'Forgot Password?'}
           </Button>
         </Link>
-      </div>
-      <div style={{ marginTop: '1rem' }}>
-        {"Don't have an account? "}
-        <Link to={routes.signup()}>{'Signup'}</Link>
-      </div>
+        <p>
+          {"Don't have an account? "}
+          <Link to={routes.signup()}>{'Signup'}</Link>
+        </p>
+      </AuthFormFooter>
     </AuthStyledForm>
   </AuthLayout>
 )

--- a/console-frontend/src/auth/signup/index.js
+++ b/console-frontend/src/auth/signup/index.js
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useReducer, useRef } from 'react'
 import routes from 'app/routes'
 import styled from 'styled-components'
 import { apiRequest, apiSignUp } from 'utils'
-import { AuthStyledForm } from 'auth/components'
+import { AuthFormFooter, AuthStyledForm } from 'auth/components'
 import { FormControl, Input, InputLabel } from '@material-ui/core'
 import { useSnackbar } from 'notistack'
 
@@ -136,6 +136,9 @@ const Signup = () => {
             deleteHostname={deleteHostname}
             editHostnameValue={editHostnameValue}
             form={state.form}
+            fullWidth
+            margin="normal"
+            required
           />
           <FormControl fullWidth margin="normal" required>
             <InputLabel htmlFor="email">{'E-mail'}</InputLabel>
@@ -180,15 +183,15 @@ const Signup = () => {
               value={state.form.passwordConfirmation}
             />
           </FormControl>
-          <div style={{ marginTop: '2rem', width: '70%' }}>
+          <AuthFormFooter>
             <Button color="primaryGradient" fullWidth type="submit" variant="contained">
               {'Signup'}
             </Button>
-          </div>
-          <div style={{ marginTop: '1rem' }}>
-            {'Already have an account? '}
-            <Link to={routes.login()}>{'Login'}</Link>
-          </div>
+            <p>
+              {'Already have an account? '}
+              <Link to={routes.login()}>{'Login'}</Link>
+            </p>
+          </AuthFormFooter>
         </AuthStyledForm>
       )}
     </AuthLayout>

--- a/console-frontend/src/shared/hostnames-form.js
+++ b/console-frontend/src/shared/hostnames-form.js
@@ -3,12 +3,7 @@ import Button from 'shared/button'
 import MuiCancel from '@material-ui/icons/Cancel'
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
-import { IconButton, InputLabel, TextField, Typography } from '@material-ui/core'
-
-const LabelContainer = styled.div`
-  margin-top: 1rem;
-  margin-bottom: -10px;
-`
+import { FormControl, IconButton, TextField, Typography } from '@material-ui/core'
 
 const StyledAddCircleOutline = styled(AddCircleOutline)`
   color: #6c6c6c;
@@ -28,6 +23,7 @@ const AddHostnameButton = ({ disabled, addHostnameSelect }) => (
 const FlexDiv = styled.div`
   display: flex;
   align-items: center;
+  width: 100%;
 `
 
 const HostnameTextField = ({ index, onChange, value, ...props }) => {
@@ -58,6 +54,7 @@ const HostnameField = ({ allowDelete, editHostnameValue, index, isFormLoading, h
         disabled={isFormLoading}
         index={index}
         inputProps={inputProps}
+        label={index === 0 && 'Hostnames'}
         onChange={editHostnameValue}
         required
         value={hostname}
@@ -71,13 +68,17 @@ const HostnameField = ({ allowDelete, editHostnameValue, index, isFormLoading, h
   )
 }
 
-const HostnamesForm = ({ form, addHostnameSelect, editHostnameValue, deleteHostname, isFormLoading }) => (
-  <>
-    <LabelContainer>
-      <InputLabel required style={{ transform: 'scale(0.75)', display: 'inline-block' }}>
-        {'Hostnames'}
-      </InputLabel>
-    </LabelContainer>
+const HostnamesForm = ({
+  addHostnameSelect,
+  deleteHostname,
+  editHostnameValue,
+  form,
+  fullWidth,
+  isFormLoading,
+  margin,
+  required,
+}) => (
+  <FormControl fullWidth={fullWidth} margin={margin || 'normal'} required={required}>
     {form.hostnames.map((hostname, index) => (
       <HostnameField
         allowDelete={form.hostnames.length > 1}
@@ -90,8 +91,10 @@ const HostnamesForm = ({ form, addHostnameSelect, editHostnameValue, deleteHostn
         key={index}
       />
     ))}
-    <AddHostnameButton addHostnameSelect={addHostnameSelect} disabled={isFormLoading} />
-  </>
+    <FlexDiv>
+      <AddHostnameButton addHostnameSelect={addHostnameSelect} disabled={isFormLoading} />
+    </FlexDiv>
+  </FormControl>
 )
 
 export default HostnamesForm


### PR DESCRIPTION
[Link to Trello card]()

## Changes

- Make hostname field full-width and with the same animated label as the other fields (only shown on the first input), as discussed with DW
- Left-align "add hostname" button
- Center login/signup buttons and additional text in smaller screens

## Preview

![image](https://user-images.githubusercontent.com/24722181/61652781-aa20ab00-acb0-11e9-9300-ea2238389f6d.png)
