### PR TITLE
Disable google's translation

### DIFF
--- a/console-frontend/deploy/public-index.html
+++ b/console-frontend/deploy/public-index.html
@@ -22,6 +22,6 @@
   </head>
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
-    <div id="root"></div>
+    <div id="root" class="notranslate"></div>
   </body>
 </html>

--- a/console-frontend/public/index.html
+++ b/console-frontend/public/index.html
@@ -31,6 +31,6 @@
   </head>
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
-    <div id="root"></div>
+    <div id="root" class="notranslate"></div>
   </body>
 </html>

--- a/plugiamo/src/index.js
+++ b/plugiamo/src/index.js
@@ -35,7 +35,7 @@ const addFrekklsReactRoot = frekklsContainer => {
 
 const addFrekklsElements = () => {
   const frekklsContainer = document.createElement('div')
-  frekklsContainer.classList.add('frekkls-container')
+  frekklsContainer.classList.add('frekkls-container', 'notranslate')
   document.body.appendChild(frekklsContainer)
   const frekklsLoadingFrame = addFrekklsLoadingFrame(frekklsContainer)
   const frekklsReactRoot = addFrekklsReactRoot(frekklsContainer)

--- a/plugiamo/src/shared/modal.js
+++ b/plugiamo/src/shared/modal.js
@@ -76,7 +76,7 @@ const Modal = ({ allowBackgroundClose, closeModal, isOpen, container, children, 
     container = document.querySelector('.trendiamo-modal')
     if (!container) {
       const trendiamoModal = document.createElement('div')
-      trendiamoModal.classList.add('trendiamo-modal')
+      trendiamoModal.classList.add('trendiamo-modal', 'notranslate')
       document.body.appendChild(trendiamoModal)
       container = trendiamoModal
     }


### PR DESCRIPTION
## Feature Description:
Adding `class="notranslate"` to the `root` div disables the translation for all the content.


[Link To Trello Card](https://trello.com/c/BVqMJ5qD/1495-google-translate-issues)