### PR TITLE
Fix data-gathering scripts

### DIFF
--- a/plugiamo/src/data-gathering/baldessarini.js
+++ b/plugiamo/src/data-gathering/baldessarini.js
@@ -1,4 +1,5 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
 
@@ -17,18 +18,19 @@ export default {
           .find("[data-th='Artikel']")
           .children('a')
           .attr('href')
-        const price = Number(
+        const price = convertToDigits(
           jQuery
             .noConflict()(item)
             .find('span.price')
-            .last()
+            .first()
             .text()
-            .replace(/\D/g, '')
         )
-        const itemQuantity = jQuery
-          .noConflict()(item)
-          .find("[title='Menge']")
-          .attr('value')
+        const itemQuantity = convertToDigits(
+          jQuery
+            .noConflict()(item)
+            .find('input')
+            .val()
+        )
         const id = itemUrl.split('/').pop()
         return {
           id,
@@ -48,12 +50,11 @@ export default {
         hostname: location.hostname,
         withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
-        subTotalInCents: Number(
+        subTotalInCents: convertToDigits(
           jQuery
             .noConflict()('span.price')
             .last()
             .text()
-            .replace(/\D/g, '')
         ),
         currency: 'EUR',
       },

--- a/plugiamo/src/data-gathering/impressorajato.js
+++ b/plugiamo/src/data-gathering/impressorajato.js
@@ -1,32 +1,24 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
-
-const convertToCents = selector => {
-  return Number(selector.replace(/\D/g, ''))
-}
 
 export default {
   getProductsFromCart() {
     return jQuery
       .noConflict()('#shopping-cart-table > tbody')
       .find('tr')
-      .map((index, element) => {
-        const name = jQuery
-          .noConflict()(element)
-          .find('h2 > a')
-          .attr('title')
-        const url = jQuery
-          .noConflict()(element)
-          .find('h2 > a')
-          .attr('href')
-        const quantity = Number(
-          jQuery
-            .noConflict()(element)
-            .find("[selected='selected']")
-            .attr('value')
+      .map((index, item) => {
+        const element = jQuery.noConflict()(item)
+        const name = element.find('h2 > a').attr('title')
+        const url = element.find('h2 > a').attr('href')
+        const quantity = convertToDigits(element.find("[selected='selected']").attr('value'))
+        const price = convertToDigits(
+          element
+            .find('.cart-price')
+            .first()
+            .text()
         )
-        const price = convertToCents(element.children[2].innerText)
         return { name, url, price, quantity }
       })
       .toArray()
@@ -39,10 +31,12 @@ export default {
         withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
         currency: 'BRL',
-        subTotalInCents: convertToCents(
+        subTotalInCents: convertToDigits(
           jQuery
             .noConflict()('#shopping-cart-totals-table')
-            .find('.price')[0].innerText
+            .find('.price')
+            .first()
+            .text()
         ),
       },
     }

--- a/plugiamo/src/data-gathering/mymuesli.js
+++ b/plugiamo/src/data-gathering/mymuesli.js
@@ -1,11 +1,7 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
-
-const convertToCents = selector => {
-  if (!selector) return 0
-  return Number(selector.replace(/\D/g, ''))
-}
 
 export default {
   getProductsFromCart() {
@@ -24,12 +20,12 @@ export default {
       if (itemUrl && !itemUrl.indexOf('www.mymuesli.com') !== -1) {
         itemUrl = `https://www.mymuesli.com${itemUrl}`
       }
-      const price = convertToCents(
+      const price = convertToDigits(
         $(item)
-          .find('.js-total')
+          .find('.js-price')
           .text()
       )
-      const itemQuantity = Number(
+      const itemQuantity = convertToDigits(
         $(item)
           .find('.amount')
           .text()
@@ -58,7 +54,7 @@ export default {
         hostname: location.hostname,
         withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
-        subTotalInCents: convertToCents($('.js-cartamount').text()),
+        subTotalInCents: convertToDigits($('.js-cartamount').text()),
         currency: 'EUR',
       },
     }

--- a/plugiamo/src/data-gathering/pampling.js
+++ b/plugiamo/src/data-gathering/pampling.js
@@ -1,4 +1,5 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
 
@@ -15,15 +16,16 @@ export default {
         const itemUrl = $(item)
           .find('.articulo > a')
           .attr('href')
-        const price = Number(
+        const price = convertToDigits(
           $(item)
-            .find('.total')
+            .find('.precio')
             .text()
-            .replace(/\D/g, '')
         )
-        const itemQuantity = $(item)
-          .find('.cantidad')
-          .text()
+        const itemQuantity = convertToDigits(
+          $(item)
+            .find('.cantidad')
+            .text()
+        )
 
         return {
           name: itemName,
@@ -43,11 +45,7 @@ export default {
         hostname: location.hostname,
         withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
-        subTotalInCents: Number(
-          $('#cantidad_total_productos')
-            .text()
-            .replace(/\D/g, '')
-        ),
+        subTotalInCents: convertToDigits($('#cantidad_total_productos').text()),
         currency: 'EUR',
       },
     }
@@ -61,8 +59,7 @@ export default {
     if (!window.$) return
 
     if (location.pathname.match(/tienda\/cesta/)) {
-      if (!$('.pedido')[0]) return
-      $('#btn_comprar').on('click', () =>
+      $(document).on('click', '#btn_comprar', () =>
         RollbarWrapper(() => {
           const json = _this.checkoutObject()
           mixpanel.track(json.name, json.data)

--- a/plugiamo/src/data-gathering/pierre-cardin.js
+++ b/plugiamo/src/data-gathering/pierre-cardin.js
@@ -1,4 +1,5 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
 
@@ -17,13 +18,12 @@ export default {
           .find("[data-th='Artikel']")
           .children('a')
           .attr('href')
-        const price = Number(
+        const price = convertToDigits(
           jQuery
             .noConflict()(item)
             .find('span.price')
-            .last()
+            .first()
             .text()
-            .replace(/\D/g, '')
         )
         const itemQuantity = jQuery
           .noConflict()(item)
@@ -39,6 +39,7 @@ export default {
           currency: 'EUR',
         }
       })
+      .toArray()
   },
   checkoutObject() {
     return {
@@ -47,12 +48,11 @@ export default {
         hostname: location.hostname,
         withPlugin: !!jQuery.noConflict()('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
-        subTotalInCents: Number(
+        subTotalInCents: convertToDigits(
           jQuery
             .noConflict()('span.price')
             .last()
             .text()
-            .replace(/\D/g, '')
         ),
         currency: 'EUR',
       },

--- a/plugiamo/src/data-gathering/pionier-workwear.js
+++ b/plugiamo/src/data-gathering/pionier-workwear.js
@@ -1,37 +1,37 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
 
 export default {
   getProductsFromCart() {
-    return $('.item-holder')
+    return $('.shoppingcart_list > form')
       .map((i, item) => {
         const itemName = $(item)
-          .find('.item-name')
+          .find('.single-item-title h2')
           .text()
           .trim()
         if (!itemName) return
-        const itemUrl =
-          location.hostname +
+        const itemUrl = `${location.hostname}/${$(item)
+          .find('.single-item-holder a')
+          .attr('href')}`
+        const price = convertToDigits(
           $(item)
-            .find('a')
-            .attr('href')
-        const price = Number(
-          $(item)
-            .find('.item-info > li > .value')
-            .last()
+            .find('.add-info-price')
+            .first()
             .text()
-            .replace(/\D/g, '')
         )
-        const itemQuantity = $(item)
-          .find('.item-info > li > .value')
-          .first()
-          .text()
+        const quantity = convertToDigits(
+          $(item)
+            .find('.info-holder input')
+            .first()
+            .val()
+        )
         return {
           name: itemName,
           url: itemUrl,
           price,
-          quantity: itemQuantity,
+          quantity,
           currency: 'EUR',
         }
       })
@@ -44,11 +44,7 @@ export default {
         hostname: location.hostname,
         withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
         products: this.getProductsFromCart(),
-        subTotalInCents: Number(
-          $('#total_summary_list_info')
-            .text()
-            .replace(/\D/g, '')
-        ),
+        subTotalInCents: convertToDigits($('#total_summary_list_info').text()),
         currency: 'EUR',
       },
     }

--- a/plugiamo/src/data-gathering/time-block.js
+++ b/plugiamo/src/data-gathering/time-block.js
@@ -1,4 +1,5 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
 
@@ -15,16 +16,27 @@ export default {
           .find('.product-name > a')
           .first()
           .attr('href')
-        const price = Number(
+        const priceInCents = convertToDigits(
           $(item)
             .find('.woocommerce-Price-amount.amount')
-            .last()
+            .first()
             .text()
-            .replace(/\D/g, '')
         )
-        const itemQuantity = $(item)
-          .find('.input-text.qty.text')
-          .attr('value')
+        const price =
+          $(item)
+            .find('.woocommerce-Price-amount.amount')
+            .first()
+            .text() +
+          $(item)
+            .find('.subscription-details')
+            .first()
+            .text()
+
+        const itemQuantity = convertToDigits(
+          $(item)
+            .find('.input-text.qty.text')
+            .attr('value')
+        )
         const isSubscription = !!$(item)
           .find('.subscription-details')
           .text()
@@ -32,6 +44,7 @@ export default {
           name: itemName,
           url: itemUrl,
           price,
+          priceInCents,
           quantity: itemQuantity,
           currency: 'EUR',
           isSubscription,
@@ -54,19 +67,19 @@ export default {
           .attr('href')
         const itemPrice = $(item)
           .find('.woocommerce-Price-amount.amount')
-          .last()
+          .first()
           .text()
-        const itemPriceInCents = Number(
+        const itemPriceInCents = convertToDigits(
           $(item)
             .find('.woocommerce-Price-amount.amount')
-            .last()
+            .first()
             .text()
-            .replace(/\D/g, '')
         )
-        const itemQuantity = $(item)
-          .find('.quantity-container')
-          .text()
-          .replace(/\D/g, '')
+        const itemQuantity = convertToDigits(
+          $(item)
+            .find('.quantity-container')
+            .text()
+        )
 
         const isSubscription = !!$(item)
           .find('.subscription-details')
@@ -84,40 +97,49 @@ export default {
       })
       .toArray()
   },
-  checkoutObject(isfromAjaxCart = false) {
-    if (isfromAjaxCart) {
-      return {
-        name: 'Proceed To Checkout',
-        data: {
-          hostname: location.hostname,
-          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
-          products: this.getProductsFromAjaxCart(),
-          subTotalInCents: Number(
-            $('.product_list_widget')
-              .find('.woocommerce-Price-amount.amount')
-              .last()
-              .text()
-              .replace(/\D/g, '')
-          ),
-          currency: 'EUR',
-        },
-      }
-    } else {
-      return {
-        name: 'Proceed To Checkout',
-        data: {
-          hostname: location.hostname,
-          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
-          products: this.getProductsFromCart(),
-          subTotalInCents: Number(
-            $('.order-total')
-              .first()
-              .text()
-              .replace(/\D/g, '')
-          ),
-          currency: 'EUR',
-        },
-      }
+  getDataFromPDP() {
+    const isSubscription = $('form.cart button[type="submit"]').text() === 'Sign Up Now'
+    return [
+      {
+        name: $(isSubscription ? '.woocommerce-product-details__short-description p' : '.product_title.entry-title')
+          .first()
+          .text(),
+        url: location.href,
+        price: $('.uncont .price').text(),
+        priceInCents: convertToDigits($('.uncont .woocommerce-Price-amount.amount').text()),
+        quantity: convertToDigits($('form.cart .quantity input').val()),
+        currency: 'EUR',
+        isSubscription,
+      },
+    ]
+  },
+  checkoutObject({ isfromAjaxCart, isProductPage }) {
+    const products = isProductPage
+      ? this.getDataFromPDP()
+      : isfromAjaxCart
+      ? this.getProductsFromAjaxCart()
+      : this.getProductsFromCart()
+
+    const subTotalInCents = convertToDigits(
+      isfromAjaxCart
+        ? $('.order-total')
+            .first()
+            .text()
+        : $('.product_list_widget')
+            .find('.woocommerce-Price-amount.amount')
+            .last()
+            .text()
+    )
+
+    return {
+      name: 'Proceed To Checkout',
+      data: {
+        hostname: location.hostname,
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
+        products,
+        subTotalInCents,
+        currency: 'EUR',
+      },
     }
   },
   setupDataGathering() {
@@ -129,19 +151,27 @@ export default {
 
     if (!window.$) return
 
-    $('.checkout.wc-forward.btn.btn-link').on('click', () => () =>
+    $(document).on('click', '.checkout.wc-forward.btn.btn-link', () =>
       RollbarWrapper(() => {
         // ajax cart
-        const isfromAjaxCart = true
-        const json = _this.checkoutObject(isfromAjaxCart)
+        const json = _this.checkoutObject({ isfromAjaxCart: true })
         mixpanel.track(json.name, json.data)
       })
     )
     if (location.pathname.match(/^\/de\/warenkorb/)) {
       // regular cart
-      $('.checkout-button.btn.btn-default.alt.wc-forward ').on('click', () =>
+      $(document).on('click', '.checkout-button.btn.btn-default.alt.wc-forward, #woo_pp_ec_button', () =>
         RollbarWrapper(() => {
-          const json = _this.checkoutObject()
+          const json = _this.checkoutObject({})
+          mixpanel.track(json.name, json.data)
+        })
+      )
+    }
+
+    if (location.pathname.match(/^\/de\//)) {
+      $(document).on('click', '#woo_pp_ec_button_product', () =>
+        RollbarWrapper(() => {
+          const json = _this.checkoutObject({ isProductPage: true })
           mixpanel.track(json.name, json.data)
         })
       )

--- a/plugiamo/src/data-gathering/tontonetfils.js
+++ b/plugiamo/src/data-gathering/tontonetfils.js
@@ -4,106 +4,28 @@ import { RollbarWrapper } from 'ext/rollbar'
 
 export default {
   getProductsFromCart() {
-    return $('.cart__row')
-      .map((i, item) => {
-        const itemName = $(item)
-          .find('.cart__product-name')
-          .text()
-          .trim()
-        if (!itemName) return
-        const itemUrl =
-          location.hostname +
-          $(item)
-            .find('.cart__product-name')
-            .attr('href')
-        const price = Number(
-          $(item)
-            .find('.cart__price')
-            .text()
-            .replace(/\D/g, '')
-        )
-        const itemQuantity = $(item)
-          .find('.js-qty__num')
-          .attr('value')
-        return {
-          name: itemName,
-          url: itemUrl,
-          price,
-          quantity: itemQuantity,
-          currency: 'EUR',
-        }
-      })
-      .toArray()
-  },
-  getProductsFromAjaxCart() {
-    return $('.ajaxcart__product')
-      .map((i, item) => {
-        const itemName = $(item)
-          .find('.ajaxcart__product-name')
-          .text()
-          .trim()
-        if (!itemName) return
-        const itemUrl =
-          location.hostname +
-          $(item)
-            .find('.ajaxcart__product-name')
-            .attr('href')
-        const itemPrice = $(item)
-          .find('.ajaxcart__price')
-          .text()
-          .trim()
-        const itemPriceInCents = Number(
-          $(item)
-            .find('.ajaxcart__price')
-            .text()
-            .replace(/\D/g, '')
-        )
-        const itemQuantity = $(item)
-          .find('.ajaxcart__qty-num')
-          .attr('value')
-        return {
-          name: itemName,
-          url: itemUrl,
-          price: itemPrice,
-          priceInCents: itemPriceInCents,
-          quantity: itemQuantity,
-          currency: 'EUR',
-        }
-      })
-      .toArray()
+    if (!window.swymCart.items) return []
+    return window.swymCart.items.map(item => ({
+      id: item.id,
+      name: item.product_title,
+      url: `${location.hostname}/${item.url}`,
+      price: item.price,
+      quantity: item.quantity,
+      currency: 'EUR',
+      size: item.variant_title,
+    }))
   },
   checkoutObject() {
-    if ($('#CartDrawer.js-drawer-open')[0]) {
-      return {
-        name: 'Proceed To Checkout',
-        data: {
-          hostname: location.hostname,
-          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
-          products: this.getProductsFromAjaxCart(),
-          subTotalInCents: Number(
-            $('.ajaxcart__subtotal')
-              .last()
-              .text()
-              .replace(/\D/g, '')
-          ),
-          currency: 'EUR',
-        },
-      }
-    } else {
-      return {
-        name: 'Proceed To Checkout',
-        data: {
-          hostname: location.hostname,
-          withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
-          products: this.getProductsFromCart(),
-          subTotalInCents: Number(
-            $('.cart__subtotal')
-              .text()
-              .replace(/\D/g, '')
-          ),
-          currency: 'EUR',
-        },
-      }
+    if (!window.swymCart) return
+    return {
+      name: 'Proceed To Checkout',
+      data: {
+        hostname: location.hostname,
+        withPlugin: !!$('iframe[title="Frekkls Launcher"]')[0],
+        products: this.getProductsFromCart(),
+        subTotalInCents: window.swymCart.total_price,
+        currency: 'EUR',
+      },
     }
   },
   setupDataGathering() {

--- a/plugiamo/src/special/assessment/utils.js
+++ b/plugiamo/src/special/assessment/utils.js
@@ -76,10 +76,7 @@ const assessProducts = (products, tags) => {
 const getShopcartProductIds = () =>
   process.env.ASSESSMENT_PRODUCT_ID
     ? [process.env.ASSESSMENT_PRODUCT_ID]
-    : dataGathering
-        .getProductsFromCart()
-        .map((key, value) => value.id)
-        .toArray()
+    : dataGathering.getProductsFromCart().map((key, value) => value.id)
 
 const recommendedProducts = ({ results, suggestions }) => {
   const client = results.find(item => item.hostname === assessmentHostname)

--- a/plugiamo/src/utils/index.js
+++ b/plugiamo/src/utils/index.js
@@ -19,4 +19,9 @@ const getScrollbarWidth = () => {
   return widthNoScroll - widthWithScroll
 }
 
-export { isSmall, isLarge, getScrollbarWidth }
+const convertToDigits = selector => {
+  if (!selector) return 0
+  return Number(selector.replace(/\D/g, ''))
+}
+
+export { isSmall, isLarge, getScrollbarWidth, convertToDigits }

--- a/tracker/src/data-gathering/almagreendesign.js
+++ b/tracker/src/data-gathering/almagreendesign.js
@@ -1,9 +1,8 @@
 import mixpanel from 'ext/mixpanel'
-import { getAffiliateToken } from 'utils'
+import { convertToDigits, getAffiliateToken } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 
 const $$ = (selector, callback) => Array.prototype.map.call(document.querySelectorAll(selector), callback)
-const convertToCents = text => (text ? Number(text.replace(/\D/g, '')) : 0)
 
 // from https://stackoverflow.com/a/52809105
 const setupLocationChangeEvent = () => {
@@ -35,7 +34,7 @@ export default {
   triggerProceedToCheckout() {
     const products = $$('.order-products .product-cart', element => {
       const name = (element.querySelector('.product-name') || { textContent: '' }).textContent.trim()
-      const price = convertToCents((element.querySelector('.main-price') || { textContent: '' }).textContent)
+      const price = convertToDigits((element.querySelector('.main-price') || { textContent: '' }).textContent)
       const quantity = (element.querySelector('.quantity') || { value: 0 }).value
       return { name, price, quantity, currency: 'EUR' }
     })
@@ -43,7 +42,7 @@ export default {
       hostname: location.hostname,
       products,
       currency: 'EUR',
-      subTotalInCents: convertToCents((document.querySelector('div.main-total') || { textContent: '' }).textContent),
+      subTotalInCents: convertToDigits((document.querySelector('div.main-total') || { textContent: '' }).textContent),
       affiliateToken: getAffiliateToken(),
     })
   },

--- a/tracker/src/data-gathering/elementum.js
+++ b/tracker/src/data-gathering/elementum.js
@@ -1,11 +1,6 @@
 import mixpanel from 'ext/mixpanel'
-import { getAffiliateToken } from 'utils'
+import { convertToDigits, getAffiliateToken } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
-
-const convertToCents = selector => {
-  if (!selector) return 0
-  return Number(selector.replace(/\D/g, ''))
-}
 
 export default {
   triggerCartProceedToCheckout() {
@@ -22,7 +17,7 @@ export default {
             .$(item)
             .find('a')
             .attr('href')
-        const price = convertToCents(
+        const price = convertToDigits(
           window
             .$(item)
             .find('.ajaxcart__price')
@@ -42,7 +37,7 @@ export default {
       hostname: location.hostname,
       products,
       currency: 'EUR',
-      subTotalInCents: convertToCents(
+      subTotalInCents: convertToDigits(
         window
           .$('.ajaxcart__subtotal')
           .last()
@@ -56,7 +51,7 @@ export default {
       {
         name: window.$('.product-single__title').text(),
         url: location.origin + location.pathname,
-        price: convertToCents(window.$('.product-single__price').text()),
+        price: convertToDigits(window.$('.product-single__price').text()),
         quantity: 1,
         currency: 'EUR',
       },
@@ -65,7 +60,7 @@ export default {
       hostname: location.hostname,
       products,
       currency: 'EUR',
-      subTotalInCents: convertToCents(
+      subTotalInCents: convertToDigits(
         window
           .$('.product-single__price')
           .last()

--- a/tracker/src/data-gathering/theoceanbottle.js
+++ b/tracker/src/data-gathering/theoceanbottle.js
@@ -1,12 +1,8 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { getAffiliateToken } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
-
-const convertToCents = selector => {
-  if (!selector) return 0
-  return Number(selector.replace(/\D/g, ''))
-}
 
 export default {
   getProductsFromCart() {
@@ -25,14 +21,13 @@ export default {
             .find('.cart-title')
             .children('a')
             .attr('href')
-        const price = convertToCents(
+        const price = convertToDigits(
           window
             .$(item)
-            .find('.cart-item-total')
-            .last()
+            .find('.cart-item-price')
             .text()
         )
-        const itemQuantity = Number(
+        const itemQuantity = convertToDigits(
           window
             .$(item)
             .find('.cart-item-quantity-display')
@@ -57,7 +52,7 @@ export default {
         hostname: location.hostname,
         products: this.getProductsFromCart(),
         currency: 'GBP',
-        subTotalInCents: convertToCents(
+        subTotalInCents: convertToDigits(
           window
             .$('span.money')
             .last()
@@ -76,6 +71,12 @@ export default {
 
     if (location.pathname.match(/^\/cart((\/\w+)+|\/?)/)) {
       window.$(document).on('click', '.cart-button-checkout.button', () =>
+        RollbarWrapper(() => {
+          const json = this.checkoutObject()
+          mixpanel.track(json.name, json.data)
+        })
+      )
+      window.$(document).on('click', '.dynamic-checkout__content div[role="button"]', () =>
         RollbarWrapper(() => {
           const json = this.checkoutObject()
           mixpanel.track(json.name, json.data)

--- a/tracker/src/data-gathering/vintageforacause.js
+++ b/tracker/src/data-gathering/vintageforacause.js
@@ -1,9 +1,8 @@
 import mixpanel from 'ext/mixpanel'
-import { getAffiliateToken } from 'utils'
+import { convertToDigits, getAffiliateToken } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 
 const $$ = (selector, callback) => Array.prototype.map.call(document.querySelectorAll(selector), callback)
-const convertToCents = text => (text ? Number(text.replace(/\D/g, '')) : 0)
 
 export default {
   triggerPurchaseSuccess() {
@@ -14,7 +13,7 @@ export default {
       const id = (element.dataset || { variantId: '' }).variantId
       const name = (element.querySelector('.cart-product-desc a') || { textContent: '' }).textContent.trim()
       const url = (element.querySelector('.cart-product-desc a') || { href: '' }).href
-      const price = convertToCents((element.querySelector('.product-price') || { textContent: '' }).textContent)
+      const price = convertToDigits((element.querySelector('.product-price') || { textContent: '' }).textContent)
       const quantity = (element.querySelector('.inputCounter') || { value: 0 }).value
       return { id, name, url, price, quantity, currency: 'EUR' }
     })
@@ -22,7 +21,9 @@ export default {
       hostname: location.hostname,
       products,
       currency: 'EUR',
-      subTotalInCents: convertToCents((document.querySelector('.cart-total-price') || { textContent: '' }).textContent),
+      subTotalInCents: convertToDigits(
+        (document.querySelector('.cart-total-price') || { textContent: '' }).textContent
+      ),
       affiliateToken: getAffiliateToken(),
     })
   },
@@ -30,7 +31,7 @@ export default {
     const id = (((window.ShopifyAnalytics || {}).meta || {}).product || {}).id
     const name = (document.querySelector('[itemprop="name"]') || { textContent: '' }).textContent.trim()
     const url = (document.querySelector('meta[itemprop="url"]') || { content: '' }).content
-    const price = convertToCents((document.querySelector('[itemprop="price"]') || { textContent: '' }).textContent)
+    const price = convertToDigits((document.querySelector('[itemprop="price"]') || { textContent: '' }).textContent)
     const quantity = (document.querySelector('#quantity') || { value: 0 }).value
     const products = [
       {
@@ -46,7 +47,7 @@ export default {
       hostname: location.hostname,
       products,
       currency: 'EUR',
-      subTotalInCents: convertToCents(
+      subTotalInCents: convertToDigits(
         (document.querySelector('.product-normal-price') || { textContent: '' }).textContent
       ),
       affiliateToken: getAffiliateToken(),

--- a/tracker/src/data-gathering/waterhaul.js
+++ b/tracker/src/data-gathering/waterhaul.js
@@ -1,12 +1,8 @@
 import mixpanel from 'ext/mixpanel'
+import { convertToDigits } from 'utils'
 import { getAffiliateToken } from 'utils'
 import { RollbarWrapper } from 'ext/rollbar'
 /* eslint-disable no-undef */
-
-const convertToCents = selector => {
-  if (!selector) return 0
-  return Number(selector.replace(/\D/g, ''))
-}
 
 export default {
   getProduct(isMenuCart, item) {
@@ -22,16 +18,25 @@ export default {
         .find('h3')
         .children('a')
         .attr('href')
-      const price = convertToCents(
+      const price = convertToDigits(
         jQuery
           .noConflict()(item)
-          .find('.product-subtotal')
+          .find('.woocommerce-Price-amount.amount')
+          .first()
           .text()
+      )
+      const quantity = convertToDigits(
+        jQuery
+          .noConflict()(item)
+          .find('.mc-quantity')
+          .text()
+          .split('×')[0]
       )
       return {
         name: itemName,
         url: itemUrl,
         price,
+        quantity,
         currency: 'EUR',
       }
     } else {
@@ -46,15 +51,22 @@ export default {
         .find('.product-name')
         .children('a')
         .attr('href')
-      const price = convertToCents(
+      const price = convertToDigits(
         jQuery
           .noConflict()(item)
-          .find('.product-subtotal')
+          .find('.product-price')
           .text()
+      )
+      const quantity = convertToDigits(
+        jQuery
+          .noConflict()(item)
+          .find('input')
+          .val()
       )
       return {
         name: itemName,
         url: itemUrl,
+        quantity,
         price,
         currency: 'EUR',
       }
@@ -71,7 +83,7 @@ export default {
         hostname: location.hostname,
         products: this.getProductsFromCart(isMenuCart),
         currency: 'EUR',
-        subTotalInCents: convertToCents(
+        subTotalInCents: convertToDigits(
           jQuery
             .noConflict()('.cart-subtotal')
             .find('.woocommerce-Price-amount.amount')

--- a/tracker/src/utils/index.js
+++ b/tracker/src/utils/index.js
@@ -12,4 +12,9 @@ const setAffiliateToken = () => {
 
 const getAffiliateToken = () => localStorage.getItem('aftk')
 
-export { setAffiliateToken, getAffiliateToken }
+const convertToDigits = selector => {
+  if (!selector) return 0
+  return Number(selector.replace(/\D/g, ''))
+}
+
+export { setAffiliateToken, getAffiliateToken, convertToDigits }


### PR DESCRIPTION
### Changes
- Price will be always 1 item price, not the sub-total of item;
- `convertToCents` will be renamed to `convertToDigits` and become consistent;
- Some websites used Shopify (tontonetfils and trendiamo-mvp) and in every page it includes an object  `window.swymCart` which contains all the information about current shopping cart. Script will use those objects instead of DOM ones.
- Supporting `PayPal` button in Timeblock (in PDP as well);
- Supporting `Google Pay` button in theoceanbottle.