### PR TITLE
Add shopify orders integration

### DIFF
--- a/backend/app/controllers/shop_api/v1/orders_controller.rb
+++ b/backend/app/controllers/shop_api/v1/orders_controller.rb
@@ -1,0 +1,61 @@
+module ShopApi
+  module V1
+    class OrdersController < RestController
+      before_action :set_tenant_from_hostname
+      before_action :ensure_tenant
+      before_action :authenticate
+      before_action :set_affiliation
+
+      def create
+        @order = Order.new(order_params)
+        if @order.save
+          render json: @order, status: :created
+        else
+          render_error
+        end
+      end
+
+      private
+
+      def order_params
+        result = params.require(:order).permit(:source_id, :source, :amount_in_cents, :currency, :payload,
+                                               products: %i[id quantity name price currency])
+        result = result.merge(payload: params[:order][:payload].permit!.to_h)
+        result.merge(extra_params)
+      end
+
+      def extra_params
+        {
+          account_id: @affiliation&.account_id,
+          seller_id: @affiliation&.user_id,
+          captured_at: Time.now.utc,
+          commission_rate: @affiliation && @affiliation.account.brand.commission_rate,
+        }
+      end
+
+      def render_error
+        errors = @order.errors.full_messages.map { |string| { title: string } }
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+
+      def authenticate
+        auth_header = request.headers["Authorization"]
+        return if auth_header == "Plain #{ENV['SHOP_API_TOKEN']}"
+
+        user_not_authorized
+      end
+
+      def set_tenant_from_hostname
+        hostname_header = request.headers["Hostname"]
+        set_current_tenant(Website.find_with_hostname(hostname_header)&.account)
+      end
+
+      def set_affiliation
+        affiliate_token = params[:order][:affiliate_token]
+        return unless affiliate_token
+
+        @affiliation = Affiliation.find_by(token: affiliate_token)
+      end
+    end
+  end
+end

