### PR TITLE
Fix withPlugin mixpanel property

### DIFF
--- a/plugiamo/src/data-gathering/baldessarini.js
+++ b/plugiamo/src/data-gathering/baldessarini.js
@@ -10,7 +10,7 @@ export default {
       name: 'Add To Cart',
       data: {
         hostname: location.hostname,
-        withPlugin: !!jQuery.noConflict()('.frekkls-container')[0],
+        withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         productId: formFields.find(element => element.name === 'product').value,
         productName: jQuery
           .noConflict()("[data-ui-id='page-title-wrapper']")
@@ -94,7 +94,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!jQuery.noConflict()('.frekkls-container')[0],
+        withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         subTotalInCents: Number(
           jQuery

--- a/plugiamo/src/data-gathering/buttwrap.js
+++ b/plugiamo/src/data-gathering/buttwrap.js
@@ -11,7 +11,7 @@ export default {
       name: 'Add To Cart',
       data: {
         hostname: location.hostname,
-        withPlugin: !!window.$('.frekkls-container')[0],
+        withPlugin: !!window.$('iframe[title="Frekkls Launcher"]')[0],
         productId: formFields.find(element => element.name === 'id').value,
         productName: window.$('.product-single__title').html(),
         subTotalInCents: convertToCents(window.$('span.money').html()),
@@ -45,7 +45,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!window.$('.frekkls-container')[0],
+        withPlugin: !!window.$('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         currency: moneySpans.attr('data-currency') || 'EUR',
         subTotalInCents: convertToCents(moneySpans.text()),

--- a/plugiamo/src/data-gathering/impressorajato.js
+++ b/plugiamo/src/data-gathering/impressorajato.js
@@ -15,7 +15,7 @@ export default {
       name: 'Add To Cart',
       data: {
         hostname: location.hostname,
-        withPlugin: !!jQuery.noConflict()('.frekkls-container')[0],
+        withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         productId: formFields.find(element => element.name === 'product').value,
         productName: jQuery
           .noConflict()(".product-name > [itemprop='name']")
@@ -69,7 +69,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!jQuery.noConflict()('.frekkls-container')[0],
+        withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         currency: 'BRL',
         subTotalInCents: convertToCents(

--- a/plugiamo/src/data-gathering/mymuesli.js
+++ b/plugiamo/src/data-gathering/mymuesli.js
@@ -12,7 +12,7 @@ export default {
       name: 'Add To Cart',
       data: {
         hostname: location.hostname,
-        withPlugin: !!$('.frekkls-container')[0],
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         currency: 'EUR',
         ...form,
       },
@@ -66,7 +66,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!$('.frekkls-container')[0],
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         subTotalInCents: convertToCents($('.js-cartamount').text()),
         currency: 'EUR',

--- a/plugiamo/src/data-gathering/pampling.js
+++ b/plugiamo/src/data-gathering/pampling.js
@@ -11,7 +11,7 @@ export default {
         name: 'Add To Cart',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           productName: $(target)
             .parent()
             .attr('data-autor'),
@@ -44,7 +44,7 @@ export default {
         name: 'Add To Cart',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           productName: $('#datos_autor')
             .text()
             .trim()
@@ -116,7 +116,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!$('.frekkls-container')[0],
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         subTotalInCents: Number(
           $('#cantidad_total_productos')

--- a/plugiamo/src/data-gathering/pierre-cardin.js
+++ b/plugiamo/src/data-gathering/pierre-cardin.js
@@ -10,7 +10,7 @@ export default {
       name: 'Add To Cart',
       data: {
         hostname: location.hostname,
-        withPlugin: !!jQuery.noConflict()('.frekkls-container')[0],
+        withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         productId: formFields.find(element => element.name === 'product').value,
         productName: jQuery
           .noConflict()("[data-ui-id='page-title-wrapper']")
@@ -92,7 +92,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!jQuery.noConflict()('.frekkls-container')[0],
+        withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         subTotalInCents: Number(
           jQuery

--- a/plugiamo/src/data-gathering/pionier-workwear.js
+++ b/plugiamo/src/data-gathering/pionier-workwear.js
@@ -7,7 +7,7 @@ export default {
       name: 'Add To Cart',
       data: {
         hostname: location.hostname,
-        withPlugin: !!$('.frekkls-container')[0],
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         productId: $('input.inputtext.number.itemControl').attr('value'),
         productName: $('.single-item-title > h2').text(),
         currency: 'EUR',
@@ -82,7 +82,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!$('.frekkls-container')[0],
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         subTotalInCents: Number(
           $('#total_summary_list_info')

--- a/plugiamo/src/data-gathering/shopinfo.js
+++ b/plugiamo/src/data-gathering/shopinfo.js
@@ -23,7 +23,7 @@ export default {
           name: 'Add To Cart',
           data: {
             hostname: location.hostname,
-            withPlugin: !!window.$('.frekkls-container')[0],
+            withPlugin: !!window.$('iframe[title="Frekkls Launcher"]')[0],
             productId: data.productId,
             productName: data.productName,
             productBrand: data.brand,
@@ -68,7 +68,7 @@ export default {
       name: 'Proceed To Checkout',
       data: {
         hostname: location.hostname,
-        withPlugin: !!window.$('.frekkls-container')[0],
+        withPlugin: !!window.$('iframe[title="Frekkls Launcher"]')[0],
         products: this.products,
         currency: 'BRL',
         subTotalInCents: convertToCents(

--- a/plugiamo/src/data-gathering/time-block.js
+++ b/plugiamo/src/data-gathering/time-block.js
@@ -9,7 +9,7 @@ export default {
         name: 'Add To Cart',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           productId: $(target).attr('data-product_id'),
           productName: productDiv.find('.t-entry-title').text(),
           currency: 'EUR',
@@ -29,7 +29,7 @@ export default {
         name: 'Add To Cart',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           productId: $('button.add_to_cart_button')[0].value,
           productName: $('.product_title').text(),
           currency: 'EUR',
@@ -131,7 +131,7 @@ export default {
         name: 'Proceed To Checkout',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           products: this.getProductsFromAjaxCart(),
           subTotalInCents: Number(
             $('.product_list_widget')
@@ -148,7 +148,7 @@ export default {
         name: 'Proceed To Checkout',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           products: this.getProductsFromCart(),
           subTotalInCents: Number(
             $('.order-total')

--- a/plugiamo/src/data-gathering/tontonetfils.js
+++ b/plugiamo/src/data-gathering/tontonetfils.js
@@ -8,7 +8,7 @@ export default {
       name: 'Add To Cart',
       data: {
         hostname: location.hostname,
-        withPlugin: !!$('.frekkls-container')[0],
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         productId: formFields.find(element => element.name === 'id').value,
         productName: $('.product-single__title').text(),
         currency: 'EUR',
@@ -107,7 +107,7 @@ export default {
         name: 'Proceed To Checkout',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           products: this.getProductsFromAjaxCart(),
           subTotalInCents: Number(
             $('.ajaxcart__subtotal')
@@ -123,7 +123,7 @@ export default {
         name: 'Proceed To Checkout',
         data: {
           hostname: location.hostname,
-          withPlugin: !!$('.frekkls-container')[0],
+          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
           products: this.getProductsFromCart(),
           subTotalInCents: Number(
             $('.cart__subtotal')


### PR DESCRIPTION
## Update:
`withPlugin` in data-gathering scripts now targets the presence of the launcher iframe. It was targeting the iframe with `'.frekkls-container'` selector which is there if the snippet is included in that page (even if the launcher is not showing), meaning, `withPlugin` was always `True`.

### Tested in all clients with data-gathering scripts:
- [x] Baldessarini
- [x] Buttwrap
- [x] Impressorajato
- [x] mymuesli
- [x] Pampling
- [x] PierreCardinGermany
- [x] PionierWorkwear
- [x] Shopinfo
- [x] TimeBlock
- [x] TonTonEtFils

[Link To Trello Card](https://trello.com/c/EMVZi2NO/1517-investigate-if-withplugin-mixpanel-property-is-being-sent-with-correct-values)