### PR TITLE
Fix mymuesli data-gathering script: attempt nr. 2

### DIFF
--- a/plugiamo/src/data-gathering/mymuesli.js
+++ b/plugiamo/src/data-gathering/mymuesli.js
@@ -2,6 +2,7 @@ import mixpanel from 'ext/mixpanel'
 /* eslint-disable no-undef */
 
 const convertToCents = selector => {
+  if (!selector) return 0
   return Number(selector.replace(/\D/g, ''))
 }
 
@@ -30,7 +31,7 @@ export default {
       let itemUrl = $(item)
         .find('.article-description a')
         .attr('href')
-      if (itemUrl && !itemUrl.includes('www.mymuesli.com')) {
+      if (itemUrl && !itemUrl.indexOf('www.mymuesli.com') !== -1) {
         itemUrl = `https://www.mymuesli.com${itemUrl}`
       }
       const price = convertToCents(
@@ -45,9 +46,9 @@ export default {
           .trim()
       )
       let id = $(item).attr('data-offer-id')
-      if (id === '148') {
-        const splittedUrl = itemUrl && itemUrl.split('/')
-        id = splittedUrl.length !== 0 && `custom-${splittedUrl[splittedUrl.length - 1]}`
+      if (itemUrl && id === '148') {
+        const splitUrl = itemUrl.split('/')
+        id = splitUrl.length !== 0 && `custom-${splitUrl[splitUrl.length - 1]}`
       }
       finalObject.push({
         id,
@@ -74,6 +75,7 @@ export default {
   },
   trackAddToCart({ dataElement, isForm }) {
     const form = this.getAddToCartObject({ dataElement, isForm })
+    if (!form) return
     const json = this.addToCartObject({ form })
     mixpanel.track(json.name, json.data)
   },
@@ -82,7 +84,7 @@ export default {
     if (isForm) {
       const formFields = element.serializeArray()
       let productId, productName, subTotalInCents
-      if (location.pathname.includes('/muesli/') && !element.find('button').attr('data-tm-offer-id')) {
+      if (location.pathname.indexOf('/muesli/') !== -1 && !element.find('button').attr('data-tm-offer-id')) {
         productId = element.find('button').attr('value')
         productName = $('.container.basic-section.custommix')
           .find('.basic-text h1')
@@ -94,15 +96,50 @@ export default {
           .text()
           .trim()
           .split('für ')
-        subTotalInCents = convertToCents((priceBase.length > 1 && priceBase[1]) || '0')
-      } else if (location.pathname.includes('/mixer/')) {
+        subTotalInCents = convertToCents(priceBase.length > 1 && priceBase[1])
+      } else if (location.pathname.indexOf('/mixer/') !== -1) {
         productId = formFields && formFields[3] && formFields[3].value
         productName = formFields && formFields[0] && formFields[0].value
         subTotalInCents = convertToCents($('.js-total-price').text())
+      } else if (element.parent().attr('class') === 'updateCart') {
+        const isMinus = element.find('button i.fa').hasClass('fa-minus')
+        if (isMinus) return
+        const container = element.closest('.row')
+        productId =
+          container
+            .parent()
+            .closest('.row')
+            .attr('data-offer-id') ||
+          element
+            .find('input[name="offer_identifier"]')
+            .first()
+            .attr('value')
+        productName = container
+          .find('.article-description a')
+          .first()
+          .text()
+          .trim()
+          .replace(/\n|\r/g, '')
+          .replace(/\s\s+/g, ' ')
+        subTotalInCents = convertToCents(container.find('.js-price').text())
       } else {
-        productId = element.find('button').attr('data-tm-offer-id')
+        const elementParent = element.parent().parent()
+        const hasSelector = elementParent.find('select').length !== 0
+        const priceBase = hasSelector
+          ? elementParent
+              .find('.b2b-priceTag.active')
+              .text()
+              .trim()
+              .split('für ')
+          : element.find('button').attr('data-tm-offer-price')
+        productId = hasSelector
+          ? element
+              .find('input[name="offer_identifier"]')
+              .first()
+              .attr('value')
+          : element.find('button').attr('data-tm-offer-id')
         productName = formFields && formFields[1] && formFields[1].value
-        subTotalInCents = convertToCents(element.find('button').attr('data-tm-offer-price'))
+        subTotalInCents = convertToCents(hasSelector ? priceBase.length > 0 && priceBase[0] : priceBase)
       }
       return {
         productId,
@@ -120,24 +157,33 @@ export default {
     }
   },
   setupDataGathering() {
-    try {
-      if (location.pathname.match(/^\/shop\/complete/)) {
-        mixpanel.track('Purchase Success', { hostname: location.hostname })
-      } else if (location.pathname.match(/^\/shop\/cart/)) {
-        $(document).on('click', 'a[href="https://www.mymuesli.com/shop/kasse"]', () => {
+    if (!window.$) return
+    if (location.pathname.match(/^\/shop\/complete/)) {
+      mixpanel.track('Purchase Success', { hostname: location.hostname })
+    } else if (location.pathname.match(/^\/shop\/cart/)) {
+      $(document).on('click', 'a[href="https://www.mymuesli.com/shop/kasse"]', () => {
+        try {
           const json = this.checkoutObject()
           mixpanel.track(json.name, json.data)
-        })
-      }
-      $(document).on('click', '.offer-popup-container', event => {
+        } catch (error) {
+          // No action
+        }
+      })
+    }
+    $(document).on('click', '.offer-popup-container', event => {
+      try {
         const dataElement = $(event.target).closest('.offer-item.offerbutton-new-container')
         this.trackAddToCart({ dataElement, isForm: false })
-      })
-      $('form[action="https://www.mymuesli.com/shop/cart/put"]').on('submit', event =>
+      } catch (error) {
+        // No action
+      }
+    })
+    $(document).on('submit', 'form[action="https://www.mymuesli.com/shop/cart/put"]', event => {
+      try {
         this.trackAddToCart({ dataElement: event.target, isForm: true })
-      )
-    } catch (error) {
-      // No action
-    }
+      } catch (error) {
+        // No action
+      }
+    })
   },
 }


### PR DESCRIPTION
### Changes
- Fix for `convertToCents` in mymuesli data gathering script;
- Along with this, protected any potentially risky lines of the script with `try ... catch`;
- Added case for adding products from shopping cart by clicking a "+" in products list;
- Replaced `includes(...)` by `indexOf(...) !== -1` because the script is run before browser checks which could lead to exceptions.