### PR TITLE
Make U2U Admin responsive: step 2 (modals)

### DIFF
--- a/console-frontend/src/app/layout/menu/modal-user-settings/index.js
+++ b/console-frontend/src/app/layout/menu/modal-user-settings/index.js
@@ -15,8 +15,11 @@ const Tab = styled(MuiTab)`
 `
 
 const ContentContainer = styled.div`
-  min-height: 700px;
-  padding: 24px;
+  padding: 22px;
+  @media (min-width: 960px) {
+    min-height: 700px;
+    padding: 24px;
+  }
 `
 
 const TabsContainer = ({ tabs, selectedTab, setSelectedTab }) => {

--- a/console-frontend/src/app/screens/affiliate-partners/brand-card/actions.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-card/actions.js
@@ -4,7 +4,6 @@ import ClipboardInput from 'shared/clipboard-input'
 import mixpanel from 'ext/mixpanel'
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
-import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
 import { IconButton } from 'shared/form-elements'
 import { ReactComponent as NewTabIcon } from 'assets/icons/new-tab.svg'
 
@@ -54,7 +53,7 @@ const WebsiteButton = ({ affiliation, websiteHostname }) => {
   )
 }
 
-const Actions = ({ affiliation, brand, onClickCustomLink, openBrandModal, width }) => {
+const Actions = ({ affiliation, brand, onClickCustomLink, openBrandModal }) => {
   const onCopyAffiliateLink = useCallback(text => {
     mixpanel.track('Copied Affiliate Link', { hostname: window.location.hostname, text })
   }, [])
@@ -79,25 +78,13 @@ const Actions = ({ affiliation, brand, onClickCustomLink, openBrandModal, width 
             text={affiliation.defaultAffiliateLink}
           />
         ) : (
-          <Button
-            color="primaryGradient"
-            inline
-            onClick={onClickPromoteNow}
-            size="large"
-            width={!isWidthUp('md', width) && '100%'}
-          >
+          <Button color="primaryGradient" flex fullWidthOnMobile inline onClick={onClickPromoteNow} size="large">
             {'Promote now'}
           </Button>
         )}
       </ButtonContainer>
       {affiliation && (
-        <Button
-          color="white"
-          inline={isWidthUp('md', width)}
-          onClick={onClickCustomLink}
-          size="large"
-          width={!isWidthUp('md', width) && '100%'}
-        >
+        <Button color="white" flex fullWidthOnMobile inlineOnDesktop onClick={onClickCustomLink} size="large">
           {'Custom link'}
         </Button>
       )}
@@ -105,4 +92,4 @@ const Actions = ({ affiliation, brand, onClickCustomLink, openBrandModal, width 
   )
 }
 
-export default withWidth()(Actions)
+export default Actions

--- a/console-frontend/src/app/screens/affiliate-partners/brand-modal/content.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-modal/content.js
@@ -2,20 +2,27 @@ import Footer from './footer'
 import Header from './header'
 import React, { useCallback, useRef } from 'react'
 import styled from 'styled-components'
+import { Typography } from '@material-ui/core'
 
 const BrandDescription = styled.div`
   color: #272932;
+  h2 {
+    font-size: 20px;
+  }
 `
 
 const ContentContainer = styled.div`
   overflow-x: hidden;
-  padding: 10px 60px 20px;
-  margin-top: 70px;
+  padding: 12px 24px;
   position: relative;
+  @media (min-width: 960px) {
+    padding: 10px 60px 20px;
+  }
+  margin-top: 70px;
+  font-family: Lato, 'Helvetica', 'Arial', sans-serif;
 `
 
 const ContentScrollContainer = styled.div`
-  max-height: calc(100vh - 315px);
   overflow-y: auto;
 `
 
@@ -28,7 +35,7 @@ const TermsAndConditionsContent = styled.div``
 
 const TermsAndConditions = ({ brand, termsRef }) => (
   <div ref={termsRef}>
-    <h2>{'Terms and Conditions'}</h2>
+    <Typography variant="h5">{'Terms and Conditions'}</Typography>
     <TermsAndConditionsContent dangerouslySetInnerHTML={{ __html: brand.termsAndConditions }} />
   </div>
 )
@@ -36,16 +43,17 @@ const TermsAndConditions = ({ brand, termsRef }) => (
 const Content = ({ brand, removeAffiliation, createAffiliation, handleClose, selectedAffiliation, isLoading }) => {
   const contentRef = useRef(null)
   const termsRef = useRef(null)
+  const headerRef = useRef(null)
 
   const scrollToTermsAndConditions = useCallback(() => {
-    if (!contentRef.current || !termsRef.current) return
-    contentRef.current.scrollTo(0, termsRef.current.offsetTop + 350)
+    if (!contentRef.current || !termsRef.current || !headerRef.current) return
+    contentRef.current.scrollTo(0, termsRef.current.offsetTop + headerRef.current.clientHeight + 55)
   }, [])
 
   return (
     <MainContainer>
       <ContentScrollContainer ref={contentRef}>
-        <Header brand={brand} />
+        <Header brand={brand} headerRef={headerRef} />
         <ContentContainer>
           <BrandDescription dangerouslySetInnerHTML={{ __html: brand.fullDescription }} />
           <TermsAndConditions brand={brand} termsRef={termsRef} />

--- a/console-frontend/src/app/screens/affiliate-partners/brand-modal/footer.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-modal/footer.js
@@ -8,14 +8,21 @@ import { Typography } from '@material-ui/core'
 
 const Container = styled.div`
   background: #e7ecef;
-  min-height: 100px;
-  padding: 20px 60px 20px;
+  padding: 12px 24px 12px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  flex-shrink: 0;
+  @media (min-height: 960px) {
+    padding: 20px 60px 20px;
+  }
 `
 
 const CommissionRate = styled.div`
   color: #0f7173;
   font-size: 32px;
   font-weight: 700;
+  line-height: 1;
 `
 
 const CommissionDescription = styled.div`
@@ -25,8 +32,6 @@ const CommissionDescription = styled.div`
 
 const Conditions = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
 `
 
 const ActionsContainer = styled.div`
@@ -101,6 +106,7 @@ const CreateAffiliateLinkContainer = styled.div`
 const AffiliateTerms = styled.div`
   display: flex;
   align-items: baseline;
+  margin-top: 6px;
 `
 
 const SuccessScreen = ({ selectedAffiliation, removeAffiliation, isLoading }) => {
@@ -144,6 +150,7 @@ const SuccessScreen = ({ selectedAffiliation, removeAffiliation, isLoading }) =>
         <Button
           color={showRemoveConfirmationAlert ? 'error' : 'primaryGradient'}
           disabled={isLoading || selectedAffiliation.hasRevenues}
+          flex
           isFormSubmitting={isLoading}
           onClick={onRemoveButtonClick}
           size="small"
@@ -172,6 +179,8 @@ const Actions = ({ isCreateLinkClicked, onCreateLinkClick, scrollToTermsAndCondi
           <Button
             color="primaryGradient"
             disabled={isCreateLinkClicked || !acceptedTermsAndConditions}
+            flex
+            fullWidthOnMobile
             isFormSubmitting={isCreateLinkClicked}
             onClick={onCreateLinkClick}
             size="large"

--- a/console-frontend/src/app/screens/affiliate-partners/brand-modal/header.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-modal/header.js
@@ -33,7 +33,10 @@ const Logo = styled.img`
 const HeaderContent = styled.div`
   position: absolute;
   bottom: -60px;
-  left: 60px;
+  left: 22px;
+  @media (min-height: 960px) {
+    left: 60px;
+  }
 `
 
 const BrandLogo = ({ brand }) => {
@@ -46,28 +49,38 @@ const BrandLogo = ({ brand }) => {
 
 const HeaderImageContainer = styled.div`
   position: relative;
-  height: 300px;
+  height: 120px;
   width: 100%;
   overflow: hidden;
   display: flex;
   justify-content: center;
   align-items: center;
   background: linear-gradient(45deg, #ccc, rgba(255, 255, 255, 0));
+  @media (min-width: 960px) {
+    height: 300px;
+  }
 `
 
 const SocialLinkContainer = styled.a`
-  width: 26px;
-  height: 26px;
-  & + & {
-    margin-left: 10px;
+  font-size: 0;
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+  padding: 10px;
+  @media (min-width: 960px) {
+    svg {
+      width: auto;
+      height: auto;
+    }
   }
 `
 
 const SocialLinksContainer = styled.div`
   position: absolute;
-  left: 120px;
+  left: 130px;
   top: 60px;
-  padding: 17px;
+  padding: 17px 0;
   display: flex;
 `
 
@@ -87,9 +100,9 @@ const BrandSocialLinks = ({ brand }) => {
   )
 }
 
-const Header = ({ brand }) => {
+const Header = ({ brand, headerRef }) => {
   return (
-    <Container>
+    <Container ref={headerRef}>
       <HeaderImageContainer>
         <Image src={brand.headerImageUrl} />
       </HeaderImageContainer>

--- a/console-frontend/src/app/screens/affiliate-partners/brand-modal/index.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-modal/index.js
@@ -17,6 +17,7 @@ const BrandModal = ({ brand, createAffiliation, open, setOpen, removeAffiliation
           selectedAffiliation={selectedAffiliation}
         />
       }
+      flexContent
       fullWidth
       handleClose={handleClose}
       hasManualPadding

--- a/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/content.js
+++ b/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/content.js
@@ -6,13 +6,20 @@ import { Typography } from '@material-ui/core'
 
 const ContentContainer = styled.div`
   overflow-x: hidden;
-  padding: 10px 60px 20px;
+  padding: 10px 24px 20px;
   position: relative;
+  @media (min-width: 960px) {
+    padding: 10px 60px 20px;
+  }
 `
 
 const ContentScrollContainer = styled.div`
-  max-height: calc(100vh - 200px);
+  max-height: auto;
   overflow-y: auto;
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
 `
 
 const MainContainer = styled.div`
@@ -22,7 +29,11 @@ const MainContainer = styled.div`
 
 const IconContainer = styled.div`
   text-align: center;
-  padding: 35px 0 10px;
+  padding: 0px 0 10px;
+  margin-top: 0;
+  @media (min-width: 960px) {
+    margin-top: 35px;
+  }
 `
 
 const Content = ({ affiliation }) => {

--- a/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/footer.js
+++ b/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/footer.js
@@ -9,8 +9,14 @@ const urlInputProps = { pattern: 'https?://.+' }
 
 const Container = styled.div`
   background: #e7ecef;
-  min-height: 100px;
-  padding: 60px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  justify-content: center;
+  @media (min-height: 960px) {
+    padding: 20px 60px 20px;
+  }
 `
 
 const ClipboardContainer = styled.div`
@@ -22,7 +28,7 @@ const ClipboardContainer = styled.div`
 const Footer = ({ affiliation }) => {
   const { enqueueSnackbar } = useSnackbar()
 
-  const [isLoading, setIsLoading] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
 
   const createAffiliateLink = useCallback(
     async text => {

--- a/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/index.js
+++ b/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/index.js
@@ -8,6 +8,7 @@ const CustomLinkModal = ({ affiliation, open, setOpen }) => {
   return (
     <Dialog
       content={<Content affiliation={affiliation} />}
+      flexContent
       fullWidth
       handleClose={handleClose}
       hasManualPadding

--- a/console-frontend/src/auth/login/index.js
+++ b/console-frontend/src/auth/login/index.js
@@ -17,7 +17,6 @@ const Footer = ({ isSubmitting }) => (
       <Button
         color="primaryGradient"
         disabled={isSubmitting}
-        fullWidth
         isFormSubmitting={isSubmitting}
         type="submit"
         variant="contained"

--- a/console-frontend/src/auth/signup/account.js
+++ b/console-frontend/src/auth/signup/account.js
@@ -173,7 +173,6 @@ const AccountSignup = () => {
               <Button
                 color="primaryGradient"
                 disabled={state.isFormSubmitting}
-                fullWidth
                 isFormSubmitting={state.isFormSubmitting}
                 type="submit"
                 variant="contained"

--- a/console-frontend/src/auth/signup/affiliate.js
+++ b/console-frontend/src/auth/signup/affiliate.js
@@ -181,7 +181,6 @@ const AffiliateSignup = () => {
               <Button
                 color="primaryGradient"
                 disabled={state.isFormSubmitting}
-                fullWidth
                 isFormSubmitting={state.isFormSubmitting}
                 type="submit"
                 variant="contained"

--- a/console-frontend/src/shared/button.js
+++ b/console-frontend/src/shared/button.js
@@ -6,7 +6,21 @@ import { CircularProgress } from '@material-ui/core'
 import { Button as MuiButton, Tooltip } from '@material-ui/core'
 import { showUpToUsBranding } from 'utils'
 
-const ButtonContainer = styled(props => <div {...omit(props, ['inline', 'centered', 'width'])} />)`
+const ButtonContainer = styled(props => (
+  <div {...omit(props, ['inline', 'centered', 'width', 'fullWidthOnMobile', 'inlineOnDesktop'])} />
+))`
+
+  ${({ inlineOnDesktop }) =>
+    inlineOnDesktop &&
+    `
+    @media (min-width: 960px) {
+      display: inline-block;
+        * + & {
+          margin-left: 10px;
+        }
+    }
+  `}
+
 ${({ inline }) =>
   inline
     ? `display: inline-block;
@@ -17,7 +31,15 @@ ${({ inline }) =>
       margin-top: 12px;
     }`}
   justify-content: ${({ centered }) => (centered ? 'center' : 'normal')};
-  width: ${({ width }) => (width ? width : 'auto')};
+${({ fullWidthOnMobile, width }) =>
+  fullWidthOnMobile
+    ? `
+        width: 100%;
+        @media (min-width: 960px) {
+          width: ${width || 'auto'};
+        }
+      `
+    : `width: ${({ width }) => width || 'auto'};`}
 
 `
 
@@ -48,10 +70,11 @@ const uptousButtonSizes = {
   },
 }
 
-const StyledMuiButton = styled(props => <MuiButton {...omit(props, ['width'])} />)`
-  width: ${({ width }) => (width ? width : 'auto')};
+const StyledMuiButton = styled(props => <MuiButton {...omit(props, ['flex'])} />)`
   white-space: nowrap;
-  ${({ size }) => showUpToUsBranding() && uptousButtonSizes['mobile'][size || 'medium']}
+  ${({ flex }) => flex && 'width: 100%;'}
+  ${({ size }) =>
+    showUpToUsBranding() && uptousButtonSizes['mobile'][size || 'medium']}
   @media (min-width: 960px) {
     ${({ size }) => showUpToUsBranding() && uptousButtonSizes['desktop'][size || 'medium']}
   }
@@ -65,7 +88,7 @@ const StyledCircularProgress = () => (
 
 // Needed for when button is disabled as it won't fire the needed hover events for the tootip
 const EventFirer = styled.div`
-  max-width: fit-content;
+  width: 100%;
 `
 
 const ConditionalWrap = ({ disabled, wrap, children }) => (disabled ? wrap(children) : children)
@@ -84,6 +107,9 @@ const Button = ({
   centered,
   children,
   inline,
+  fullWidthOnMobile,
+  inlineOnDesktop,
+  flex,
   ...props
 }) => {
   const [styleObject, setStyleObject] = useState({})
@@ -124,7 +150,13 @@ const Button = ({
   )
 
   return (
-    <ButtonContainer centered={centered} inline={inline} width={width}>
+    <ButtonContainer
+      centered={centered}
+      fullWidthOnMobile={fullWidthOnMobile}
+      inline={inline}
+      inlineOnDesktop={inlineOnDesktop}
+      width={width}
+    >
       <Tooltip
         open={tooltipEnabled && tooltipOpen && isFormPristine}
         placement={tooltipPlacement}
@@ -139,15 +171,14 @@ const Button = ({
               'tooltipText',
               'tooltipPlacement',
               'isFormSubmitting',
-              'width',
               'centered',
             ])}
             disabled={disabled}
+            flex={flex}
             onClick={onClick}
             onMouseEnter={onButtonHoverStart}
             onMouseLeave={onButtonHoverEnd}
             style={disabled ? buttonStyles['disabled'] : styleObject}
-            width={width}
           >
             <ButtonContents>
               {isFormSubmitting && <StyledCircularProgress />}

--- a/console-frontend/src/shared/clipboard-input.js
+++ b/console-frontend/src/shared/clipboard-input.js
@@ -37,7 +37,7 @@ const TextInput = styled(props => <Input {...omit(props, ['wasCopied', 'pasteabl
 
 const CopyButton = styled(props => <Button {...omit(props, ['pasteable'])} />)`
   height: 100%;
-  width: ${({ pasteable }) => (pasteable ? '135px' : '90px')};
+  width: ${({ pasteable }) => (pasteable ? '120px' : '90px')};
   box-shadow: none;
   border-radius: 0;
 `

--- a/console-frontend/src/shared/dialog.js
+++ b/console-frontend/src/shared/dialog.js
@@ -3,6 +3,7 @@ import MuiIconButton from '@material-ui/core/IconButton'
 import omit from 'lodash.omit'
 import React from 'react'
 import styled from 'styled-components'
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
 import { DialogActions, DialogContent, DialogContentText, Dialog as MuiDialog, Typography } from '@material-ui/core'
 import { showUpToUsBranding } from 'utils'
 
@@ -38,9 +39,11 @@ const DialogSubtitle = styled.span`
   margin-top: -20px;
 `
 
-const StyledDialogContent = styled(props => <DialogContent {...omit(props, ['hasManualPadding'])} />)`
+const StyledDialogContent = styled(props => <DialogContent {...omit(props, ['hasManualPadding', 'flexContent'])} />)`
   padding-bottom: 0;
   ${({ hasManualPadding }) => hasManualPadding && 'padding: 0;'}
+  ${({ flexContent }) =>
+    flexContent && 'display: flex;'}
 `
 
 const TitleContainer = styled.div`
@@ -63,10 +66,13 @@ const Dialog = ({
   subtitle,
   content,
   hasManualPadding,
+  width,
+  flexContent,
   ...props
 }) => (
   <MuiDialog
     aria-labelledby="form-dialog-title"
+    fullScreen={!isWidthUp('md', width)}
     onClose={handleClose}
     onKeyUp={onKeyUp}
     open={open}
@@ -78,11 +84,11 @@ const Dialog = ({
     </StyledIconButton>
     <TitleContainer hasManualPadding={hasManualPadding}>{title && <Title title={title} />}</TitleContainer>
     {subtitle && <DialogSubtitle>{subtitle}</DialogSubtitle>}
-    <StyledDialogContent hasManualPadding={hasManualPadding}>
+    <StyledDialogContent flexContent={flexContent} hasManualPadding={hasManualPadding}>
       {typeof content == 'string' ? <DialogContentText>{content}</DialogContentText> : content}
     </StyledDialogContent>
     {dialogActions && <DialogActions style={{ margin: '12px' }}>{dialogActions}</DialogActions>}
   </MuiDialog>
 )
 
-export default Dialog
+export default withWidth()(Dialog)

--- a/console-frontend/src/shared/form-elements/checkbox.js
+++ b/console-frontend/src/shared/form-elements/checkbox.js
@@ -5,6 +5,7 @@ import { FormControlLabel, FormLabel, Checkbox as MuiCheckbox } from '@material-
 const StyledLabel = styled(FormLabel)`
   cursor: pointer;
   user-select: none;
+  line-height: inherit;
 `
 
 const Checkbox = ({ value, setValue, onChange, label, required, color, ...props }) => {


### PR DESCRIPTION
### Changes
- U2U affiliate partners page / user settings modals are responsive now.

### Minor
- Fixed `shared/button` width issues related to EventFirer component (when the button was disabled and had a `width` prop of `100%` it wasn't full-width);
- Changed the alignment of `terms and conditions` checkbox and label to the left side in brands modal (confirmed by DW);
- Changed the font-family from `Nunito` to `Lato` in Brands modal content;
- Line height of checkbox label was causing 1-2 pixels off on Y axis. Fixed it so that it's exactly in the middle of the container.