--- a/backend/app/services/jql/scripts.rb
+++ b/backend/app/services/jql/scripts.rb
@@ -79,6 +79,7 @@ module Jql
 
     def self.order_dummy
       {
+        source: "dummy",
         currency: "PTT",
         amountInCents: 1000,
         products: [product_dummy],

--- a/backend/app/services/mixpanel/fetch_orders.rb
+++ b/backend/app/services/mixpanel/fetch_orders.rb
@@ -39,6 +39,7 @@ class Mixpanel::FetchOrders
 
   def order_params(affiliation, order)
     {
+      source: order["source"] || "mixpanel",
       seller: affiliation.user,
       account: affiliation.account,
       captured_at: Time.now.utc,

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
     namespace :shop_api do
       namespace :v1 do
         resources :products, only: %i[index show create update destroy]
+        resources :orders, only: %i[create]
       end
     end
 

--- a/backend/db/migrate/20190911090817_add_source_to_orders.rb
+++ b/backend/db/migrate/20190911090817_add_source_to_orders.rb
@@ -1,0 +1,6 @@
+class AddSourceToOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orders, :source, :string
+    add_column :orders, :source_id, :integer, limit: 8
+  end
+end

--- a/backend/db/migrate/20190911150735_add_payload_to_orders.rb
+++ b/backend/db/migrate/20190911150735_add_payload_to_orders.rb
@@ -1,0 +1,5 @@
+class AddPayloadToOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orders, :payload, :json
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190911112547) do
+ActiveRecord::Schema.define(version: 20190911150735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,6 +102,9 @@ ActiveRecord::Schema.define(version: 20190911112547) do
     t.json "products"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "source"
+    t.bigint "source_id"
+    t.json "payload"
     t.index ["account_id"], name: "index_orders_on_account_id"
     t.index ["seller_id"], name: "index_orders_on_seller_id"
   end

--- a/backend/lib/populate.rb
+++ b/backend/lib/populate.rb
@@ -380,6 +380,7 @@ class Populate # rubocop:disable Metrics/ClassLength
 
   def order_params(affiliation) # rubocop:disable Metrics/MethodLength
     {
+      source: "dummy",
       seller: affiliation.user,
       account: affiliation.account,
       captured_at: Time.now.utc,

--- a/integrations/shopify/app/jobs/orders_paid_job.rb
+++ b/integrations/shopify/app/jobs/orders_paid_job.rb
@@ -1,0 +1,13 @@
+class OrdersPaidJob < ApplicationJob
+  def perform(shop_domain:, webhook:)
+    shop = Shop.find_by(shopify_domain: shop_domain)
+
+    shop.with_shopify_session do
+      RestClient::OrderWebhookRequest.new(shop_domain, webhook).create_order
+    end
+  rescue StandardError, ShopifyAPI::ValidationException, ShopifyAPI::Base::InvalidSessionError,
+         ShopifyAPI::Limits::LimitUnavailable, InMemorySessionStore::EnvironmentError,
+         ShopifySessionRepository::ConfigurationError => e
+    Rollbar.warning(e)
+  end
+end

--- a/integrations/shopify/app/models/shop.rb
+++ b/integrations/shopify/app/models/shop.rb
@@ -1,6 +1,6 @@
 class Shop < ApplicationRecord
   include ShopifyApp::SessionStorage
-  after_create :perform_export_products
+  # after_create :perform_export_products
 
   def perform_export_products
     export_products

--- a/integrations/shopify/app/services/rest_client/order_webhook_request.rb
+++ b/integrations/shopify/app/services/rest_client/order_webhook_request.rb
@@ -1,0 +1,25 @@
+class RestClient::OrderWebhookRequest
+  def initialize(shop_domain, webhook)
+    @shop_domain = shop_domain
+    @order_webhook = webhook
+    @request_data = RestClient::RequestData.new(@shop_domain)
+  end
+
+  def create_order
+    order = find_and_convert_order
+    return unless order[:affiliate_token]
+
+    RestClient.post(base_url, { order: order }.to_json, @request_data.headers)
+  end
+
+  private
+
+  def base_url
+    "#{ENV['SHOP_API_URL']}/orders"
+  end
+
+  def find_and_convert_order
+    order = ShopifyAPI::Order.find(@order_webhook[:id])
+    @request_data.convert_order(order)
+  end
+end

--- a/integrations/shopify/app/services/rest_client/request_data.rb
+++ b/integrations/shopify/app/services/rest_client/request_data.rb
@@ -13,6 +13,44 @@ class RestClient::RequestData
     }
   end
 
+  def convert_to_cents(amount)
+    (100 * amount.to_r).to_i
+  end
+
+  def convert_line_item(item)
+    {
+      id: item.product_id,
+      quantity: item.quantity,
+      name: item.title,
+      price: convert_to_cents(item.price_set.shop_money.amount),
+      currency: item.price_set.shop_money.currency_code,
+    }
+  end
+
+  def get_affiliate_token(landing_site)
+    match = landing_site.match(/aftk=([^&]*)/)
+    match ? match[1] : nil
+  end
+
+  def order_payload(order)
+    order.attributes.except(:email, :customer, :client_details, :note, :user_id, :location_id, :device_id, :phone,
+                            :customer_locale, :note_attributes, :payment_gateway_names, :processing_method,
+                            :contact_email, :shipping_lines, :billing_address, :shipping_address, :fulfillments,
+                            :origin_location)
+  end
+
+  def convert_order(order)
+    {
+      source: "shopify",
+      source_id: order.id,
+      amount_in_cents: convert_to_cents(order.subtotal_price_set.shop_money.amount),
+      currency: order.currency,
+      products: order.line_items.map { |item| convert_line_item(item) },
+      affiliate_token: get_affiliate_token(order.landing_site),
+      payload: order_payload(order),
+    }
+  end
+
   def headers
     {
       Content_type: :json,

--- a/integrations/shopify/app/views/home/index.html.erb
+++ b/integrations/shopify/app/views/home/index.html.erb
@@ -13,8 +13,8 @@
   <h2>You're all set! 🚀</h2>
   <p>
     We successfully placed the Frekkls code snippet in the code of your Shopify store.<br>
-    Be aware that any modules set to active previously are showing on your site as of this moment.<br>
-    If you wish to disable the tool temporarily you can do so under the 'Account' section of your admin panel.
+    <!-- Be aware that any modules set to active previously are showing on your site as of this moment.<br>
+    If you wish to disable the tool temporarily you can do so under the 'Account' section of your admin panel. -->
   </p>
   <p>
     If something is wrong, get in touch with our support

--- a/integrations/shopify/app/views/layouts/_navbar.html.erb
+++ b/integrations/shopify/app/views/layouts/_navbar.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar">
-  <%= link_to "https://admin.frekkls.com" do %>
+  <!-- <%= link_to "https://admin.frekkls.com" do %> -->
     <%= image_tag "frekkls-logo.svg", alt: "Frekkls", class: "navbar-logo" %>
-  <% end %>
+  <!-- <% end %> -->
 </nav>

--- a/integrations/shopify/config/initializers/shopify_app.rb
+++ b/integrations/shopify/config/initializers/shopify_app.rb
@@ -5,7 +5,7 @@ ShopifyApp.configure do |config|
   config.secret = ENV["SHOPIFY_SHARED_SECRET"]
 
   # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
-  config.scope = "read_products,write_script_tags"
+  config.scope = "read_orders, read_products, write_script_tags"
 
   config.embedded_app = false
 
@@ -14,12 +14,13 @@ ShopifyApp.configure do |config|
   config.session_repository = Shop
 
   config.scripttags = [
-    { event: 'onload', src: 'https://plugiamo.s3.eu-central-1.amazonaws.com/plugin.js', display_scope: "all" },
+    { event: 'onload', src: 'https://js.frekkls.com/tracker.js', display_scope: "all" },
   ]
   config.webhooks = [
     {topic: 'app/uninstalled', address: "#{ENV["BASE_API_URL"]}/webhooks/app_uninstalled", format: 'json'},
-    {topic: 'products/delete', address: "#{ENV["BASE_API_URL"]}/webhooks/products_delete", format: 'json'},
-    {topic: 'products/update', address: "#{ENV["BASE_API_URL"]}/webhooks/products_update", format: 'json'},
-    {topic: 'products/create', address: "#{ENV["BASE_API_URL"]}/webhooks/products_create", format: 'json'},
+    # {topic: 'products/delete', address: "#{ENV["BASE_API_URL"]}/webhooks/products_delete", format: 'json'},
+    # {topic: 'products/update', address: "#{ENV["BASE_API_URL"]}/webhooks/products_update", format: 'json'},
+    # {topic: 'products/create', address: "#{ENV["BASE_API_URL"]}/webhooks/products_create", format: 'json'},
+    {topic: 'orders/paid', address: "#{ENV["BASE_API_URL"]}/webhooks/orders_paid", format: 'json'},
   ]
 end


### PR DESCRIPTION
 ## Feature description:

After marking an order as paid in a shopify store containing our integration app, a background job, `OrdersPaidJob`,  is queued (in the shopify-integration system) which will trigger the webhook to make an API call to `api.frekkls.com/shop_api/v1/orders`, creating a new record in the `Orders` table.

#### Note:
1) The API call to `api.frekkls.com/shop_api/v1/orders` is only triggered if the user arrived to the shop through an affiliate link with containing `aftk=foo` e.g. "https://trendiamo-mvp.myshopify.com/products/black-sweatshirt?aftk=b6c0ade4".
2) `source` and `source_id` fields were added to the "Order" model. `source` for "shopify", `source_id` referencing the id of the order in the order's `source`.



[Link To Trello Card](https://trello.com/c/FVS8cT8I/1597-shopify-integration-implement-order-integration)