### PR TITLE
Style adjustments in U2U (referrals shadow + label links)

### DIFF
--- a/console-frontend/src/shared/link.js
+++ b/console-frontend/src/shared/link.js
@@ -1,19 +1,32 @@
 import omit from 'lodash.omit'
-import React from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components'
 import { Link as RouteLink } from 'react-router-dom'
 import { showUpToUsBranding } from 'utils'
 
 const Container = styled(props => <span {...omit(props, ['isText'])} />)`
   a {
+    outline: none;
     ${({ isText }) => (showUpToUsBranding() && isText ? 'color: #128976;' : 'text-decoration: none;')}
   }
 `
 
-const Link = ({ children, to, ...props }) => (
-  <Container isText={typeof children === 'string'}>
-    {to ? <RouteLink to={to}>{children}</RouteLink> : <a {...props}>{children}</a>}
-  </Container>
-)
+const Link = ({ children, to, ...props }) => {
+  const onClick = useCallback(event => {
+    event.stopPropagation()
+  }, [])
+
+  return (
+    <Container isText={typeof children === 'string'}>
+      {to ? (
+        <RouteLink to={to}>{children}</RouteLink>
+      ) : (
+        <a onClick={onClick} onKeyUp={onClick} role="link" tabIndex={0} {...props}>
+          {children}
+        </a>
+      )}
+    </Container>
+  )
+}
 
 export default Link

--- a/console-frontend/src/shared/paper.js
+++ b/console-frontend/src/shared/paper.js
@@ -1,0 +1,19 @@
+import omit from 'lodash.omit'
+import React from 'react'
+import styled from 'styled-components'
+import { Paper } from '@material-ui/core'
+import { showUpToUsBranding } from 'utils'
+
+const StyledPaper = styled(props => <Paper {...omit(props, ['foldable'])} />)`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  & + * {
+    margin-top: ${showUpToUsBranding() ? '18px' : '10px'};
+  }
+  ${({ foldable }) => foldable && 'padding-top: 16px;'}
+  ${showUpToUsBranding() &&
+    'border-radius: 0; box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.07);'}
+`
+
+export default StyledPaper

--- a/console-frontend/src/shared/section.js
+++ b/console-frontend/src/shared/section.js
@@ -1,9 +1,10 @@
 import Divider from './form-elements/divider'
 import omit from 'lodash.omit'
+import Paper from 'shared/paper'
 import React, { memo, useCallback, useMemo, useState } from 'react'
 import SectionTitle from './form-elements/section-title'
 import styled from 'styled-components'
-import { Collapse, Paper } from '@material-ui/core'
+import { Collapse } from '@material-ui/core'
 import { showUpToUsBranding } from 'utils'
 
 const Container = styled.div`
@@ -11,18 +12,6 @@ const Container = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-`
-
-const StyledPaper = styled(props => <Paper {...omit(props, ['foldable'])} />)`
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  & + * {
-    margin-top: ${showUpToUsBranding() ? '18px' : '10px'};
-  }
-  ${({ foldable }) => foldable && 'padding-top: 16px;'}
-  ${showUpToUsBranding() &&
-    'border-radius: 0; box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.07);'}
 `
 
 const SectionContent = styled(props => <div {...omit(props, ['foldable'])} />)`
@@ -53,7 +42,7 @@ const Section = ({
   const showDivider = useMemo(() => !showUpToUsBranding() || foldable, [foldable])
 
   return (
-    <StyledPaper className={className} elevation={4} foldable={foldable} {...props}>
+    <Paper className={className} elevation={4} foldable={foldable} {...props}>
       <Container>
         {title && (
           <>
@@ -78,7 +67,7 @@ const Section = ({
           <SectionContent>{children}</SectionContent>
         )}
       </Container>
-    </StyledPaper>
+    </Paper>
   )
 }
 

--- a/console-frontend/src/shared/uptous/index.js
+++ b/console-frontend/src/shared/uptous/index.js
@@ -1,5 +1,6 @@
+import Paper from 'shared/paper'
 import styled from 'styled-components'
-import { Paper, Typography } from '@material-ui/core'
+import { Typography } from '@material-ui/core'
 
 export const MainCard = styled(Paper)`
   margin-left: 1rem;
@@ -7,9 +8,8 @@ export const MainCard = styled(Paper)`
   align-self: center;
   max-width: 600px;
   min-width: 500px;
-  display: flex;
-  flex-direction: column;
   overflow: hidden;
+  align-items: stretch;
 `
 
 export const CardContent = styled.div`


### PR DESCRIPTION
### Changes
- Added `event.stopPropagation()` to `Link` component so that when user clicks on it in the label of the checkbox it doesn't check the checkbox;
- `StyledPaper` component from `shared/section` was moved to `shared/paper` in order to use it's `box-shadow` in multiple places (such as `MainCard` in `shared/uptous`).