### PR TITLE
Send some emails from frekkls and some from uptous

### DIFF
--- a/backend/app/mailers/devise_sparkpost_mailer.rb
+++ b/backend/app/mailers/devise_sparkpost_mailer.rb
@@ -3,27 +3,27 @@ class DeviseSparkpostMailer < Devise::Mailer
 
   def confirmation_instructions(record, token, _opts = {})
     url = api_v1_users_confirmation_url(record, { confirmation_token: token }.merge(host_options(record)))
+    app = record.not_affiliate? ? "frekkls" : "uptous"
     sparkpost_data = {
       substitution_data: {
-        app: record.not_affiliate? ? "frekkls" : "uptous",
         user_identifier: record.first_name,
         # https://developers.sparkpost.com/api/template-language/#header-links
         dynamic_html: { confirm_email_link: %(<a href="#{url}">Confirm your email</a>) },
       },
-      template_id: "confirmation-instructions",
+      template_id: "#{app}-confirmation-instructions",
     }
     mail(to: record.email, sparkpost_data: sparkpost_data)
   end
 
   def reset_password_instructions(record, token, _opts = {})
     url = api_v1_users_password_edit_url(record, { reset_password_token: token }.merge(host_options(record)))
+    app = record.not_affiliate? ? "frekkls" : "uptous"
     sparkpost_data = {
       substitution_data: {
-        app: record.not_affiliate? ? "frekkls" : "uptous",
         user_identifier: record.first_name,
         dynamic_html: { change_password_link: %(<a href="#{url}">Change my password</a>) },
       },
-      template_id: "reset-password-instructions",
+      template_id: "#{app}-reset-password-instructions",
     }
     mail(to: record.email, sparkpost_data: sparkpost_data)
   end
@@ -37,7 +37,7 @@ class DeviseSparkpostMailer < Devise::Mailer
         invite_url: "#{ENV['MAILER_HOST']}/api/v1/users/invites/accept?token=#{token}",
         dynamic_html: { accept_email_link: %(<a href="#{url}">Accept the invite</a>) },
       },
-      template_id: "accept-invite",
+      template_id: "frekkls-accept-invite",
     }
     mail(to: record.email, sparkpost_data: sparkpost_data)
   end

--- a/backend/app/mailers/sparkpost_mailer.rb
+++ b/backend/app/mailers/sparkpost_mailer.rb
@@ -2,7 +2,7 @@ class SparkpostMailer < ApplicationMailer
   def delius_asmt_inquiry(hash)
     sparkpost_data = {
       substitution_data: substitution_data(hash),
-      template_id: "asmt-inquiry",
+      template_id: "frekkls-asmt-inquiry",
     }
     mail(to: ENV["DELIUS_ASMT_EMAIL"], bcc: ENV["DELIUS_ASMT_EMAIL_BCC"], sparkpost_data: sparkpost_data)
   end
@@ -13,7 +13,7 @@ class SparkpostMailer < ApplicationMailer
         promoter_name: "#{user.first_name} #{user.last_name}",
         promoter_email: user.email,
       },
-      template_id: "promoter-upgrade-request",
+      template_id: "uptous-promoter-upgrade-request",
     }
     mail(to: ENV["PROMOTER_UPGRADE_EMAIL"], sparkpost_data: sparkpost_data)
   end

--- a/infra/email-templates/frekkls-accept-invite.html
+++ b/infra/email-templates/frekkls-accept-invite.html
@@ -106,7 +106,7 @@
 
     <!--[if (mso)|(IE)]><td valign="top" style="width:600px;padding-bottom:40px; padding-top:40px;"><![endif]-->
 <div id="builtin_column_0-0" class="hse-column">
-  <div><img alt="mail_header_noedge" src="https://cdn2.hubspot.net/hub/4568386/hubfs/mail_header_noedge.png?t=1532967061861&amp;width=560&amp;name=mail_header_noedge.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
+  <div><img alt="mail_header_noedge" src="https://uptous.fra1.cdn.digitaloceanspaces.com/frekkls-email-header.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
 
 
   <p>Hello!</p>

