### PR TITLE
Fix Failed to fetch blank page for user

### DIFF
--- a/console-frontend/src/auth/index.js
+++ b/console-frontend/src/auth/index.js
@@ -37,7 +37,6 @@ const auth = {
   },
   setCsrfToken(json) {
     localStorage.setItem('CSRF-TOKEN', json.token)
-    localStorage.setItem('loggedIn', json.loggedIn)
   },
   getUser() {
     if (!this.user) this.user = JSON.parse(localStorage.getItem('authUser') || '{}')


### PR DESCRIPTION
# Bugfix:
### Steps to replicate the bug:
1) Login to app.uptous.co
2) clear localstorage without clearing the session cookie
3) go to /login
4) refresh the page

### Bug description:
This happens when localStorage in flushed but the session cookie is not. In this case, if the user goes to /login, the 'GET' request to /csrf_token will return 'loggedin' true, so, in localstorage the loggedin var gets set to true, without the 'authuser' var object, resulting in this issue.

[Link To Trello Card](https://trello.com/c/obPIEDYa/1654-typeerror-failed-to-fetch-user-sees-blank-page)