### PR TITLE
Fix errors with img url

### DIFF
--- a/console-frontend/src/auth/index.js
+++ b/console-frontend/src/auth/index.js
@@ -41,6 +41,10 @@ const auth = {
   },
   getUser() {
     if (!this.user) this.user = JSON.parse(localStorage.getItem('authUser') || '{}')
+    // TODO: remove these lines after 2019-10-16 (check https://github.com/trendiamo/core/pull/880)
+    if (this.user.imgUrl && !this.user.img) {
+      this.user.img = { url: this.user.imgUrl }
+    }
     return this.user
   },
   isAffiliate() {


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/IvI5TafB)

## Changes

Fix errors 24, 25, 26, 27 in Rollbar (see https://rollbar.com/frekkls/admin/items), caused by changing `imgUrl` to `img.url` in #872.

Some users still have `imgUrl` in their local storage. If present, it gets now converted to `img.url`.