### PR TITLE
Add dummy data for revenues chart

### DIFF
--- a/backend/app/controllers/api/v1/mixpanel_events_controller.rb
+++ b/backend/app/controllers/api/v1/mixpanel_events_controller.rb
@@ -14,8 +14,21 @@ module Api
       private
 
       def jql_params
+        current_tenant ? data_dashboard_params : revenues_params
+      end
+
+      def data_dashboard_params
         hostname = current_tenant.websites.first.hostnames.first
         { dates: JSON.parse(params.require(:dates)).with_indifferent_access, hostname: hostname, sort: params[:sort] }
+      end
+
+      def revenues_params
+        token = current_user.affiliations.find_by(token: params.require(:affiliateToken))
+        {
+          dates: JSON.parse(params.require(:dates)).with_indifferent_access,
+          affiliateToken: token,
+          sort: params[:sort],
+        }
       end
     end
   end

--- a/backend/app/policies/mixpanel_event_policy.rb
+++ b/backend/app/policies/mixpanel_event_policy.rb
@@ -1,5 +1,5 @@
 class MixpanelEventPolicy < ApplicationPolicy
   def index?
-    user&.admin
+    user&.admin || user&.affiliate_role != "not_affiliate"
   end
 end

--- a/backend/app/services/jql/scripts.rb
+++ b/backend/app/services/jql/scripts.rb
@@ -62,5 +62,14 @@ module Jql
     def self.date_range(params)
       (Date.parse(params[:dates][:from_date])..Date.parse(params[:dates][:to_date])).step(7)
     end
+
+    def self.revenues_dummy(params)
+      date_range(params).map do |date|
+        {
+          date: date.to_s,
+          revenues: rand(0..1000),
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
## Update
Add dummy data to the `revenues` chart.

`GET` Request to endpoint `api/v1/events`

**params**: 
```
params = {
 dates:  {"from_date": "2019-06-01", "to_date": "2019-07-01"},
 affiliateToken: "ebf58c5c"
 chart: "revenues"
}
```

**response**: 
```
[
    {
        "date": "2019-05-27",
        "revenues": 164
    },
    {
        "date": "2019-06-03",
        "revenues": 249
    },
    {
        "date": "2019-06-10",
        "revenues": 132
    },
    {
        "date": "2019-06-17",
        "revenues": 873
    },
    {
        "date": "2019-06-24",
        "revenues": 28
    },
    {
        "date": "2019-07-01",
        "revenues": 54
    }
]
```