### PR TITLE
U2U: Fix simple lists in iPhone

### DIFF
--- a/console-frontend/src/shared/table-elements/simple-list.js
+++ b/console-frontend/src/shared/table-elements/simple-list.js
@@ -20,6 +20,7 @@ const StyledTable = styled(props => <Table {...omit(props, ['sticky'])} />)`
 
 const StyledTableHead = styled(TableHead)`
   display: table;
+  width: 100%;
 `
 
 const StyledTableBody = styled(TableBody)`
@@ -100,11 +101,17 @@ const SimpleList = ({ columns, records, sticky, ...props }) => {
               <TableRowBody hover key={record.id || index} role="checkbox" tabIndex="-1">
                 {columns.map(column => {
                   const value = record[column.id]
-                  return value ? (
+                  return (
                     <StyledTableCell key={column.id} {...column}>
-                      {column.type === 'image' ? <Logo src={value} /> : <Typography variant="h6">{value}</Typography>}
+                      {value ? (
+                        column.type === 'image' ? (
+                          <Logo src={value} />
+                        ) : (
+                          <Typography variant="h6">{value}</Typography>
+                        )
+                      ) : null}
                     </StyledTableCell>
-                  ) : null
+                  )
                 })}
               </TableRowBody>
             ))}


### PR DESCRIPTION
[Link to Trello card](https://trello.com/c/65REnrdW)

## Changes

- In mobile, columns in table header are now aligned and not pushed to the left
- When a value is missing, an empty `td` is now rendering

## Preview

![image](https://user-images.githubusercontent.com/24722181/66324533-8ff48180-e91d-11e9-988b-afb02b9e4a8b.png)
