### PR TITLE
Show alert in unsupported browsers

### DIFF
--- a/console-frontend/deploy/public-index.html
+++ b/console-frontend/deploy/public-index.html
@@ -21,6 +21,14 @@
     </script>
   </head>
   <body>
+    <script>
+      !(function() {
+        if (typeof Set === "undefined") {
+          alert('Your browser is not supported')
+          document.write('<!--')
+        }
+      })()
+    </script>
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root" class="notranslate"></div>
   </body>

--- a/console-frontend/public/index.html
+++ b/console-frontend/public/index.html
@@ -29,6 +29,14 @@
     <title></title>
   </head>
   <body>
+    <script>
+      !(function() {
+        if (typeof Set === "undefined") {
+          alert('Your browser is not supported')
+          document.write('<!--')
+        }
+      })()
+    </script>
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root" class="notranslate"></div>
   </body>


### PR DESCRIPTION
## Update
Some older browsers and devices don't support javascript's `Set` collection.  For those we don't render the app.
Fixes [#52](https://rollbar.com/frekkls/admin/items/52/) [#58](https://rollbar.com/frekkls/admin/items/58/) [#44](https://rollbar.com/frekkls/admin/items/44/) [#46](https://rollbar.com/frekkls/admin/items/46/)

[Link To Trello Card](https://trello.com/c/giaR0MZ7/1665-investigate-rollbar-errors-44-45-46)