### PR TITLE
Don't show 'add new sellers' button to editors

### DIFF
--- a/console-frontend/src/shared/autocomplete/index.js
+++ b/console-frontend/src/shared/autocomplete/index.js
@@ -1,4 +1,5 @@
 import AddSellerModal from './add-seller-modal'
+import auth from 'auth'
 import debounce from 'debounce-promise'
 import Downshift from 'downshift'
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react'
@@ -77,7 +78,7 @@ const AutocompleteInput = ({
         endAdornment={
           <>
             <DropdownButton onClick={onDropdownClick} />
-            {name === 'Seller' && <AddSellerButton onClick={onAddSellerClick} />}
+            {auth.getAccountRole() !== 'editor' && name === 'Seller' && <AddSellerButton onClick={onAddSellerClick} />}
           </>
         }
         fullWidth


### PR DESCRIPTION
[Trello card](https://trello.com/c/mnQMVA9s)

## Changes

An editor could see the 'add new seller' icon in simple chats, and when trying to create a seller, he was getting logged out. He is now not able to see the icon anymore.