--- a/infra/email-templates/frekkls-asmt-inquiry.html
+++ b/infra/email-templates/frekkls-asmt-inquiry.html
@@ -128,7 +128,7 @@
                               <b>Email:</b>
                             </td>
                             <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
-                              {{email}}
+                              {{inquiry_email}}
                             </td>
                           </tr>
                           <tr>

--- a/infra/email-templates/frekkls-confirmation-instructions.html
+++ b/infra/email-templates/frekkls-confirmation-instructions.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml"><head>
+<meta name="x-apple-disable-message-reformatting">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--[if gte mso 9]>
+  <xml>
+      <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+  </xml>
+
+  <style>
+    li {
+      text-indent: -1em;
+    }
+  </style>
+<![endif]-->
+<meta name="generator" content="HubSpot"><meta property="og:url" content="http://trendiamo-4568386.hs-sites.com/-temporary-slug-20a1f82e-829d-4bab-9cd3-450bb43acf7f"><style type="text/css">[owa] .hse-column-container{max-width:600px !important;width:600px !important}[owa] .hse-column{display:table-cell;vertical-align:top}
+[owa] .hse-section-1-col .hse-column{max-width:600px !important;width:600px !important}
+[owa] .hse-section-2-col .hse-wide{max-width:400px !important;width:400px !important}
+[owa] .hse-section-2-col .hse-narrow{max-width:200px !important;width:200px !important}
+[owa] .hse-section-2-col .hse-column{max-width:300px;width:300px}[owa] .hse-section-3-col .hse-column{max-width:200px !important;width:200px !important}
+[owa] .hse-section-4-col .hse-column{max-width:150px !important;width:150px !important}
+@media only screen and (min-width:640px){.hse-column-container{max-width:600px !important;width:600px !important}
+.hse-column{display:table-cell;vertical-align:top}.hse-section-1-col .hse-column{max-width:600px !important;width:600px !important}
+.hse-section-2-col .hse-column{max-width:300px !important;width:300px !important}
+.hse-section-2-col .hse-column.hse-wide{max-width:400px !important;width:400px !important}
+.hse-section-2-col .hse-column.hse-narrow{max-width:200px !important;width:200px !important}
+.hse-section-3-col .hse-column{max-width:200px !important;width:200px !important}
+.hse-section-4-col .hse-column{max-width:150px !important;width:150px !important}
+}@media only screen and (max-width:639px){img{height:auto !important;width:100% !important}
+}</style></head>
+
+<body style="margin:0 !important; padding:0 !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word">
+
+
+<!--[if gte mso 9]>
+<v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
+
+    <v:fill type="tile" size="100%,100%" src="" color="#ffffff"/>
+
+</v:background>
+<![endif]-->
+
+
+  <div class="hse-body-background" style="background-color:#ffffff" bgcolor="#ffffff">
+    <table role="presentation" class="hse-body-wrapper-table" cellpadding="0" cellspacing="0" style="border-collapse:collapse !important; border-spacing:0 !important; mso-table-lspace:0pt !important; mso-table-rspace:0pt !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word; margin:0; padding:0; width:100% !important; min-width:320px !important; height:100% !important" width="100%" height="100%">
+      <tbody><tr>
+        <td class="hse-body-wrapper-td" valign="top" style="border-collapse:collapse; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word">
+
+          <div id="hs_cos_wrapper_main" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_email_flex_area" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="email_flex_area">  <div id="section_1531826626773" class="hse-section hse-section-1-col hse-section-first " style="padding-left:10px; padding-right:10px; padding-top:20px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;"><![endif]-->
+<div id="column_1531826626773_0" class="hse-column ">
+  <div id="hs_cos_wrapper_module_15318266267724" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="module">
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+
+  <div id="builtin_section-0" class="hse-section hse-section-1-col " style="padding-left:10px; padding-right:10px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff; padding-bottom:40px; padding-top:40px" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;padding-bottom:40px; padding-top:40px;"><![endif]-->
+<div id="builtin_column_0-0" class="hse-column">
+  <div><img alt="mail_header_noedge" src="https://uptous.fra1.cdn.digitaloceanspaces.com/frekkls-email-header.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
+
+
+  <p>Hello {{user_identifier}}!</p>
+  <p>Your account has been created. Please click the link below to access your account:</p>
+  <p>{{ render_dynamic_content(dynamic_html.confirm_email_link) }}</p>
+  <p>If you didn't request this, please ignore this email.</p>
+
+
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+
+  <div id="builtin_section-1" class="hse-section hse-section-1-col hse-section-last " style="padding-left:10px; padding-right:10px; padding-bottom:20px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;"><![endif]-->
+<div id="builtin_column_1-0" class="hse-column ">
+<div id="hs_cos_wrapper_builtin_module_1_0_0" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="module">
+
+
+
+
+
+
+
+
+
+
+
+<table class="hse-footer hse-secondary" role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse !important; border-spacing:0 !important; mso-table-lspace:0pt !important; mso-table-rspace:0pt !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; word-break:break-word; text-align:center; font-family:Arial, sans-serif; font-size:12px; line-height:1.35; color:#23496d; margin-bottom:0; padding:0" align="center">
+    <tbody>
+        <tr>
+            <td align="center" valign="top" style="border-collapse:collapse; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly; word-break:break-word; text-align:center; font-family:helvetica; font-size:12px; color:#23496d; font-weight:normal; font-style:normal; text-decoration:none; margin-bottom:0; padding:10px 20px; line-height:1.35">
+                <p style="margin-bottom: 1em; margin:0; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly">
+                  trendiamo Unipessoal Lda., Rua de São Bernardo 60-A, Lisbon, Lisbon, 1200-826, Portugal, +351 213 960 149
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table></div>
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+</div>
+
+        </td>
+      </tr>
+    </tbody></table>
+  </div>
+
+
+
+</body></html>

