### PR TITLE
Add Brand

### DIFF
--- a/backend/app/controllers/api/v1/accounts_controller.rb
+++ b/backend/app/controllers/api/v1/accounts_controller.rb
@@ -37,7 +37,8 @@ module Api
       private
 
       def account_params
-        params.require(:account).permit(:name, :is_affiliate, websites_attributes: [:name, hostnames: []])
+        params.require(:account).permit(:name, :is_affiliate, websites_attributes: [:name, hostnames: []],
+                                                              brand_attributes: %i[name description logo_url])
       end
 
       def render_error

--- a/backend/app/controllers/api/v1/brands_controller.rb
+++ b/backend/app/controllers/api/v1/brands_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class BrandsController < RestAdminController
+      def index
+        @brands = policy_scope(Brand).all
+        authorize @brands
+        render json: @brands
+      end
+    end
+  end
+end

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -11,6 +11,9 @@ class Account < ApplicationRecord
 
   has_many :invites, dependent: :destroy
 
+  has_one :brand, dependent: :destroy
+
+  accepts_nested_attributes_for :brand, allow_destroy: true
   accepts_nested_attributes_for :websites, allow_destroy: true
 
   before_validation :set_slug, on: :create
@@ -20,7 +23,6 @@ class Account < ApplicationRecord
 
   def as_json(_options = {})
     attributes.slice("name", "slug", "is_affiliate", "created_at", "updated_at").merge(websites_attributes: websites)
-
   end
 
   def duplicate(name, hostnames)

--- a/backend/app/models/brand.rb
+++ b/backend/app/models/brand.rb
@@ -1,0 +1,11 @@
+class Brand < ApplicationRecord
+  acts_as_tenant
+  belongs_to :account
+
+  validates :name, presence: true, uniqueness: true
+
+  def as_json(_options = {})
+    attributes
+      .slice("id", "name", "description", "logo_url", "created_at", "updated_at", "lock_version")
+  end
+end

--- a/backend/app/policies/brand_policy.rb
+++ b/backend/app/policies/brand_policy.rb
@@ -1,0 +1,11 @@
+class BrandPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.includes(:account).where(accounts: { is_affiliate: true })
+    end
+  end
+
+  def index?
+    user
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
         resources :websites, only: %i[show update]
         resources :website_settings, only: %i[update]
         get "/website_settings", to: "website_settings#show"
+        resources :brands, only: %i[index]
 
         get "/sellers/autocomplete", to: "autocompletes#sellers_autocomplete"
         get "/flows/autocomplete", to: "autocompletes#flows_autocomplete"

