### PR TITLE
Autofocus first field in all forms

### DIFF
--- a/console-frontend/src/app/layout/menu/modal-user-settings/edit-me.js
+++ b/console-frontend/src/app/layout/menu/modal-user-settings/edit-me.js
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import useForm from 'ext/hooks/use-form'
 import WhiteButton from 'shared/white-button'
 import { apiMe, apiMeUpdate, apiRequest, atLeastOneNonBlankCharInputProps } from 'utils'
+import { Field } from 'shared/form-elements'
 import { Prompt } from 'react-router'
 import { TextField } from '@material-ui/core'
 import { useSnackbar } from 'notistack'
@@ -103,7 +104,8 @@ const EditMe = ({ togglePasswordForm }) => {
         required
         value={form.email}
       />
-      <TextField
+      <Field
+        autoFocus
         disabled={isFormLoading || isCropping || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}

--- a/console-frontend/src/app/resources/showcases/form/product-pick.js
+++ b/console-frontend/src/app/resources/showcases/form/product-pick.js
@@ -69,6 +69,7 @@ const ProductPick = ({
       title={productPick.id ? productPick.name : 'New Product Pick'}
     >
       <Field
+        autoFocus={index > 0 && !productPick.id}
         disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}

--- a/console-frontend/src/app/resources/showcases/form/spotlight.js
+++ b/console-frontend/src/app/resources/showcases/form/spotlight.js
@@ -166,6 +166,7 @@ const Spotlight = ({
       >
         <Autocomplete
           autocomplete={apiPersonasAutocomplete}
+          autoFocus={index > 0 && !spotlight.id}
           defaultPlaceholder="Choose a persona"
           disabled={isCropping || isFormLoading || isUploaderLoading}
           fullWidth

--- a/console-frontend/src/app/resources/simple-chats/form/main-form.js
+++ b/console-frontend/src/app/resources/simple-chats/form/main-form.js
@@ -50,6 +50,7 @@ const MainForm = ({
   return (
     <Section title={title}>
       <Field
+        autoFocus
         disabled={isCropping || isFormLoading || isUploaderLoading}
         fullWidth
         inputProps={atLeastOneNonBlankCharInputProps}

--- a/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
+++ b/console-frontend/src/app/resources/simple-chats/form/product-message-fields.js
@@ -4,6 +4,7 @@ import { Checkbox, FormControlLabel } from '@material-ui/core'
 import { Field, FormHelperText } from 'shared/form-elements'
 
 const ProductMessagesForm = ({
+  autoFocus,
   isCropping,
   isFormLoading,
   isNextSameType,
@@ -19,6 +20,7 @@ const ProductMessagesForm = ({
 }) => (
   <>
     <Field
+      autoFocus={autoFocus}
       disabled={isCropping || isFormLoading || isUploaderLoading}
       fullWidth
       label="Title"
@@ -80,6 +82,7 @@ const ProductMessagesForm = ({
 )
 
 const ProductMessageFields = ({
+  autoFocus,
   isCropping,
   isFormLoading,
   isNextSameType,
@@ -117,6 +120,7 @@ const ProductMessageFields = ({
 
   return (
     <ProductMessagesForm
+      autoFocus={autoFocus}
       isCropping={isCropping}
       isFormLoading={isFormLoading}
       isNextSameType={isNextSameType}

--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-message.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-message.js
@@ -38,10 +38,16 @@ const MessageField = ({
   simpleChatMessageIndex,
   simpleChatStep,
 }) => {
+  const autoFocus = useMemo(() => simpleChatMessageIndex > 0 && !simpleChatMessage.id, [
+    simpleChatMessage.id,
+    simpleChatMessageIndex,
+  ])
+
   switch (simpleChatMessage.type) {
     case 'SimpleChatTextMessage':
       return (
         <TextMessageFields
+          autoFocus={autoFocus}
           disabled={isFormLoading || isUploaderLoading}
           name="simpleChatMessage_text"
           onChange={onSimpleChatMessageEdit}
@@ -54,6 +60,7 @@ const MessageField = ({
     case 'SimpleChatProductMessage':
       return (
         <ProductMessageFields
+          autoFocus={autoFocus}
           isCropping={isCropping}
           isFormLoading={isFormLoading}
           isNextSameType={isNextSameType}
@@ -71,6 +78,7 @@ const MessageField = ({
     case 'SimpleChatVideoMessage':
       return (
         <VideoMessageField
+          autoFocus={autoFocus}
           disabled={isFormLoading || isUploaderLoading}
           name="simpleChatMessage_video"
           onChange={onSimpleChatMessageEdit}

--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-step.js
@@ -224,6 +224,7 @@ const SimpleChatStep = ({
         <>
           {simpleChatStep.key !== 'default' && (
             <Field
+              autoFocus={simpleChatStepIndex > 0 && !simpleChatStep.id}
               disabled={isCropping || isFormLoading || isUploaderLoading}
               fullWidth
               inputProps={atLeastOneNonBlankCharInputProps}

--- a/console-frontend/src/app/resources/simple-chats/form/text-message-fields.js
+++ b/console-frontend/src/app/resources/simple-chats/form/text-message-fields.js
@@ -213,6 +213,7 @@ const beautifyHTML = value => {
 }
 
 const TextMessageFields = ({
+  autoFocus,
   disabled,
   onChange,
   onFocus,
@@ -237,6 +238,13 @@ const TextMessageFields = ({
     // Change default input placeholder on mount
     textEditorRef.current.editor.theme.tooltip.textbox.dataset.link = 'https://frekkls.com'
   }, [])
+
+  useEffect(
+    () => {
+      autoFocus && textEditorRef.current.focus()
+    },
+    [autoFocus]
+  )
 
   const onValueChange = useCallback(
     value => {

--- a/console-frontend/src/app/resources/simple-chats/form/video-message-field.js
+++ b/console-frontend/src/app/resources/simple-chats/form/video-message-field.js
@@ -2,7 +2,15 @@ import React, { useCallback } from 'react'
 import { Field } from 'shared/form-elements'
 import { youtubeInputProps } from 'utils'
 
-const VideoMessageField = ({ disabled, name, onChange, onFocus, simpleChatMessage, simpleChatMessageIndex }) => {
+const VideoMessageField = ({
+  autoFocus,
+  disabled,
+  name,
+  onChange,
+  onFocus,
+  simpleChatMessage,
+  simpleChatMessageIndex,
+}) => {
   const onValueChange = useCallback(
     event => {
       onChange({ ...simpleChatMessage, videoUrl: event.target.value || '' }, simpleChatMessageIndex)
@@ -12,6 +20,7 @@ const VideoMessageField = ({ disabled, name, onChange, onFocus, simpleChatMessag
 
   return (
     <Field
+      autoFocus={autoFocus}
       disabled={disabled}
       fullWidth
       inputProps={youtubeInputProps}

--- a/console-frontend/src/app/resources/triggers/form.js
+++ b/console-frontend/src/app/resources/triggers/form.js
@@ -187,6 +187,7 @@ const TriggerForm = ({ history, backRoute, location, title, loadFormObject, save
         <Form formRef={formRef} isFormPristine={isFormPristine} onSubmit={newOnFormSubmit}>
           <Autocomplete
             autocomplete={apiFlowsAutocomplete}
+            autoFocus
             defaultPlaceholder="Choose a Module"
             disabled={isFormLoading}
             fullWidth

--- a/console-frontend/src/app/screens/account/users/invite.js
+++ b/console-frontend/src/app/screens/account/users/invite.js
@@ -85,6 +85,7 @@ const UserInvite = ({ history }) => {
     <Section title="Invite User">
       <Form formRef={formRef} isFormPristine={isFormPristine} onSubmit={newOnFormSubmit}>
         <Field
+          autoFocus
           disabled={isFormLoading}
           fullWidth
           label="Email"

--- a/console-frontend/src/shared/autocomplete.js
+++ b/console-frontend/src/shared/autocomplete.js
@@ -19,8 +19,18 @@ const DropdownButton = ({ onClick }) => (
   </InputAdornment>
 )
 
-const AutocompleteInput = ({ formControlProps, loadAllOptions, inputProps, label, name }) => {
+const AutocompleteInput = ({ autoFocus, disabled, formControlProps, loadAllOptions, inputProps, label, name }) => {
   const inputRef = useRef(null)
+  const [hasFocused, setHasFocused] = useState(false)
+
+  useEffect(
+    () => {
+      if (!autoFocus || hasFocused || disabled) return
+      setHasFocused(true)
+      inputRef.current.focus()
+    },
+    [autoFocus, disabled, hasFocused]
+  )
 
   const onDropdownClick = useCallback(
     () => {
@@ -37,6 +47,7 @@ const AutocompleteInput = ({ formControlProps, loadAllOptions, inputProps, label
         {label}
       </InputLabel>
       <Input
+        disabled={disabled}
         endAdornment={<DropdownButton onClick={onDropdownClick} />}
         fullWidth
         inputProps={{ ref: inputRef }}
@@ -81,6 +92,7 @@ const itemToString = selected => (selected ? selected.label : '')
 
 const Autocomplete = ({
   autocomplete,
+  autoFocus,
   disabled,
   label,
   required,
@@ -166,6 +178,8 @@ const Autocomplete = ({
       }) => (
         <div style={{ width: '100%', position: 'relative' }}>
           <AutocompleteInput
+            autoFocus={autoFocus}
+            disabled={disabled}
             formControlProps={{ disabled, required, fullWidth }}
             inputProps={getInputProps({
               placeholder: prevSelected ? prevSelected.label : defaultPlaceholder,

--- a/console-frontend/src/shared/form-elements/field.js
+++ b/console-frontend/src/shared/form-elements/field.js
@@ -1,5 +1,5 @@
 import omit from 'lodash.omit'
-import React, { memo, useCallback, useEffect, useState } from 'react'
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import theme from 'app/theme'
 import { FormControl, Input, InputLabel } from '@material-ui/core'
@@ -16,10 +16,12 @@ const Container = styled.div`
   position: relative;
 `
 
-const Field = ({ max, label, value, required, onBlur, onFocus, onChange, ...props }) => {
-  const [textLength, setTextLength] = useState(0)
-  const [isOutsideLimits, setIsOutsideLimits] = useState(false)
+const Field = ({ autoFocus, disabled, label, max, onBlur, onChange, onFocus, required, value, ...props }) => {
+  const inputRef = useRef(null)
   const [focused, setFocused] = useState(false)
+  const [hasFocused, setHasFocused] = useState(false)
+  const [isOutsideLimits, setIsOutsideLimits] = useState(false)
+  const [textLength, setTextLength] = useState(0)
 
   const handleChange = useCallback(
     event => {
@@ -49,6 +51,15 @@ const Field = ({ max, label, value, required, onBlur, onFocus, onChange, ...prop
 
   useEffect(
     () => {
+      if (!autoFocus || hasFocused || disabled) return
+      setHasFocused(true)
+      inputRef.current.focus()
+    },
+    [autoFocus, disabled, hasFocused]
+  )
+
+  useEffect(
+    () => {
       if (value.length !== textLength) {
         setTextLength(value.length)
         setIsOutsideLimits(value.length > max)
@@ -64,12 +75,14 @@ const Field = ({ max, label, value, required, onBlur, onFocus, onChange, ...prop
           {label}
         </InputLabel>
         <Input
-          required={required}
-          {...omit(props, ['setTextLength', 'setIsOutsideLimits', 'setFocused', 'margin'])}
+          disabled={!hasFocused && disabled}
+          inputRef={inputRef}
           onBlur={handleBlur}
           onChange={handleChange}
           onFocus={handleFocus}
+          required={required}
           value={value}
+          {...omit(props, ['autoFocus', 'margin', 'setFocused', 'setIsOutsideLimits', 'setTextLength'])}
         />
       </FormControl>
       {focused && max && (


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/Bj4H6E6Y)

## Changes

In all forms, the first field is now autofocusing when its section has mounted. This was done by modifying the behavior of the `autoFocus` prop on `Field` and `TextField`, making possible to use the prop on different fields on the same page.