### PR TITLE
Remove drag handle in the starting section but keep its space

### DIFF
--- a/console-frontend/src/app/resources/simple-chats/form/simple-chat-section.js
+++ b/console-frontend/src/app/resources/simple-chats/form/simple-chat-section.js
@@ -181,6 +181,7 @@ const SimpleChatSection = ({
         foldable
         folded={folded}
         hideTop
+        isDragHandleVisible={simpleChatSectionIndex > 0}
         title={
           simpleChatSectionIndex === 0
             ? 'Starting Section'

--- a/console-frontend/src/shared/form-elements/form-section.js
+++ b/console-frontend/src/shared/form-elements/form-section.js
@@ -26,9 +26,19 @@ const FoldButton = ({ isFoldedByLogic, folded, toggleFolded }) => (
   </IconButton>
 )
 
-const HeaderBar = ({ dragHandle, ellipsize, isFoldedByLogic, toggleFolded, folded, foldable, title, actions }) => (
+const HeaderBar = ({
+  dragHandle,
+  isDragHandleVisible,
+  ellipsize,
+  isFoldedByLogic,
+  toggleFolded,
+  folded,
+  foldable,
+  title,
+  actions,
+}) => (
   <FlexBar>
-    {dragHandle && <DragHandle />}
+    {dragHandle && <DragHandle visible={isDragHandleVisible !== false} />}
     <Header ellipsize={ellipsize} variant="subtitle1">
       {title}
     </Header>
@@ -40,6 +50,7 @@ const HeaderBar = ({ dragHandle, ellipsize, isFoldedByLogic, toggleFolded, folde
 const FormSection = ({
   backgroundColor,
   dragHandle,
+  isDragHandleVisible,
   title,
   children,
   folded: defaultFolded,
@@ -70,6 +81,7 @@ const FormSection = ({
         ellipsize={ellipsize}
         foldable={foldable}
         folded={folded}
+        isDragHandleVisible={isDragHandleVisible}
         isFoldedByLogic={isFoldedByLogic}
         title={title}
         toggleFolded={toggleFolded}

--- a/console-frontend/src/shared/sortable-elements/index.js
+++ b/console-frontend/src/shared/sortable-elements/index.js
@@ -8,10 +8,11 @@ import {
   SortableHandle,
 } from 'react-sortable-hoc'
 
-const ReorderIcon = styled(Reorder)`
+const ReorderIcon = styled(props => <Reorder {...omit(props, ['visible'])} />)`
   cursor: ns-resize;
   color: rgba(0, 0, 0, 0.54);
   margin-right: 1rem;
+  ${({ visible }) => (!visible ? 'visibility: hidden' : '')}
 `
 
 export const DragHandle = SortableHandle(ReorderIcon)


### PR DESCRIPTION
### Changes
- Made it so that the drag handle will not be shown in starting section of simple chats;
- Header text position will not change there.