### PR TITLE
Fix DD data selector switch bug

### DIFF
--- a/console-frontend/src/app/screens/data-dashboard/avg-cart-value.js
+++ b/console-frontend/src/app/screens/data-dashboard/avg-cart-value.js
@@ -67,20 +67,21 @@ const AvgCartValue = ({ dates }) => {
         if (requestError) {
           enqueueSnackbar(requestError, { variant: 'error' })
           setHasErrors(true)
+        } else if (json.length === 0) {
+          setHasErrors(true)
         } else {
           const labels = json.map(record => format(new Date(record.date), 'MMM d'))
           const withPluginData = json.map(record => record.withPluginTotal)
           const withoutPluginData = json.map(record => record.withoutPluginTotal)
-          if (json.length > 0) {
-            setChartData({
-              labels,
-              currency: json[0].currency,
-              datasets: [
-                { data: withoutPluginData, label: 'Without plugin' },
-                { ...withPluginDatasetConfig, data: withPluginData, label: 'With plugin' },
-              ],
-            })
-          }
+          setChartData({
+            labels,
+            currency: json[0].currency,
+            datasets: [
+              { data: withoutPluginData, label: 'Without plugin' },
+              { ...withPluginDatasetConfig, data: withPluginData, label: 'With plugin' },
+            ],
+          })
+          setHasErrors(false)
         }
         setIsLoading(false)
       })()

--- a/console-frontend/src/app/screens/data-dashboard/conversion-rate.js
+++ b/console-frontend/src/app/screens/data-dashboard/conversion-rate.js
@@ -55,10 +55,13 @@ const ConversionRate = ({ dates }) => {
         if (requestError) {
           enqueueSnackbar(requestError, { variant: 'error' })
           setHasErrors(true)
+        } else if (json.length === 0) {
+          setHasErrors(true)
         } else {
           const labels = json.map(record => format(new Date(record.date), 'MMM d'))
           const data = json.map(record => parseFloat(record.conversionRate * 100).toFixed(2))
           setChartData({ labels, datasets: [{ data, ...config }] })
+          setHasErrors(false)
         }
         setIsLoading(false)
       })()

--- a/console-frontend/src/app/screens/data-dashboard/most-interacted-modules.js
+++ b/console-frontend/src/app/screens/data-dashboard/most-interacted-modules.js
@@ -203,6 +203,7 @@ const MostInteractedModules = ({ dates }) => {
           setHasErrors(true)
         } else {
           setData(json)
+          setHasErrors(false)
         }
         setIsLoading(false)
       })()


### PR DESCRIPTION
### Changes
- Fixes the bug with switching data and not seeing results even when they should've been visible;
- Also, as part of this PR made it so that the warning about error appears when the data is empty for all the charts