### PR TITLE
Allow account to be affiliate

### DIFF
--- a/backend/app/controllers/api/v1/accounts_controller.rb
+++ b/backend/app/controllers/api/v1/accounts_controller.rb
@@ -37,7 +37,7 @@ module Api
       private
 
       def account_params
-        params.require(:account).permit(:name, websites_attributes: [:name, hostnames: []])
+        params.require(:account).permit(:name, :is_affiliate, websites_attributes: [:name, hostnames: []])
       end
 
       def render_error

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -19,7 +19,8 @@ class Account < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
 
   def as_json(_options = {})
-    attributes.slice("name", "slug", "created_at", "updated_at").merge(websites_attributes: websites)
+    attributes.slice("name", "slug", "is_affiliate", "created_at", "updated_at").merge(websites_attributes: websites)
+
   end
 
   def duplicate(name, hostnames)

--- a/backend/db/migrate/20190821091559_add_is_affiliate_to_accounts.rb
+++ b/backend/db/migrate/20190821091559_add_is_affiliate_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddIsAffiliateToAccounts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :accounts, :is_affiliate, :boolean, default: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190808141359) do
+ActiveRecord::Schema.define(version: 20190821091559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20190808141359) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.string "slug", default: "", null: false
+    t.boolean "is_affiliate", default: false
     t.index ["slug"], name: "index_accounts_on_slug", unique: true
   end
 

--- a/console-frontend/src/app/screens/accounts/account-new.js
+++ b/console-frontend/src/app/screens/accounts/account-new.js
@@ -7,8 +7,8 @@ import routes from 'app/routes'
 import styled from 'styled-components'
 import useForm from 'ext/hooks/use-form'
 import { apiAccountCreate, apiRequest, atLeastOneNonBlankCharInputProps } from 'utils'
+import { Checkbox, FormControl, FormControlLabel, FormHelperText, TextField } from '@material-ui/core'
 import { Form } from 'shared/form-elements'
-import { FormControl, TextField } from '@material-ui/core'
 import { useSnackbar } from 'notistack'
 import { withRouter } from 'react-router'
 
@@ -19,6 +19,7 @@ const SaveButton = styled(Button)`
 const loadFormObject = () => {
   return {
     name: '',
+    isAffiliate: false,
     websitesAttributes: [{ hostnames: [''] }],
   }
 }
@@ -39,6 +40,7 @@ const NewAccount = ({ history }) => {
         {
           account: {
             name: form.name,
+            isAffiliate: form.isAffiliate,
             websitesAttributes: [
               {
                 name: form.name,
@@ -65,6 +67,7 @@ const NewAccount = ({ history }) => {
     isFormSubmitting,
     onFormSubmit,
     setFieldValue,
+    mergeForm,
     mergeFormCallback,
   } = useForm({
     formObjectTransformer,
@@ -111,6 +114,13 @@ const NewAccount = ({ history }) => {
     [mergeFormCallback]
   )
 
+  const toggleIsAffiliate = useCallback(
+    event => {
+      mergeForm({ isAffiliate: event.target.checked })
+    },
+    [mergeForm]
+  )
+
   if (isFormLoading) return <CircularProgress />
 
   return (
@@ -129,6 +139,12 @@ const NewAccount = ({ history }) => {
             required
             value={form.name}
           />
+          <FormControlLabel
+            control={<Checkbox checked={form.isAffiliate} color="primary" onChange={toggleIsAffiliate} />}
+            disabled={isFormLoading}
+            label="Affiliate"
+          />
+          <FormHelperText>{'If checked, the brand will be listed in app.uptous.co'}</FormHelperText>
         </FormControl>
         <HostnamesForm
           addHostnameSelect={addHostnameSelect}


### PR DESCRIPTION
# Changes:
Add `is_affiliate` boolean field to the `account` model. 
When adding an account, the admin user is able to set this field.

![image](https://user-images.githubusercontent.com/35154956/63426137-0d197500-c40a-11e9-8278-a3087a5a9e25.png)


[Link To Trello Card](https://trello.com/c/2fF3QJO9/1534-allow-account-to-be-affiliate)