--- a/infra/email-templates/frekkls-reset-password-instructions.html
+++ b/infra/email-templates/frekkls-reset-password-instructions.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml"><head>
+<meta name="x-apple-disable-message-reformatting">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--[if gte mso 9]>
+  <xml>
+      <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+  </xml>
+
+  <style>
+    li {
+      text-indent: -1em;
+    }
+  </style>
+<![endif]-->
+<meta name="generator" content="HubSpot"><meta property="og:url" content="http://trendiamo-4568386.hs-sites.com/-temporary-slug-20a1f82e-829d-4bab-9cd3-450bb43acf7f"><style type="text/css">[owa] .hse-column-container{max-width:600px !important;width:600px !important}[owa] .hse-column{display:table-cell;vertical-align:top}
+[owa] .hse-section-1-col .hse-column{max-width:600px !important;width:600px !important}
+[owa] .hse-section-2-col .hse-wide{max-width:400px !important;width:400px !important}
+[owa] .hse-section-2-col .hse-narrow{max-width:200px !important;width:200px !important}
+[owa] .hse-section-2-col .hse-column{max-width:300px;width:300px}[owa] .hse-section-3-col .hse-column{max-width:200px !important;width:200px !important}
+[owa] .hse-section-4-col .hse-column{max-width:150px !important;width:150px !important}
+@media only screen and (min-width:640px){.hse-column-container{max-width:600px !important;width:600px !important}
+.hse-column{display:table-cell;vertical-align:top}.hse-section-1-col .hse-column{max-width:600px !important;width:600px !important}
+.hse-section-2-col .hse-column{max-width:300px !important;width:300px !important}
+.hse-section-2-col .hse-column.hse-wide{max-width:400px !important;width:400px !important}
+.hse-section-2-col .hse-column.hse-narrow{max-width:200px !important;width:200px !important}
+.hse-section-3-col .hse-column{max-width:200px !important;width:200px !important}
+.hse-section-4-col .hse-column{max-width:150px !important;width:150px !important}
+}@media only screen and (max-width:639px){img{height:auto !important;width:100% !important}
+}</style></head>
+
+<body style="margin:0 !important; padding:0 !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word">
+
+
+<!--[if gte mso 9]>
+<v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
+
+    <v:fill type="tile" size="100%,100%" src="" color="#ffffff"/>
+
+</v:background>
+<![endif]-->
+
+
+  <div class="hse-body-background" style="background-color:#ffffff" bgcolor="#ffffff">
+    <table role="presentation" class="hse-body-wrapper-table" cellpadding="0" cellspacing="0" style="border-collapse:collapse !important; border-spacing:0 !important; mso-table-lspace:0pt !important; mso-table-rspace:0pt !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word; margin:0; padding:0; width:100% !important; min-width:320px !important; height:100% !important" width="100%" height="100%">
+      <tbody><tr>
+        <td class="hse-body-wrapper-td" valign="top" style="border-collapse:collapse; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word">
+
+          <div id="hs_cos_wrapper_main" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_email_flex_area" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="email_flex_area">  <div id="section_1531826626773" class="hse-section hse-section-1-col hse-section-first " style="padding-left:10px; padding-right:10px; padding-top:20px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;"><![endif]-->
+<div id="column_1531826626773_0" class="hse-column ">
+  <div id="hs_cos_wrapper_module_15318266267724" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="module">
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+
+  <div id="builtin_section-0" class="hse-section hse-section-1-col " style="padding-left:10px; padding-right:10px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff; padding-bottom:40px; padding-top:40px" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;padding-bottom:40px; padding-top:40px;"><![endif]-->
+<div id="builtin_column_0-0" class="hse-column">
+  <div><img alt="mail_header_noedge" src="https://uptous.fra1.cdn.digitaloceanspaces.com/frekkls-email-header.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
+
+
+  <p>Hello {{user_identifier}}!</p>
+  <p>Someone has requested a link to change your password. You can do this through the link below.</p>
+  <p>{{change_password_url}}</p>
+  <p>{{ render_dynamic_content(dynamic_html.change_password_link) }}</p>
+  <p>If you didn't request this, please ignore this email.</p>
+  <p>Your password won't change until you access the link above and create a new one.</p>
+
+
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+
+  <div id="builtin_section-1" class="hse-section hse-section-1-col hse-section-last " style="padding-left:10px; padding-right:10px; padding-bottom:20px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;"><![endif]-->
+<div id="builtin_column_1-0" class="hse-column ">
+<div id="hs_cos_wrapper_builtin_module_1_0_0" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="module">
+
+
+
+
+
+
+
+
+
+
+
+<table class="hse-footer hse-secondary" role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse !important; border-spacing:0 !important; mso-table-lspace:0pt !important; mso-table-rspace:0pt !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; word-break:break-word; text-align:center; font-family:Arial, sans-serif; font-size:12px; line-height:1.35; color:#23496d; margin-bottom:0; padding:0" align="center">
+    <tbody>
+        <tr>
+            <td align="center" valign="top" style="border-collapse:collapse; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly; word-break:break-word; text-align:center; font-family:helvetica; font-size:12px; color:#23496d; font-weight:normal; font-style:normal; text-decoration:none; margin-bottom:0; padding:10px 20px; line-height:1.35">
+                <p style="margin-bottom: 1em; margin:0; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly">
+                  trendiamo Unipessoal Lda., Rua de São Bernardo 60-A, Lisbon, Lisbon, 1200-826, Portugal, +351 213 960 149
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table></div>
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+</div>
+
+        </td>
+      </tr>
+    </tbody></table>
+  </div>
+
+
+
+</body></html>

