### PR TITLE
Add pictures file_format validation

### DIFF
--- a/backend/app/models/picture.rb
+++ b/backend/app/models/picture.rb
@@ -13,6 +13,7 @@ class Picture < ApplicationRecord
   has_many :simple_chat_product_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
   has_many :simple_chat_picture_messages, foreign_key: :pic_id, dependent: :restrict_with_exception, inverse_of: :pic
 
+  validates :file_format, inclusion: { in: %w[gif jpeg png] }
   validate :url_must_be_valid
   validates :url, presence: true, uniqueness: true
 

--- a/backend/db/migrate/20190726105744_change_file_format_on_pictures.rb
+++ b/backend/db/migrate/20190726105744_change_file_format_on_pictures.rb
@@ -1,0 +1,5 @@
+class ChangeFileFormatOnPictures < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :pictures, :file_format, false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190725160758) do
+ActiveRecord::Schema.define(version: 20190726105744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 20190725160758) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "active", default: false
-    t.string "file_format"
+    t.string "file_format", null: false
     t.index ["account_id"], name: "index_pictures_on_account_id"
   end
 


### PR DESCRIPTION
## Update:
- Add validation for `picture`'s `file_format` field (db + model).

[Link To Trello Card](https://trello.com/c/ByLur2Eb/1444-picture-gallery-bug-in-some-sorting-methods)