### PR TITLE
Fix launcher disappearing bug in PC assessment flow

### DIFF
--- a/plugiamo/src/app/app.js
+++ b/plugiamo/src/app/app.js
@@ -3,7 +3,6 @@ import getFrekklsConfig from 'frekkls-config'
 import mixpanel from 'ext/mixpanel'
 import setup from './setup'
 import setupFlowHistory from './setup/flow-history'
-import useTimeout from 'ext/hooks/use-timeout'
 import { h } from 'preact'
 import { isDeliusAssessment } from 'special/assessment/utils'
 import { isSmall } from 'utils'
@@ -12,12 +11,14 @@ import { timeout } from 'plugin-base'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 const App = ({
+  clearDisappearTimeout,
   Component,
   data,
   disappear,
   hideContentFrame,
   pluginState,
   setDisappear,
+  setDisappearTimeout,
   setPluginState,
   setShowAssessmentContent,
   setShowingBubbles,
@@ -28,7 +29,6 @@ const App = ({
   timeoutToDisappear,
 }) => {
   const [isUnmounting, setIsUnmounting] = useState(false)
-  const [setDisappearTimeout, clearDisappearTimeout] = useTimeout()
   const autoOpen = useRef(null)
   const flowType = useRef(null)
   const flowId = useRef(null)

--- a/plugiamo/src/shared/modal.js
+++ b/plugiamo/src/shared/modal.js
@@ -52,7 +52,7 @@ const styles = {
 const ModalTemplate = ({ allowBackgroundClose, closeModal, children, isResourceLoaded }, ref) => {
   return (
     <div onClick={allowBackgroundClose && closeModal} ref={ref} role="presentation" style={styles.modal} tabIndex="-1">
-      <IconClose onClick={closeModal} style={styles.iconClose} />
+      <IconClose onClick={!allowBackgroundClose && closeModal} style={styles.iconClose} />
       <div role="dialog" style={styles.dialog}>
         {isResourceLoaded === false && (
           <div style={styles.loaderContainer}>

--- a/plugiamo/src/special/assessment/app-hacks.js
+++ b/plugiamo/src/special/assessment/app-hacks.js
@@ -6,6 +6,7 @@ import AssessmentForm from './form'
 import AssessmentSizeGuide from './size-guide'
 import googleAnalytics from 'ext/google-analytics'
 import Router from 'app/content/router'
+import useTimeout from 'ext/hooks/use-timeout'
 import { assessmentHostname } from 'config'
 import { getScrollbarWidth } from 'utils'
 import { h } from 'preact'
@@ -19,13 +20,14 @@ const defaultShowingContent = isDeliusAssessment() ? assessmentHostname === 'www
 const assessmentModule = assessmentData[assessmentHostname] && assessmentData[assessmentHostname].assessment
 
 const AppHacks = ({ data }) => {
+  const [disappear, setDisappear] = useState(false)
   const [hideContentFrame, setHideContentFrame] = useState(false)
+  const [pluginState, setPluginState] = useState('default')
+  const [setDisappearTimeout, clearDisappearTimeout] = useTimeout()
+  const [showAssessmentContent, setShowAssessmentContent] = useState(false)
   const [showingBubbles, setShowingBubbles] = useState(isShowingDefault)
   const [showingContent, setShowingContent] = useState(defaultShowingContent)
   const [showingLauncher, setShowingLauncher] = useState(isShowingDefault)
-  const [pluginState, setPluginState] = useState('default')
-  const [disappear, setDisappear] = useState(false)
-  const [showAssessmentContent, setShowAssessmentContent] = useState(false)
 
   useEffect(() => {
     if (getScrollbarWidth() === 0) return
@@ -40,8 +42,10 @@ const AppHacks = ({ data }) => {
     () =>
       showAssessmentContent || isDeliusAssessment() ? (
         <Assessment
+          isDelius={isDeliusAssessment()}
           module={assessmentModule}
           setDisappear={setDisappear}
+          setDisappearTimeout={setDisappearTimeout}
           setHideContentFrame={setHideContentFrame}
           setPluginState={setPluginState}
           setShowAssessmentContent={setShowAssessmentContent}
@@ -52,12 +56,14 @@ const AppHacks = ({ data }) => {
       ) : (
         <Router />
       ),
-    [showAssessmentContent, showingContent]
+    [setDisappearTimeout, showAssessmentContent, showingContent]
   )
 
   if (isDeliusPDP()) {
     return (
       <AssessmentForm
+        clearDisappearTimeout={clearDisappearTimeout}
+        setDisappearTimeout={setDisappearTimeout}
         setShowingContent={setShowingContent}
         showingBubbles={showingBubbles}
         showingContent={showingContent}
@@ -80,6 +86,8 @@ const AppHacks = ({ data }) => {
   if (!data.loading && !data.error && !data.flow && isPCAssessment()) {
     return (
       <AssessmentSizeGuide
+        clearDisappearTimeout={clearDisappearTimeout}
+        setDisappearTimeout={setDisappearTimeout}
         setShowingContent={setShowingContent}
         showingBubbles={showingBubbles}
         showingContent={showingContent}
@@ -92,12 +100,14 @@ const AppHacks = ({ data }) => {
 
   return (
     <App
+      clearDisappearTimeout={clearDisappearTimeout}
       Component={Component}
       data={showAssessmentContent || isDeliusAssessment() ? assessmentModule : data}
       disappear={disappear}
       hideContentFrame={hideContentFrame}
       pluginState={pluginState}
       setDisappear={setDisappear}
+      setDisappearTimeout={setDisappearTimeout}
       setPluginState={setPluginState}
       setShowAssessmentContent={setShowAssessmentContent}
       setShowingBubbles={setShowingBubbles}

--- a/plugiamo/src/special/assessment/form/index.js
+++ b/plugiamo/src/special/assessment/form/index.js
@@ -5,7 +5,6 @@ import data from 'special/assessment/data/delius'
 import getFrekklsConfig from 'frekkls-config'
 import mixpanel from 'ext/mixpanel'
 import useChatActions from 'ext/hooks/use-chat-actions'
-import useTimeout from 'ext/hooks/use-timeout'
 import { client, gql } from 'ext/hooks/use-graphql'
 import { h } from 'preact'
 import { isSmall } from 'utils'
@@ -52,14 +51,20 @@ const inquiryMutation = variables =>
     .then(data => data)
     .catch(error => error)
 
-const Plugin = ({ setShowingContent, showingBubbles, showingContent, showingLauncher }) => {
+const Plugin = ({
+  clearDisappearTimeout,
+  setDisappearTimeout,
+  setShowingContent,
+  showingBubbles,
+  showingContent,
+  showingLauncher,
+}) => {
   const [isUnmounting, setIsUnmounting] = useState(false)
   const [assessmentForm, setAssessmentForm] = useState({})
   const [isMessageSent, setIsMessageSent] = useState(false)
   const [ctaButtonDisabled, setCtaButtonDisabled] = useState(true)
   const [pluginState, setPluginState] = useState('closed')
   const [disappear, setDisappear] = useState(false)
-  const [setDisappearTimeout, clearDisappearTimeout] = useTimeout()
 
   useEffect(() => () => timeout.clear('exitOnMobile'), [])
 

--- a/plugiamo/src/special/assessment/index.js
+++ b/plugiamo/src/special/assessment/index.js
@@ -1,14 +1,12 @@
 import AssessmentBase from './base'
-import useTimeout from 'ext/hooks/use-timeout'
-import { assessmentHostname } from 'config'
 import { h } from 'preact'
 import { isSmall } from 'utils'
 import { useCallback, useEffect, useState } from 'preact/hooks'
 
-const isDelius = assessmentHostname === 'www.delius-contract.de'
-
 const Assessment = ({
+  isDelius,
   module,
+  setDisappearTimeout,
   setDisappear,
   setHideContentFrame,
   setShowAssessmentContent,
@@ -22,7 +20,6 @@ const Assessment = ({
   const [endNodeTags, setEndNodeTags] = useState([])
   const [showingCtaButton, setShowingCtaButton] = useState(false)
   const [currentStepKey, setCurrentStepKey] = useState(assessmentState.key || 'root')
-  const [setDisappearTimeout, clearDisappearTimeout] = useTimeout()
 
   const resetAssessment = useCallback(() => {
     setTags([])
@@ -39,8 +36,9 @@ const Assessment = ({
     setHideContentFrame(false)
     setDisappearTimeout(() => setDisappear(true), isDelius ? 500 : 10000)
   }, [
-    setDisappear,
+    isDelius,
     setDisappearTimeout,
+    setDisappear,
     setHideContentFrame,
     setPluginState,
     setShowAssessmentContent,
@@ -49,12 +47,8 @@ const Assessment = ({
   ])
 
   useEffect(() => {
-    if (showingContent) clearDisappearTimeout()
-  }, [clearDisappearTimeout, showingContent])
-
-  useEffect(() => {
     if (showingContent && isDelius) setShowAssessmentContent(true)
-  }, [setShowAssessmentContent, showingContent])
+  }, [isDelius, setShowAssessmentContent, showingContent])
 
   useEffect(() => {
     setHideContentFrame(!isSmall() && currentStepKey === 'store')

--- a/plugiamo/src/special/assessment/size-guide/index.js
+++ b/plugiamo/src/special/assessment/size-guide/index.js
@@ -6,18 +6,23 @@ import data from 'special/assessment/data/pierre-cardin'
 import getFrekklsConfig from 'frekkls-config'
 import mixpanel from 'ext/mixpanel'
 import useChatActions from 'ext/hooks/use-chat-actions'
-import useTimeout from 'ext/hooks/use-timeout'
 import { fetchProducts } from 'special/assessment/utils'
 import { h } from 'preact'
 import { isSmall } from 'utils'
 import { SimpleChat, timeout } from 'plugin-base'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 
-const Plugin = ({ setShowingContent, showingBubbles, showingContent, showingLauncher }) => {
+const Plugin = ({
+  clearDisappearTimeout,
+  setDisappearTimeout,
+  setShowingContent,
+  showingBubbles,
+  showingContent,
+  showingLauncher,
+}) => {
   const [disappear, setDisappear] = useState(false)
   const [isUnmounting, setIsUnmounting] = useState(false)
   const [pluginState, setPluginState] = useState('default')
-  const [setDisappearTimeout, clearDisappearTimeout] = useTimeout()
 
   const [product, setProduct] = useState(null)
   const [productType, setProductType] = useState(null)


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/GBJexvnr)

## Changes

- Fix duplicate click event on close modal button: when the background click is allowed, it was applying the click event both on the background and the icon, causing the `onCloseModal` callback to fire twice
- Fix bug with `useTimeout` in assessment: the `Assessment` component unmounts when the modal closes, causing the reducer to reset, so `useTimeout` can't stay there, and was moved up to the parent `AppHacks`