### PR TITLE
Change pictures file_format type to string

### DIFF
--- a/backend/app/models/picture.rb
+++ b/backend/app/models/picture.rb
@@ -13,8 +13,6 @@ class Picture < ApplicationRecord
   has_many :simple_chat_product_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
   has_many :simple_chat_picture_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
 
-  enum file_format: %i[jpeg png gif]
-
   validate :url_must_be_valid
   validates :url, presence: true, uniqueness: true
 
@@ -30,7 +28,7 @@ class Picture < ApplicationRecord
 
   def as_json(_options = {})
     attributes
-      .slice("id", "url", "created_at", "updated_at")
+      .slice("id", "url", "file_format", "created_at", "updated_at")
       .merge(personas: personas,
              product_picks: product_picks,
              simple_chat_messages: simple_chat_messages)

--- a/backend/db/migrate/20190725160615_remove_file_format_from_pictures.rb
+++ b/backend/db/migrate/20190725160615_remove_file_format_from_pictures.rb
@@ -1,0 +1,5 @@
+class RemoveFileFormatFromPictures < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :pictures, :file_format
+  end
+end

--- a/backend/db/migrate/20190725160758_add_file_format_to_pictures.rb
+++ b/backend/db/migrate/20190725160758_add_file_format_to_pictures.rb
@@ -1,0 +1,5 @@
+class AddFileFormatToPictures < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pictures, :file_format, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190725131417) do
+ActiveRecord::Schema.define(version: 20190725160758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,8 +94,8 @@ ActiveRecord::Schema.define(version: 20190725131417) do
     t.bigint "account_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "file_format"
     t.boolean "active", default: false
+    t.string "file_format"
     t.index ["account_id"], name: "index_pictures_on_account_id"
   end
 


### PR DESCRIPTION
Fix to PR https://github.com/trendiamo/core/pull/755:
- Added migrations to remove the previous column "file_format", integer from the pictures table and re-add it with type string.