--- a/infra/email-templates/uptous-confirmation-instructions.html
+++ b/infra/email-templates/uptous-confirmation-instructions.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml"><head>
+<meta name="x-apple-disable-message-reformatting">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--[if gte mso 9]>
+  <xml>
+      <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+  </xml>
+
+  <style>
+    li {
+      text-indent: -1em;
+    }
+  </style>
+<![endif]-->
+<meta name="generator" content="HubSpot"><meta property="og:url" content="http://trendiamo-4568386.hs-sites.com/-temporary-slug-20a1f82e-829d-4bab-9cd3-450bb43acf7f"><style type="text/css">[owa] .hse-column-container{max-width:600px !important;width:600px !important}[owa] .hse-column{display:table-cell;vertical-align:top}
+[owa] .hse-section-1-col .hse-column{max-width:600px !important;width:600px !important}
+[owa] .hse-section-2-col .hse-wide{max-width:400px !important;width:400px !important}
+[owa] .hse-section-2-col .hse-narrow{max-width:200px !important;width:200px !important}
+[owa] .hse-section-2-col .hse-column{max-width:300px;width:300px}[owa] .hse-section-3-col .hse-column{max-width:200px !important;width:200px !important}
+[owa] .hse-section-4-col .hse-column{max-width:150px !important;width:150px !important}
+@media only screen and (min-width:640px){.hse-column-container{max-width:600px !important;width:600px !important}
+.hse-column{display:table-cell;vertical-align:top}.hse-section-1-col .hse-column{max-width:600px !important;width:600px !important}
+.hse-section-2-col .hse-column{max-width:300px !important;width:300px !important}
+.hse-section-2-col .hse-column.hse-wide{max-width:400px !important;width:400px !important}
+.hse-section-2-col .hse-column.hse-narrow{max-width:200px !important;width:200px !important}
+.hse-section-3-col .hse-column{max-width:200px !important;width:200px !important}
+.hse-section-4-col .hse-column{max-width:150px !important;width:150px !important}
+}@media only screen and (max-width:639px){img{height:auto !important;width:100% !important}
+}</style></head>
+
+<body style="margin:0 !important; padding:0 !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word">
+
+
+<!--[if gte mso 9]>
+<v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
+
+    <v:fill type="tile" size="100%,100%" src="" color="#ffffff"/>
+
+</v:background>
+<![endif]-->
+
+
+  <div class="hse-body-background" style="background-color:#ffffff" bgcolor="#ffffff">
+    <table role="presentation" class="hse-body-wrapper-table" cellpadding="0" cellspacing="0" style="border-collapse:collapse !important; border-spacing:0 !important; mso-table-lspace:0pt !important; mso-table-rspace:0pt !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word; margin:0; padding:0; width:100% !important; min-width:320px !important; height:100% !important" width="100%" height="100%">
+      <tbody><tr>
+        <td class="hse-body-wrapper-td" valign="top" style="border-collapse:collapse; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly; font-family:Arial, sans-serif; font-size:15px; line-height:1.75; color:#23496d; word-break:break-word">
+
+          <div id="hs_cos_wrapper_main" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_email_flex_area" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="email_flex_area">  <div id="section_1531826626773" class="hse-section hse-section-1-col hse-section-first " style="padding-left:10px; padding-right:10px; padding-top:20px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;"><![endif]-->
+<div id="column_1531826626773_0" class="hse-column ">
+  <div id="hs_cos_wrapper_module_15318266267724" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="module">
+
+
+
+
+
+
+
+
+
+
+
+</div>
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+
+  <div id="builtin_section-0" class="hse-section hse-section-1-col " style="padding-left:10px; padding-right:10px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff; padding-bottom:40px; padding-top:40px" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;padding-bottom:40px; padding-top:40px;"><![endif]-->
+<div id="builtin_column_0-0" class="hse-column">
+  <div><img alt="mail_header_noedge" src="https://uptous.fra1.cdn.digitaloceanspaces.com/uptous-email-header.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
+
+
+  <p>Hello {{user_identifier}}!</p>
+  <p>Your account has been created. Please click the link below to access your account:</p>
+  <p>{{ render_dynamic_content(dynamic_html.confirm_email_link) }}</p>
+  <p>If you didn't request this, please ignore this email.</p>
+
+
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+
+  <div id="builtin_section-1" class="hse-section hse-section-1-col hse-section-last " style="padding-left:10px; padding-right:10px; padding-bottom:20px">
+
+
+
+    <!--[if !((mso)|(IE))]><!-- -->
+      <div class="hse-column-container " style="min-width:280px; max-width:600px; width:100%; Margin-left:auto; Margin-right:auto; border-collapse:collapse !important; border-spacing:0 !important; background-color:#ffffff" bgcolor="#ffffff" width="100%">
+    <!--<![endif]-->
+
+    <!--[if (mso)|(IE)]>
+      <div class="hse-column-container" style="min-width:280px;max-width:600px;width:100%;Margin-left:auto;Margin-right:auto;border-collapse:collapse!important;border-spacing:0!important;">
+      <table align="center" style="" cellpadding="0" cellspacing="0" role="presentation" class=""  width="600px" bgcolor="#ffffff">
+      <tr style="background-color:#ffffff;">
+    <![endif]-->
+
+    <!--[if (mso)|(IE)]><td valign="top" style="width:600px;"><![endif]-->
+<div id="builtin_column_1-0" class="hse-column ">
+<div id="hs_cos_wrapper_builtin_module_1_0_0" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module" style="color: inherit; font-size: inherit; line-height: inherit;" data-hs-cos-general-type="widget" data-hs-cos-type="module">
+
+
+
+
+
+
+
+
+
+
+
+<table class="hse-footer hse-secondary" role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse !important; border-spacing:0 !important; mso-table-lspace:0pt !important; mso-table-rspace:0pt !important; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; word-break:break-word; text-align:center; font-family:Arial, sans-serif; font-size:12px; line-height:1.35; color:#23496d; margin-bottom:0; padding:0" align="center">
+    <tbody>
+        <tr>
+            <td align="center" valign="top" style="border-collapse:collapse; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly; word-break:break-word; text-align:center; font-family:helvetica; font-size:12px; color:#23496d; font-weight:normal; font-style:normal; text-decoration:none; margin-bottom:0; padding:10px 20px; line-height:1.35">
+                <p style="margin-bottom: 1em; margin:0; -ms-text-size-adjust:100%; -webkit-text-size-adjust:100%; mso-line-height-rule:exactly">
+                  trendiamo Unipessoal Lda., Rua de São Bernardo 60-A, Lisbon, Lisbon, 1200-826, Portugal, +351 213 960 149
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table></div>
+</div>
+<!--[if (mso)|(IE)]></td><![endif]-->
+
+
+    <!--[if (mso)|(IE)]></tr></table><![endif]-->
+
+    </div>
+
+
+  </div>
+</div>
+
+        </td>
+      </tr>
+    </tbody></table>
+  </div>
+
+
+
+</body></html>

