### PR TITLE
Uptous: handle different logins

### DIFF
--- a/backend/app/controllers/api/v1/users/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/users/sessions_controller.rb
@@ -3,8 +3,12 @@ module Api
     module Users
       class SessionsController < Devise::SessionsController
         def create
-          user = warden.authenticate!(auth_options)
-          render json: { user: user }
+          if user_can_login?
+            user = warden.authenticate!(auth_options)
+            render json: { user: user }
+          else
+            render_unauthorized_error
+          end
         end
 
         def destroy
@@ -16,6 +20,24 @@ module Api
 
         # this is invoked before destroy and we have to override it
         def verify_signed_out_user; end
+
+        def user_can_login?
+          user = User.find_by(email: params["user"]["email"])
+          return true unless user
+
+          up_to_us? ? user.promoter? : user.frekkls_user?
+        end
+
+        def up_to_us?
+          host = request.headers["HTTP_X_FORWARDED_HOST"]
+          host.include?("uptous") || (host.split(":").shift == "localhost" && params[:is_up_to_us])
+        end
+
+        def render_unauthorized_error
+          render json: { errors:
+            [{ title: "You can access this account just through #{up_to_us? ? 'Frekkls' : 'Uptous'}" }],
+                         status: :unauthorized, }
+        end
       end
     end
   end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -35,4 +35,12 @@ class User < ApplicationRecord
   def active_membership
     memberships.find_by(account: ActsAsTenant.current_tenant)
   end
+
+  def frekkls_user?
+    admin || (!mapped_roles.empty? && !mapped_roles.values.all?("promoter"))
+  end
+
+  def promoter?
+    !admin && (mapped_roles.empty? || mapped_roles.values.include?("promoter"))
+  end
 end

--- a/backend/lib/populate.rb
+++ b/backend/lib/populate.rb
@@ -227,7 +227,7 @@ class Populate # rubocop:disable Metrics/ClassLength
   def create_account
     Account.create!(name: "Test Account")
     Account.create!(name: "Test Account 2")
-    Account.create!(name: "Test Account 3")
+    Account.create!(name: "Test Account 3", is_affiliate: true)
   end
 
   def create_websites

--- a/console-frontend/src/app/screens/accounts/accounts-list-base.js
+++ b/console-frontend/src/app/screens/accounts/accounts-list-base.js
@@ -2,6 +2,7 @@ import auth from 'auth'
 import Button from 'shared/button'
 import Dialog from 'shared/dialog'
 import Link from 'shared/link'
+import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import MUIListItem from '@material-ui/core/ListItem'
 import Pagination from 'shared/pagination'
@@ -60,6 +61,13 @@ const ListItem = ({ account, hostnames }) => {
               primary={account.name}
               secondary={auth.isAdmin() ? hostnames : auth.getUser().roles[account.slug]}
             />
+            {account.isAffiliate && (
+              <Tooltip placement="top" title="This account is an affiliate partner on Uptous">
+                <ListItemIcon>
+                  <img alt="" src="/img/icons/grocery.svg" />
+                </ListItemIcon>
+              </Tooltip>
+            )}
           </StyledListItem>
         </Link>
       </Tooltip>

--- a/console-frontend/src/app/screens/accounts/accounts-list.js
+++ b/console-frontend/src/app/screens/accounts/accounts-list.js
@@ -1,4 +1,5 @@
 import AccountsListBase from './accounts-list-base'
+import auth from 'auth'
 import CircularProgress from 'app/layout/loading'
 import debounce from 'debounce-promise'
 import Layout from './layout'
@@ -35,7 +36,13 @@ const AccountsList = () => {
   const fetchAccounts = useCallback(
     async () => {
       const { json, requestError, response } = await apiRequest(apiAccountList, [{ ...query, searchQuery }])
-      requestError ? enqueueSnackbar(requestError, { variant: 'error' }) : setAccounts(json)
+      const filteredAccounts = json.filter(account => {
+        if (auth.isAdmin()) return account
+
+        const userRole = auth.getUser().roles[account.slug]
+        return !account.isAffiliate || userRole !== 'promoter'
+      })
+      requestError ? enqueueSnackbar(requestError, { variant: 'error' }) : setAccounts(filteredAccounts)
       setTotalAccountsCount(extractCountFromHeaders(response.headers))
       setFetched(true)
     },

--- a/console-frontend/src/auth/login/index.js
+++ b/console-frontend/src/auth/login/index.js
@@ -4,7 +4,7 @@ import Button from 'shared/button'
 import Link from 'shared/link'
 import React, { useCallback, useEffect, useState } from 'react'
 import routes from 'app/routes'
-import { apiRequest, apiSignIn } from 'utils'
+import { apiRequest, apiSignIn, isUpToUs } from 'utils'
 import { AuthFormFooter, AuthStyledForm } from 'auth/components'
 import { FormControl, Input, InputLabel } from '@material-ui/core'
 import { useSnackbar } from 'notistack'
@@ -81,7 +81,7 @@ const Login1 = () => {
       event.preventDefault()
       const { json, errors, requestError } = await apiRequest(
         apiSignIn,
-        [{ user: { email: loginForm.email, password: loginForm.password } }],
+        [{ user: { email: loginForm.email, password: loginForm.password }, isUpToUs }],
         { isLoginRequest: true }
       )
       if (requestError) enqueueSnackbar(requestError, { variant: 'error' })


### PR DESCRIPTION
[Trello card](https://trello.com/c/Kv15uUiN)

## Changes

- Add `user_can_login?` method to `users/sessions#create` action, checking the role of the user and the current hostname
- If a user signs in through admin.frekkls.com and has multiple memberships, he now doesn't see accounts in which he is a promoter
- Show icon next to affiliate accounts in accounts page (only for admins)