### PR TITLE
Fix mixpanel events in U2U: add brand

### DIFF
--- a/console-frontend/src/app/screens/affiliate-partners/brand-card/actions.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-card/actions.js
@@ -34,14 +34,21 @@ const StyledClipboardInput = styled(ClipboardInput)`
   }
 `
 
-const WebsiteButton = ({ affiliation, websiteHostname }) => {
-  const url = affiliation ? `https://${websiteHostname}/?aftk=${affiliation.token}` : `https://${websiteHostname}`
+const WebsiteButton = ({ affiliation, brand }) => {
+  const url = affiliation
+    ? `https://${brand.websiteHostname}/?aftk=${affiliation.token}`
+    : `https://${brand.websiteHostname}`
 
   const onClick = useCallback(
     () => {
-      mixpanel.track('Visited Brand Website', { hostname: window.location.hostname, url })
+      mixpanel.track('Visited Brand Website', {
+        hostname: window.location.hostname,
+        url,
+        brandId: brand.id,
+        brand: brand.name,
+      })
     },
-    [url]
+    [brand.id, brand.name, url]
   )
 
   return (
@@ -54,22 +61,34 @@ const WebsiteButton = ({ affiliation, websiteHostname }) => {
 }
 
 const Actions = ({ affiliation, brand, onClickCustomLink, openBrandModal }) => {
-  const onCopyAffiliateLink = useCallback(text => {
-    mixpanel.track('Copied Affiliate Link', { hostname: window.location.hostname, text })
-  }, [])
+  const onCopyAffiliateLink = useCallback(
+    text => {
+      mixpanel.track('Copied Affiliate Link', {
+        hostname: window.location.hostname,
+        text,
+        brandId: brand.id,
+        brand: brand.name,
+      })
+    },
+    [brand.id, brand.name]
+  )
 
   const onClickPromoteNow = useCallback(
     () => {
-      mixpanel.track('Clicked Promote Now', { hostname: window.location.hostname, brand: brand.name })
+      mixpanel.track('Clicked Promote Now', {
+        hostname: window.location.hostname,
+        brandId: brand.id,
+        brand: brand.name,
+      })
       openBrandModal()
     },
-    [brand.name, openBrandModal]
+    [brand.id, brand.name, openBrandModal]
   )
 
   return (
     <Container>
       <ButtonContainer>
-        <WebsiteButton affiliation={affiliation} websiteHostname={brand.websiteHostname} />
+        <WebsiteButton affiliation={affiliation} brand={brand} />
         {affiliation ? (
           <StyledClipboardInput
             backgroundColor="#e7ecef"

--- a/console-frontend/src/app/screens/affiliate-partners/brand-card/index.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-card/index.js
@@ -37,7 +37,11 @@ const BrandCard = ({
 }) => {
   const onClickCustomLink = useCallback(
     () => {
-      mixpanel.track('Clicked Custom Link', { hostname: window.location.hostname, brand: brand.name })
+      mixpanel.track('Clicked Custom Link', {
+        hostname: window.location.hostname,
+        brandId: brand.id,
+        brand: brand.name,
+      })
       setIsCustomLinkModalOpen(true)
       setSelectedBrand(brand)
     },
@@ -56,12 +60,13 @@ const BrandCard = ({
     () => {
       mixpanel.track('Clicked Brand Logo', {
         hostname: window.location.hostname,
+        brandId: brand.id,
         brand: brand.name,
         token: affiliation && affiliation.token,
       })
       openBrandModal()
     },
-    [affiliation, brand.name, openBrandModal]
+    [affiliation, brand.id, brand.name, openBrandModal]
   )
 
   return (

--- a/console-frontend/src/app/screens/affiliate-partners/brand-modal/footer.js
+++ b/console-frontend/src/app/screens/affiliate-partners/brand-modal/footer.js
@@ -109,7 +109,7 @@ const AffiliateTerms = styled.div`
   margin-top: 6px;
 `
 
-const SuccessScreen = ({ selectedAffiliation, removeAffiliation, isLoading }) => {
+const SuccessScreen = ({ brand, selectedAffiliation, removeAffiliation, isLoading }) => {
   const [showRemoveConfirmationAlert, setShowRemoveConfirmationAlert] = useState(false)
   const removeWarningTimeoutRef = useRef(null)
 
@@ -127,9 +127,17 @@ const SuccessScreen = ({ selectedAffiliation, removeAffiliation, isLoading }) =>
     [removeAffiliation, showRemoveConfirmationAlert]
   )
 
-  const onCopyAffiliateLink = useCallback(text => {
-    mixpanel.track('Copied Affiliate Link', { hostname: window.location.hostname, text })
-  }, [])
+  const onCopyAffiliateLink = useCallback(
+    text => {
+      mixpanel.track('Copied Affiliate Link', {
+        hostname: window.location.hostname,
+        text,
+        brandId: brand.id,
+        brand: brand.name,
+      })
+    },
+    [brand.id, brand.name]
+  )
 
   useEffect(() => () => clearTimeout(removeWarningTimeoutRef.current), [])
 
@@ -208,7 +216,11 @@ const Footer = ({
       setIsCreateLinkClicked(true)
       const { errors, requestError } = await createAffiliation(brand)
       if (!errors && !requestError) {
-        mixpanel.track('Created Affiliate Link', { hostname: window.location.hostname, brand: brand.name })
+        mixpanel.track('Created Affiliate Link', {
+          hostname: window.location.hostname,
+          brandId: brand.id,
+          brand: brand.name,
+        })
       }
       setIsCreateLinkClicked(false)
     },

--- a/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/footer.js
+++ b/console-frontend/src/app/screens/affiliate-partners/custom-link-modal/footer.js
@@ -48,9 +48,17 @@ const Footer = ({ affiliation }) => {
     [affiliation.id, affiliation.token, enqueueSnackbar]
   )
 
-  const onCopyCustomLink = useCallback(text => {
-    mixpanel.track('Copied Custom Link', { hostname: window.location.hostname, text })
-  }, [])
+  const onCopyCustomLink = useCallback(
+    text => {
+      mixpanel.track('Copied Custom Link', {
+        hostname: window.location.hostname,
+        text,
+        brandId: affiliation.brand.id,
+        brand: affiliation.brand.name,
+      })
+    },
+    [affiliation.brand.id, affiliation.brand.name]
+  )
 
   const mixFunction = useCallback(
     async text => {

--- a/console-frontend/src/app/screens/affiliate-partners/index.js
+++ b/console-frontend/src/app/screens/affiliate-partners/index.js
@@ -133,6 +133,7 @@ const AffiliatePartners = () => {
         if (!errors && !requestError) {
           mixpanel.track('Removed Affiliation', {
             hostname: window.location.hostname,
+            brandId: selectedAffiliation.brand.id,
             brand: selectedAffiliation.brand.name,
           })
           enqueueSnackbar(`Successfully removed affiliation with ${selectedBrand.name}`, { variant: 'success' })


### PR DESCRIPTION
### Changes
- Added `brand.id` to the mixpanel event params;
- Converted `brand` param to an object;
- Some cases were missing a `brand` info. Added it there;