### PR TITLE
Show icons instead of flow type title in Top Modules of DD type column

### DIFF
--- a/backend/app/services/jql/run_query.rb
+++ b/backend/app/services/jql/run_query.rb
@@ -37,7 +37,7 @@ module Jql
         next unless record
 
         item[:name] = record.name
-        item[:flowTypeTitle] = item[:flowType].underscore.humanize.titleize
+        item[:flowTypeTitle] = item[:flowType].upcase_first
         item[:active] = record.triggers.present?
       end
     end

--- a/console-frontend/src/app/screens/data-dashboard/most-interacted-modules.js
+++ b/console-frontend/src/app/screens/data-dashboard/most-interacted-modules.js
@@ -1,6 +1,7 @@
 import CircularProgress from 'shared/circular-progress'
 import EditButton from 'shared/edit-button'
 import ErrorMessage from './error-message'
+import moduleIcon from 'shared/module-icon'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import routes from 'app/routes'
 import styled from 'styled-components'
@@ -13,7 +14,7 @@ import { useSnackbar } from 'notistack'
 
 const columns = [
   { name: 'id', label: 'ID' },
-  { name: 'type', label: 'Type' },
+  { name: 'type', label: 'Type', align: 'center' },
   { name: 'name', label: 'Name' },
   {
     name: 'bar',
@@ -148,8 +149,10 @@ const MainTable = ({ data, handleRequestSort, sorting }) => {
           // eslint-disable-next-line react/no-array-index-key
           <TableRow key={index}>
             <TableCell>{record.flowId}</TableCell>
-            <TableCell width="15%">{record.flowTypeTitle}</TableCell>
-            <TableCell width="15%">{record.name}</TableCell>
+            <TableCell align="center" width="5%">
+              {moduleIcon(record.flowTypeTitle)}
+            </TableCell>
+            <TableCell width="25%">{record.name}</TableCell>
             <TableCell width="70%">
               <StatsBar
                 record={record}

--- a/console-frontend/src/shared/autocomplete/options.js
+++ b/console-frontend/src/shared/autocomplete/options.js
@@ -1,8 +1,8 @@
 import Avatar from 'shared/table-elements/avatar'
+import moduleIcon from 'shared/module-icon'
 import React from 'react'
 import styled from 'styled-components'
 import Typography from '@material-ui/core/Typography'
-import { AssignmentTurnedInOutlined, PersonPinOutlined, SmsOutlined } from '@material-ui/icons'
 import { imgixUrl, stringifyRect } from 'plugin-base'
 
 const StyledSelectLabel = styled.div`
@@ -23,22 +23,9 @@ const SelectLabelText = styled(Typography)`
   font-size: 16px;
 `
 
-const optionIcon = moduleTtype => {
-  switch (moduleTtype) {
-    case 'Showcase':
-      return <PersonPinOutlined />
-    case 'Outro':
-      return <AssignmentTurnedInOutlined />
-    case 'SimpleChat':
-      return <SmsOutlined />
-    default:
-      return null
-  }
-}
-
 const SuggestionWithModuleIcon = ({ suggestion }) => (
   <StyledSelectLabel>
-    {optionIcon(suggestion.value.type)}
+    {moduleIcon(suggestion.value.type)}
     <SelectLabelText>{suggestion.value.name}</SelectLabelText>
   </StyledSelectLabel>
 )

--- a/console-frontend/src/shared/module-icon.js
+++ b/console-frontend/src/shared/module-icon.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { AssignmentTurnedInOutlined, PersonPinOutlined, SmsOutlined } from '@material-ui/icons'
+
+const moduleIconsArray = {
+  Showcase: <PersonPinOutlined />,
+  Outro: <AssignmentTurnedInOutlined />,
+  SimpleChat: <SmsOutlined />,
+}
+
+const moduleIcon = moduleType => {
+  return moduleIconsArray[moduleType] || null
+}
+
+export default moduleIcon


### PR DESCRIPTION
### Changes
- Used the function from triggers form autocomplete field to show flow type icons;
- Extracted that function into `shared` folder;
- In the backend `flowTypeTitle` was set equal to `item[:flowType].upcase_first` in order to have more consistency on the frontend when using the functions that searches for the flow type icon;