### PR TITLE
Replace image for img in special flows to fix profile image not showing

### DIFF
--- a/plugiamo/src/special/assessment/data/delius.js
+++ b/plugiamo/src/special/assessment/data/delius.js
@@ -20,7 +20,7 @@ const data = {
       extraTeaserMessage: 'Wie kann ich Ihnen helfen?',
       seller: {
         name: 'Elisa',
-        image: {
+        img: {
           url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/delius/Bildschirmfoto.png',
           imgRect: {},
         },
@@ -1611,7 +1611,7 @@ const data = {
       extraTeaserMessage: '',
       seller: {
         name: 'Elisa',
-        image: {
+        img: {
           url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/delius/Bildschirmfoto.png',
           imgRect: {},
         },
@@ -1622,7 +1622,7 @@ const data = {
       extraTeaserMessage: 'Wir melden uns schnellstmöglich.',
       seller: {
         name: 'Elisa',
-        image: {
+        img: {
           url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/delius/Bildschirmfoto.png',
         },
       },

--- a/plugiamo/src/special/assessment/data/pierre-cardin.js
+++ b/plugiamo/src/special/assessment/data/pierre-cardin.js
@@ -42,7 +42,7 @@ const data = {
     seller: {
       bio: 'Designer der Hosen. Ich würde Dir gern meine Key Looks für die neue Saison vorstellen!',
       name: 'Nico de Roy',
-      image: {
+      img: {
         url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/pierre-cardin/Nico-de-Roy.jpg',
       },
     },
@@ -573,7 +573,7 @@ const data = {
       teaserMessage: 'Lust auf weitere Ergänzungen?',
       seller: {
         name: 'Nico de Roy',
-        image: {
+        img: {
           url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/pierre-cardin/Nico-de-Roy.jpg',
         },
       },
@@ -602,7 +602,7 @@ const data = {
       extraTeaserMessage: '',
       seller: {
         name: 'Nico de Roy',
-        image: {
+        img: {
           url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/pierre-cardin/Nico-de-Roy.jpg',
         },
       },
@@ -612,7 +612,7 @@ const data = {
       extraTeaserMessage: '',
       seller: {
         name: 'Nico de Roy',
-        image: {
+        img: {
           url: 'https://console-assets.ams3.digitaloceanspaces.com/manual/pierre-cardin/Nico-de-Roy.jpg',
         },
       },


### PR DESCRIPTION
### Changes
- Fixes a bug of profile image in the plugin launcher being the default one instead of an actual seller image.