### PR TITLE
Add "Interacted" mixpanel event

### DIFF
--- a/plugiamo/src/app/app.js
+++ b/plugiamo/src/app/app.js
@@ -117,6 +117,14 @@ const App = ({
     timeoutToDisappear,
   ])
 
+  const onUserInteracted = useCallback(() => {
+    mixpanel.track('Interacted', {
+      hostname: location.hostname,
+      flowType: flowType.current,
+      flowId: flowId.current,
+    })
+  }, [])
+
   useEffect(() => {
     if (showingContent) clearDisappearTimeout()
   }, [clearDisappearTimeout, showingContent])
@@ -131,6 +139,7 @@ const App = ({
       hideContentFrame={hideContentFrame}
       isUnmounting={isUnmounting}
       onToggleContent={onToggleContent}
+      onUserInteracted={onUserInteracted}
       persona={persona.current}
       pluginState={pluginState}
       position={getFrekklsConfig().position}

--- a/plugiamo/src/app/base.js
+++ b/plugiamo/src/app/base.js
@@ -33,6 +33,7 @@ const AppBase = ({
   showingBubbles,
   showingContent,
   showingLauncher,
+  onUserInteracted,
 }) => {
   const launcherConfig = useMemo(() => {
     const frekklsLC = getFrekklsConfig().launcherConfig
@@ -75,6 +76,7 @@ const AppBase = ({
         key={key}
         launcherConfig={launcherConfig}
         onToggleContent={onToggleContent}
+        onUserInteracted={onUserInteracted}
         persona={persona}
         position={position}
         setShowAssessmentContent={setShowAssessmentContent}

--- a/plugiamo/src/app/content/index.js
+++ b/plugiamo/src/app/content/index.js
@@ -14,6 +14,7 @@ const Content = ({
   persona,
   setShowAssessmentContent,
   showingContent,
+  onUserInteracted,
 }) => {
   const [entry, setEntry] = useState(true)
 
@@ -45,6 +46,7 @@ const Content = ({
     >
       <ContentWrapper
         onToggleContent={onToggleContent}
+        onUserInteracted={onUserInteracted}
         persona={persona}
         setShowAssessmentContent={setShowAssessmentContent}
       >

--- a/plugin-base/src/content-wrapper.js
+++ b/plugin-base/src/content-wrapper.js
@@ -14,8 +14,9 @@ const Wrapper = styled.div`
   color: #333;
 `
 
-const ContentWrapper = ({ children, ...props }) => {
+const ContentWrapper = ({ children, onUserInteracted, ...props }) => {
   const [isTransitioning, setIsTransitioning] = useState(false)
+  const [interacted, setInteracted] = useState(false)
 
   useEffect(() => {
     return () => {
@@ -42,7 +43,20 @@ const ContentWrapper = ({ children, ...props }) => {
     return exitDuration
   }, [])
 
-  return <Wrapper>{React.cloneElement(children, { ...props, isTransitioning, onRouteChange })}</Wrapper>
+  const handleFirstInteraction = useCallback(
+    event => {
+      if (interacted || event.which === 3) return
+      onUserInteracted && onUserInteracted()
+      setInteracted(true)
+    },
+    [onUserInteracted, interacted]
+  )
+
+  return (
+    <Wrapper onMouseDown={handleFirstInteraction} onTouchStart={handleFirstInteraction}>
+      {React.cloneElement(children, { ...props, isTransitioning, onRouteChange })}
+    </Wrapper>
+  )
 }
 
 export default ContentWrapper


### PR DESCRIPTION
### Changes
- Added `Interacted` event which will happen if the user clicks / touches the plugin content. When the user clicks `X` button in mobile screen, it will not fire though.
- It will fire even if the user clicks some children of the `Content` component, such as chat option, AF option, picture, product, etc.

### Tested
- MacOS (Firefox / Chrome / Safari);
- Windows (Firefox / Chrome / Opera);
- Ubuntu 18.04 (Chrome);
- Android (Firefox / Chrome);