### PR TITLE
Fix accounts storage

### DIFF
--- a/console-frontend/src/app/app-router-helpers.js
+++ b/console-frontend/src/app/app-router-helpers.js
@@ -3,6 +3,7 @@ import NotFound from 'app/screens/not-found'
 import React, { useCallback, useEffect } from 'react'
 import routes from './routes'
 import { apiAccountsShow, apiRequest } from 'utils'
+import { isLocalStorageAccurate } from 'utils'
 import { Redirect, Route } from 'react-router-dom'
 
 const PrivateRouteRender = ({
@@ -22,6 +23,7 @@ const PrivateRouteRender = ({
           setFetchedAccount(false)
           const { json } = await apiRequest(apiAccountsShow, [auth.getSlug()])
           auth.setAccount(json)
+          if (!isLocalStorageAccurate()) return
           setFetchedAccount(true)
         }
       })()

--- a/console-frontend/src/app/screens/not-found/index.js
+++ b/console-frontend/src/app/screens/not-found/index.js
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react'
 import routes from 'app/routes'
 import styled from 'styled-components'
 import { Button, Typography } from '@material-ui/core'
+import { isLocalStorageAccurate } from 'utils'
 
 const Fullscreen = styled.div`
   position: relative;
@@ -45,6 +46,8 @@ const NotFound = () => {
     event.preventDefault()
     window.location.href = routes.root()
   }, [])
+
+  if (!isLocalStorageAccurate()) return null
 
   return (
     <Fullscreen>

--- a/console-frontend/src/utils/index.js
+++ b/console-frontend/src/utils/index.js
@@ -169,3 +169,14 @@ export const refreshRoute = (history, route, query) => {
   history.push(routes.nullRoute())
   history.replace(route, query)
 }
+
+export const isLocalStorageAccurate = () => {
+  const accounts = localStorage.getItem('accounts')
+  const accountsObject = accounts && JSON.parse(accounts)
+  const accurate = accountsObject && !Object.keys(accountsObject).find(itemKey => !accountsObject[itemKey])
+
+  if (!auth.isLoggedIn() || accurate) {
+    return true
+  }
+  apiSignOut()
+}


### PR DESCRIPTION
### Changes
- When a user comes to the admin panel and doesn't have `accounts` key in his browser's `localStorage` or some of the items in the `accounts` object is empty (`null` / `undefined`) it will be logged out.
- If the user was on `/triggers` pathname previously, he'll see the 404 page and the `PrivateRouteRender` will not be run. This case is covered here as well.