### PR TITLE
Use menus in actions on mobile

### DIFF
--- a/console-frontend/src/app/resources/triggers/form.js
+++ b/console-frontend/src/app/resources/triggers/form.js
@@ -115,7 +115,7 @@ const TriggerForm = ({ history, backRoute, location, title, loadFormObject, save
       if (!formRef.current.reportValidity()) return
       const result = await onFormSubmit(event)
       if (!result || result.error || result.errors) return
-      if (action === 'Save & New') {
+      if (action.label === 'Save & New') {
         location.pathname === routes.triggerCreate()
           ? refreshRoute(history, routes.triggerCreate())
           : history.push(routes.triggerCreate())

--- a/console-frontend/src/app/resources/triggers/list.js
+++ b/console-frontend/src/app/resources/triggers/list.js
@@ -1,6 +1,5 @@
 import auth from 'auth'
 import BlankStateTemplate from 'shared/blank-state'
-import Button from 'shared/button'
 import CircularProgress from 'shared/circular-progress'
 import isEqual from 'lodash.isequal'
 import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react'
@@ -8,9 +7,9 @@ import routes from 'app/routes'
 import TriggersListBase from './list-base'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
 import welcomeImage from 'assets/img/background/img-welcome.png'
-import { apiRequest, apiTriggerDestroy, apiTriggerList, apiTriggerSort, showUpToUsBranding } from 'utils'
+import { Actions } from 'shared/table-elements'
+import { apiRequest, apiTriggerDestroy, apiTriggerList, apiTriggerSort } from 'utils'
 import { arrayMove } from 'react-sortable-hoc'
-import { Link } from 'react-router-dom'
 import { matchUrl } from 'plugin-base'
 import { useOnboardingHelp } from 'ext/hooks/use-onboarding'
 import { useSnackbar } from 'notistack'
@@ -24,19 +23,6 @@ const BlankState = () => (
     route={routes.triggerCreate()}
     title="Create a new trigger"
   />
-)
-
-const Actions = () => (
-  <Button
-    color="primaryGradient"
-    component={Link}
-    inline
-    size={showUpToUsBranding() ? 'small' : 'medium'}
-    to={routes.triggerCreate()}
-    variant="contained"
-  >
-    {'Create New'}
-  </Button>
 )
 
 const iterateTriggers = (triggers, input, result) => {
@@ -75,7 +61,10 @@ const matchTriggers = (triggers, referenceUrl, hostnames) => {
   return result
 }
 
-const appBarContent = { Actions: <Actions />, title: 'Triggers' }
+const appBarContent = {
+  Actions: <Actions buttonText="Create New" createRoute={routes.triggerCreate()} />,
+  title: 'Triggers',
+}
 
 const TriggersList = ({ location }) => {
   const onboardingHelp = useMemo(

--- a/console-frontend/src/app/screens/account/index.js
+++ b/console-frontend/src/app/screens/account/index.js
@@ -1,29 +1,18 @@
 import auth from 'auth'
-import Button from 'shared/button'
 import EditWebsite from './edit-website'
 import React from 'react'
 import routes from 'app/routes'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
-import { Link } from 'react-router-dom'
-import { showUpToUsBranding } from 'utils'
+import { Actions } from 'shared/table-elements'
 import { UsersList } from './users'
 
-const Actions = () => {
-  return auth.isAdmin() || auth.getAccountRole() === 'owner' ? (
-    <Button
-      color="primaryGradient"
-      component={Link}
-      inline
-      size={showUpToUsBranding() ? 'small' : 'medium'}
-      to={routes.userInvite()}
-      variant="contained"
-    >
-      {'Invite User'}
-    </Button>
-  ) : null
+const appBarContent = {
+  Actions:
+    auth.isAdmin() || auth.getAccountRole() === 'owner' ? (
+      <Actions buttonText="Invite User" createRoute={routes.userInvite()} />
+    ) : null,
+  title: 'Account',
 }
-
-const appBarContent = { Actions: <Actions />, title: 'Account' }
 
 const Account = () => {
   useAppBarContent(appBarContent)

--- a/console-frontend/src/app/screens/revenues/index.js
+++ b/console-frontend/src/app/screens/revenues/index.js
@@ -1,14 +1,13 @@
 import auth from 'auth'
 import BlankState from './blank-state'
 import CircularProgress from 'shared/circular-progress'
-import DatePicker from 'shared/form-elements/date-picker'
 import Grid from '@material-ui/core/Grid'
 import omit from 'lodash.omit'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import SectionBase from 'shared/section'
 import styled from 'styled-components'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
-import { Activity, BrandsSplit, MonthlyRevenue, Orders } from './sections'
+import { Actions, Activity, BrandsSplit, MonthlyRevenue, Orders } from './sections'
 import { apiAffiliationsList, apiConnectStripe, apiOrdersList, apiRequest } from 'utils'
 import { Hidden } from '@material-ui/core'
 import { parse } from 'query-string'
@@ -78,12 +77,12 @@ const Revenues = ({ history }) => {
   const appBarContent = useMemo(
     () => ({
       Actions: affiliations.length > 0 && (
-        <DatePicker maxDate={maxDate} minDate={minDate} setDate={setDate} value={date} />
+        <Actions maxDate={maxDate} minDate={minDate} setDate={setDate} value={date} />
       ),
       sticky: false,
       title: 'Your Revenues',
     }),
-    [affiliations.length, date, maxDate, minDate]
+    [affiliations, date, maxDate, minDate]
   )
   useAppBarContent(appBarContent)
 

--- a/console-frontend/src/app/screens/revenues/sections/actions.js
+++ b/console-frontend/src/app/screens/revenues/sections/actions.js
@@ -1,0 +1,42 @@
+import DatePicker from 'shared/form-elements/date-picker'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import MoreVertIcon from '@material-ui/icons/MoreVert'
+import React, { useCallback, useState } from 'react'
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
+import { IconButton } from 'shared/form-elements'
+
+const Actions = ({ maxDate, minDate, setDate, value, width, disabled }) => {
+  const [anchorEl, setAnchorEl] = useState(null)
+
+  const handleClick = useCallback(
+    event => {
+      setAnchorEl(event.currentTarget)
+    },
+    [setAnchorEl]
+  )
+
+  const handleClose = useCallback(
+    () => {
+      setAnchorEl(null)
+    },
+    [setAnchorEl]
+  )
+
+  if (isWidthUp('sm', width)) return <DatePicker maxDate={maxDate} minDate={minDate} setDate={setDate} value={value} />
+
+  return (
+    <>
+      <IconButton aria-haspopup="true" aria-owns="actions-menu" disabled={disabled} onClick={handleClick}>
+        <MoreVertIcon />
+      </IconButton>
+      <Menu anchorEl={anchorEl} id="actions-menu" keepMounted onClose={handleClose} open={!!anchorEl}>
+        <MenuItem dense disableGutters onClick={handleClose}>
+          <DatePicker maxDate={maxDate} minDate={minDate} setDate={setDate} value={value} />
+        </MenuItem>
+      </Menu>
+    </>
+  )
+}
+
+export default withWidth()(Actions)

--- a/console-frontend/src/app/screens/revenues/sections/index.js
+++ b/console-frontend/src/app/screens/revenues/sections/index.js
@@ -1,7 +1,8 @@
+import Actions from './actions'
 import Activity from './activity'
 import BrandsSplit from './brands-split'
 import MonthlyRevenue from './monthly-revenue'
 import Orders from './orders'
 import StripeButton from './stripe-button'
 
-export { Activity, BrandsSplit, MonthlyRevenue, Orders, StripeButton }
+export { Activity, BrandsSplit, MonthlyRevenue, Orders, StripeButton, Actions }

--- a/console-frontend/src/shared/form-elements/actions.js
+++ b/console-frontend/src/shared/form-elements/actions.js
@@ -1,9 +1,10 @@
 import ActionsMenu from './simple-menu'
 import Button from 'shared/button'
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import SaveButton from './save-button'
 import styled from 'styled-components'
-import { Tooltip, withWidth } from '@material-ui/core'
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
+import { Tooltip } from '@material-ui/core'
 
 const Container = styled.div`
   display: flex;
@@ -39,8 +40,6 @@ const Action = ({ action, disabled, isFormPristine, onFormSubmit, isFormSubmitti
   )
 }
 
-const actions = [{ label: 'Save', color: 'primaryGradient' }, { label: 'Save & New', color: 'actions' }]
-
 const Actions = ({
   isFormSubmitting,
   isFormPristine,
@@ -60,20 +59,55 @@ const Actions = ({
   tooltipTextSubmit,
   tooltipText,
   width,
-}) => (
-  <>
-    {saveAndCreateNewEnabled ? (
-      width === 'sm' || width === 'xs' ? (
-        <ActionsMenu
-          actions={actions}
-          disabled={saveDisabled}
-          isFormPristine={isFormPristine}
-          isFormSubmitting={isFormSubmitting}
-          onFormSubmit={onFormSubmit}
-        />
-      ) : (
-        <Container>
-          {actions.map(action => (
+}) => {
+  const actions = useMemo(
+    () =>
+      [
+        saveAndCreateNewEnabled && {
+          label: 'Save & New',
+          color: 'actions',
+          disabled: saveDisabled,
+          onClick: onFormSubmit,
+        },
+        previewEnabled && { label: 'Preview', color: 'actions', onClick: onPreviewClick },
+        !rejectEnabled && {
+          label: message || 'Save',
+          color: 'primaryGradient',
+          disabled: saveDisabled,
+          onClick: onFormSubmit,
+        },
+        submitEnabled && {
+          label: 'Submit',
+          color: 'primaryGradient',
+          onClick: onSubmitClick,
+          disabled: !isFormPristine || isSubmitting,
+        },
+        rejectEnabled && { label: 'Reject', color: 'error', disabled: isRejecting, onClick: onRejectClick },
+      ].filter(item => item),
+    [
+      isFormPristine,
+      isRejecting,
+      isSubmitting,
+      message,
+      onFormSubmit,
+      onPreviewClick,
+      onRejectClick,
+      onSubmitClick,
+      previewEnabled,
+      rejectEnabled,
+      saveAndCreateNewEnabled,
+      saveDisabled,
+      submitEnabled,
+    ]
+  )
+
+  if (!isWidthUp('sm', width)) return <ActionsMenu actions={actions} disabled={isFormSubmitting} />
+
+  return (
+    <>
+      <Container>
+        {saveAndCreateNewEnabled &&
+          actions.map(action => (
             <Action
               action={action}
               disabled={saveDisabled}
@@ -85,10 +119,6 @@ const Actions = ({
               tooltipText={tooltipText}
             />
           ))}
-        </Container>
-      )
-    ) : (
-      <Container>
         {previewEnabled && (
           <FlexDiv>
             <Button color="actions" onClick={onPreviewClick}>
@@ -96,7 +126,7 @@ const Actions = ({
             </Button>
           </FlexDiv>
         )}
-        {!rejectEnabled && (
+        {!saveAndCreateNewEnabled && !rejectEnabled && (
           <FlexDiv>
             <SaveButton
               disabled={saveDisabled}
@@ -137,8 +167,8 @@ const Actions = ({
           </FlexDiv>
         )}
       </Container>
-    )}
-  </>
-)
+    </>
+  )
+}
 
 export default withWidth()(Actions)

--- a/console-frontend/src/shared/form-elements/date-picker.js
+++ b/console-frontend/src/shared/form-elements/date-picker.js
@@ -19,7 +19,7 @@ const StyledArrowDropDown = styled(ArrowDropDown)`
 `
 
 const DatePickerComponent = ({ onClick, value }) => (
-  <Button color={showUpToUsBranding() ? 'whiteBg' : 'white'} onClick={onClick} variant="contained">
+  <Button color={showUpToUsBranding() ? 'whiteBg' : 'white'} inline onClick={onClick} variant="contained">
     <DatePickerValue>{value}</DatePickerValue>
     <StyledArrowDropDown />
   </Button>

--- a/console-frontend/src/shared/form-elements/simple-menu.js
+++ b/console-frontend/src/shared/form-elements/simple-menu.js
@@ -1,46 +1,43 @@
-import Button from 'shared/button'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
+import MoreVertIcon from '@material-ui/icons/MoreVert'
 import React, { useCallback, useState } from 'react'
+import { IconButton } from 'shared/form-elements'
 
-const SimpleMenuItem = ({ action, handleClose }) => {
-  const onClick = useCallback(event => handleClose(event, action.label), [action.label, handleClose])
+const SimpleMenuItem = ({ action, handleClose, disabled }) => {
+  const onClick = useCallback(event => handleClose(event, action), [action, handleClose])
 
-  return <MenuItem onClick={onClick}>{action.label}</MenuItem>
+  return (
+    <MenuItem disabled={disabled} onClick={onClick}>
+      {action.label}
+    </MenuItem>
+  )
 }
 
-const SimpleMenu = ({ isFormPristine, isFormSubmitting, disabled, message, actions, onFormSubmit }) => {
+const SimpleMenu = ({ actions, disabled }) => {
   const [anchorEl, setAnchorEl] = useState(null)
 
   const closeMenu = useCallback(() => setAnchorEl(null), [])
-  const handleClose = useCallback(
-    (event, action) => {
-      setAnchorEl(null)
-      onFormSubmit(event, action)
-    },
-    [onFormSubmit]
-  )
+
+  const handleClose = useCallback((event, action) => {
+    event.persist()
+    setAnchorEl(null)
+    // setTimeout needed to trigger form validation
+    action.onClick && setTimeout(() => action.onClick(event, action), 0)
+  }, [])
   const handleClick = useCallback(event => setAnchorEl(event.currentTarget), [])
 
   return (
-    <div>
-      <Button
-        aria-haspopup="true"
-        aria-owns={anchorEl ? 'actions-menu' : undefined}
-        color="actions"
-        disabled={disabled}
-        isFormPristine={isFormPristine}
-        isFormSubmitting={isFormSubmitting}
-        onClick={handleClick}
-      >
-        {message || 'Select Action'}
-      </Button>
+    <>
+      <IconButton aria-haspopup="true" aria-owns="actions-menu" disabled={disabled} onClick={handleClick}>
+        <MoreVertIcon />
+      </IconButton>
       <Menu anchorEl={anchorEl} id="actions-menu" onClose={closeMenu} open={Boolean(anchorEl)}>
         {actions.map(action => (
-          <SimpleMenuItem action={handleClose} handleClose={handleClose} key={action.label} />
+          <SimpleMenuItem action={action} disabled={action.disabled} handleClose={handleClose} key={action.label} />
         ))}
       </Menu>
-    </div>
+    </>
   )
 }
 

--- a/console-frontend/src/shared/table-elements/actions.js
+++ b/console-frontend/src/shared/table-elements/actions.js
@@ -1,0 +1,59 @@
+import Button from 'shared/button'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import MoreVertIcon from '@material-ui/icons/MoreVert'
+import React, { useCallback, useState } from 'react'
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
+import { IconButton } from 'shared/form-elements'
+import { Link } from 'react-router-dom'
+import { showUpToUsBranding } from 'utils'
+
+const Actions = ({ buttonText, createRoute, width }) => {
+  const [anchorEl, setAnchorEl] = useState(null)
+
+  const handleClick = useCallback(
+    event => {
+      setAnchorEl(event.currentTarget)
+    },
+    [setAnchorEl]
+  )
+
+  const handleClose = useCallback(
+    () => {
+      setAnchorEl(null)
+    },
+    [setAnchorEl]
+  )
+
+  if (!createRoute) return null
+
+  if (isWidthUp('sm', width)) {
+    return (
+      <Button
+        color="primaryGradient"
+        component={Link}
+        inline
+        size={showUpToUsBranding() ? 'small' : 'medium'}
+        to={createRoute}
+        variant="contained"
+      >
+        {buttonText}
+      </Button>
+    )
+  }
+
+  return (
+    <>
+      <IconButton aria-haspopup="true" aria-owns="actions-menu" onClick={handleClick}>
+        <MoreVertIcon />
+      </IconButton>
+      <Menu anchorEl={anchorEl} id="actions-menu" keepMounted onClose={handleClose} open={!!anchorEl}>
+        <MenuItem component={Link} dense onClick={handleClose} to={createRoute}>
+          {buttonText}
+        </MenuItem>
+      </Menu>
+    </>
+  )
+}
+
+export default withWidth()(Actions)

--- a/console-frontend/src/shared/table-elements/enhanced-list.js
+++ b/console-frontend/src/shared/table-elements/enhanced-list.js
@@ -1,4 +1,3 @@
-import Button from 'shared/button'
 import CheckBoxIcon from '@material-ui/icons/CheckBox'
 import CircularProgress from 'app/layout/loading'
 import isEmpty from 'lodash.isempty'
@@ -7,28 +6,13 @@ import React, { useCallback, useEffect, useMemo, useReducer } from 'react'
 import Section from 'shared/section'
 import useAppBarContent from 'ext/hooks/use-app-bar-content'
 import useCancelable from 'ext/hooks/use-cancelable'
-import { apiRequest, showUpToUsBranding } from 'utils'
+import { Actions, TableCell, TableHead, TableRow, TableToolbar } from 'shared/table-elements'
+import { apiRequest } from 'utils'
 import { Checkbox, Table, TableBody } from '@material-ui/core'
-import { Link } from 'react-router-dom'
 import { parse } from 'query-string'
-import { TableCell, TableHead, TableRow, TableToolbar } from 'shared/table-elements'
 import { useOnboardingHelp } from 'ext/hooks/use-onboarding'
 import { useSnackbar } from 'notistack'
 import { withRouter } from 'react-router'
-
-const Actions = ({ buttonText, createRoute }) =>
-  createRoute && (
-    <Button
-      color="primaryGradient"
-      component={Link}
-      inline
-      size={showUpToUsBranding() ? 'small' : 'medium'}
-      to={createRoute}
-      variant="contained"
-    >
-      {buttonText}
-    </Button>
-  )
 
 const EnhancedList = ({
   api,

--- a/console-frontend/src/shared/table-elements/index.js
+++ b/console-frontend/src/shared/table-elements/index.js
@@ -1,3 +1,4 @@
+import Actions from './actions'
 import ActiveColumn from './active-column'
 import Avatar from './avatar'
 import columns from './columns'
@@ -12,6 +13,7 @@ import TableToolbar from './table-toolbar'
 import Text from './text'
 
 export {
+  Actions,
   ActiveColumn,
   Avatar,
   columns,


### PR DESCRIPTION
## Update: 
Use menus in top actions (forms and lists), in mobile. 

3 actions.js files: 
1) Added shared/table-elements/actions.js -> lists and Account page (frekkls)
2) Updated shared/form-elements/actions.js -> forms
3) Added screens/revenues/sections/actions.js -> revenues page (u2u)

[Link To Trello Card](https://trello.com/c/hrdUaF9f/1681-put-the-top-actions-behind-a-3-dot-button-menu-in-mobile)