### PR TITLE
Fix image crop modal

### DIFF
--- a/console-frontend/src/shared/images-modal/cropping-dialog.js
+++ b/console-frontend/src/shared/images-modal/cropping-dialog.js
@@ -6,10 +6,8 @@ import styled from 'styled-components'
 import { CircularProgress } from '@material-ui/core'
 import { DialogActionsContainer, StyledButton } from './shared'
 
-// max-height: 253px = dialog's margin (96px) + dialog title height (76px) + dialog action height (81px)
 const DialogCroppingContainer = styled.div`
   min-height: 200px;
-  max-height: calc(100vh - 253px);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -54,7 +52,8 @@ const DialogContentCropping = ({ crop, onCropChange, onCropComplete, onImageLoad
         <HiddenImg alt="" ref={imagePreviewRef} src={image} />
         <StyledReactCrop
           crop={crop}
-          imageStyle={{ maxHeight: 'none' }}
+          // max-height: 253px = dialog's margin (96px) + dialog title height (76px) + dialog action height (81px)
+          imageStyle={{ maxHeight: 'calc(100vh - 253px)' }}
           keepSelection
           minHeight={20}
           minWidth={20}


### PR DESCRIPTION
## Bug Fix:
![fix](https://user-images.githubusercontent.com/35154956/64881311-5b5d1500-d652-11e9-87b2-0f184cb595a3.gif)

[Link To Trello Card](https://trello.com/c/RcJpvbnu/1612-upload-picture-that-is-too-tall-you-scroll-the-modal-shouldnt-scroll)