### PR TITLE
Fix trigger's form module selector bug

### DIFF
--- a/console-frontend/src/shared/autocomplete/index.js
+++ b/console-frontend/src/shared/autocomplete/index.js
@@ -162,7 +162,8 @@ const Autocomplete = ({
 
   const onInputValueChange = useCallback(
     async (searchQuery, stateAndHelpers) => {
-      if (searchQuery.length <= 2) return setIsMenuOpen(false)
+      if (searchQuery.length <= 2 || stateAndHelpers.type !== '__autocomplete_change_input__')
+        return setIsMenuOpen(false)
       const { json } = await debouncedAutocomplete(searchQuery)
       const options = json.map(option => {
         return { value: option, label: option.name }


### PR DESCRIPTION
## Bug
`Downshift`'s `onInputValueChange` fires when clicking the selector without changing the input, resulting in an unwanted `debouncedAutocomplete` request and in this bug as well. 

### Bug Preview:
![bug](https://user-images.githubusercontent.com/35154956/62718578-ffbdbd00-b9fd-11e9-9a0e-2f5dee533a90.gif)

[Link To Trello Card](https://trello.com/c/S90WUwHl/1501-triggers-form-module-selector-not-rendering-all-modules)