--- a/infra/email-templates/uptous-promoter-upgrade-request.html
+++ b/infra/email-templates/uptous-promoter-upgrade-request.html
@@ -109,11 +109,9 @@
   <div><img alt="mail_header_noedge" src="https://cdn2.hubspot.net/hub/4568386/hubfs/mail_header_noedge.png?t=1532967061861&amp;width=560&amp;name=mail_header_noedge.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
 
 
-  <p>Hello {{user_identifier}}!</p>
-  <p>Your Trendiamo account has been created. Please click the link below to access your account:</p>
-  <p>{{ render_dynamic_content(dynamic_html.confirm_email_link) }}</p>
-  <p>Also, please then reset your password, to be able to login in the future.</p>
-  <p>If you didn't request this, please ignore this email.</p>
+  <p>There is a new Promoter Upgrade Request, by:</p>
+  <p>{{promoter_name}}</p>
+  <p>{{promoter_email}}</p>
 
 
 </div>

--- a/infra/email-templates/uptous-reset-password-instructions.html
+++ b/infra/email-templates/uptous-reset-password-instructions.html
@@ -106,7 +106,7 @@
 
     <!--[if (mso)|(IE)]><td valign="top" style="width:600px;padding-bottom:40px; padding-top:40px;"><![endif]-->
 <div id="builtin_column_0-0" class="hse-column">
-  <div><img alt="mail_header_noedge" src="https://cdn2.hubspot.net/hub/4568386/hubfs/mail_header_noedge.png?t=1532967061861&amp;width=560&amp;name=mail_header_noedge.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
+  <div><img alt="mail_header_noedge" src="https://uptous.fra1.cdn.digitaloceanspaces.com/uptous-email-header.png" style="outline:none; text-decoration:none; -ms-interpolation-mode:bicubic; max-width:560px" width="560" align="middle"></div>
 
 
   <p>Hello {{user_identifier}}!</p>


### PR DESCRIPTION
https://trello.com/c/1jpiXhWe/1633-send-emails-from-frekkls-and-uptous-addresses-not-trendiamo

I've created the new templates with prefix "frekkls" or "uptous" accordingly. We're doing it this way since:

1) The sparkpost gem doesn't support sending from as param when `template_id` is used (we could maybe hack around this, but it's at least not a simple hack)
2) Also we might want the templates (eg: text) to be super different between both apps, so it actually makes more sense to do it this way.