### PR TITLE
Fix image crop

### DIFF
--- a/console-frontend/src/shared/images-modal/cropping-dialog.js
+++ b/console-frontend/src/shared/images-modal/cropping-dialog.js
@@ -54,6 +54,7 @@ const DialogContentCropping = ({ crop, onCropChange, onCropComplete, onImageLoad
         <HiddenImg alt="" ref={imagePreviewRef} src={image} />
         <StyledReactCrop
           crop={crop}
+          imageStyle={{ maxHeight: 'none' }}
           keepSelection
           minHeight={20}
           minWidth={20}


### PR DESCRIPTION
## Fix:
### Bug Preview:
![bug](https://user-images.githubusercontent.com/35154956/64608562-ddcfa580-d3c2-11e9-951a-e0597537b425.png)

The bug is fixed in the latest [release](https://github.com/DominicTobias/react-image-crop/releases) of react-image-crop. See also this [issue](https://github.com/DominicTobias/react-image-crop/issues/288).

[Link To Trello Card](https://trello.com/c/nmDtKOia/1592-cropping-dialog-is-not-showing-the-image-to-crop)