--- a/backend/db/migrate/20190821111647_create_affiliate_brands.rb
+++ b/backend/db/migrate/20190821111647_create_affiliate_brands.rb
@@ -1,0 +1,10 @@
+class CreateAffiliateBrands < ActiveRecord::Migration[5.1]
+  def change
+    create_table :brands do |t|
+      t.string :name, null: false
+      t.string :logo_url
+      t.text :description
+      t.references :account, foreign_key: true
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190821091559) do
+ActiveRecord::Schema.define(version: 20190821111647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,14 @@ ActiveRecord::Schema.define(version: 20190821091559) do
     t.string "slug", default: "", null: false
     t.boolean "is_affiliate", default: false
     t.index ["slug"], name: "index_accounts_on_slug", unique: true
+  end
+
+  create_table "brands", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "logo_url"
+    t.text "description"
+    t.bigint "account_id"
+    t.index ["account_id"], name: "index_brands_on_account_id"
   end
 
   create_table "generated_urls", force: :cascade do |t|
@@ -294,6 +302,7 @@ ActiveRecord::Schema.define(version: 20190821091559) do
     t.index ["hostnames"], name: "index_websites_on_hostnames", using: :gin
   end
 
+  add_foreign_key "brands", "accounts"
   add_foreign_key "generated_urls", "users"
   add_foreign_key "images", "accounts"
   add_foreign_key "invites", "accounts"

--- a/console-frontend/src/app/screens/accounts/account-new.js
+++ b/console-frontend/src/app/screens/accounts/account-new.js
@@ -20,6 +20,9 @@ const loadFormObject = () => {
   return {
     name: '',
     isAffiliate: false,
+    brandName: '',
+    brandDescription: '',
+    brandLogoUrl: '',
     websitesAttributes: [{ hostnames: [''] }],
   }
 }
@@ -27,6 +30,10 @@ const loadFormObject = () => {
 const formObjectTransformer = json => {
   return {
     name: json.name || '',
+    isAffiliate: json.isAffiliate || false,
+    brandName: json.brandName || '',
+    brandDescription: json.brandDescription || '',
+    brandLogoUrl: json.brandLogoUrl || '',
     hostnames: json.websitesAttributes[0].hostnames || [''],
   }
 }
@@ -41,6 +48,11 @@ const NewAccount = ({ history }) => {
           account: {
             name: form.name,
             isAffiliate: form.isAffiliate,
+            brandAttributes: form.isAffiliate && {
+              name: form.brandName,
+              description: form.brandDescription,
+              logoUrl: form.brandLogoUrl,
+            },
             websitesAttributes: [
               {
                 name: form.name,
@@ -139,12 +151,6 @@ const NewAccount = ({ history }) => {
             required
             value={form.name}
           />
-          <FormControlLabel
-            control={<Checkbox checked={form.isAffiliate} color="primary" onChange={toggleIsAffiliate} />}
-            disabled={isFormLoading}
-            label="Affiliate"
-          />
-          <FormHelperText>{'If checked, the brand will be listed in app.uptous.co'}</FormHelperText>
         </FormControl>
         <HostnamesForm
           addHostnameSelect={addHostnameSelect}
@@ -153,6 +159,47 @@ const NewAccount = ({ history }) => {
           form={form}
           isFormLoading={isFormLoading}
         />
+        <FormControl fullWidth margin="normal" required>
+          <FormControlLabel
+            control={<Checkbox checked={form.isAffiliate} color="primary" onChange={toggleIsAffiliate} />}
+            disabled={isFormLoading}
+            label="Affiliate"
+          />
+          <FormHelperText>{'If checked, the brand will be listed in app.uptous.co'}</FormHelperText>
+          {form.isAffiliate && (
+            <>
+              <TextField
+                autoFocus
+                fullWidth
+                inputProps={atLeastOneNonBlankCharInputProps}
+                label="Brand Name"
+                margin="normal"
+                name="brandName"
+                onChange={setFieldValue}
+                required
+                value={form.brandName}
+              />
+              <TextField
+                fullWidth
+                inputProps={atLeastOneNonBlankCharInputProps}
+                label="Brand Description"
+                margin="normal"
+                name="brandDescription"
+                onChange={setFieldValue}
+                value={form.brandDescription}
+              />
+              <TextField
+                fullWidth
+                inputProps={atLeastOneNonBlankCharInputProps}
+                label="Brand Logo Url"
+                margin="normal"
+                name="brandLogoUrl"
+                onChange={setFieldValue}
+                value={form.brandLogoUrl}
+              />
+            </>
+          )}
+        </FormControl>
         <SaveButton
           color="primaryGradient"
           disabled={isFormSubmitting || isFormLoading || isFormPristine}


### PR DESCRIPTION
## Feature description:
**Backend**
1) Adds a `Brand` model, that `belongs_to` `Account`, in a one-to-one relationship.  Fields: `name` (string, required, unique),  `description` (text), `logo_url` (string). 
2) Adds an `/api/v1/brands`endpoint to list the available brands.
3) Adds a `BrandPolicy` to list in the endpoint only brands having an associated `Account` with the field `is_affiliate` value `true`.
4) Allows the `Brand` to be created when the `Account` is created.

**Admin**
1) Allows an admin user to set the fields for the new `Brand` in the New Account form, if the `isAffiliate` `Account` field is set to `True`.

### Preview:
![add_brand](https://user-images.githubusercontent.com/35154956/63444480-9773d000-c42e-11e9-92d7-3ee4643eec85.gif)

[Link To Trello Card](https://trello.com/c/CQQXGdga/1537-add-brand-model-and-endpoints)
