### PR TITLE
Fix revenues tables alignement

### DIFF
--- a/console-frontend/src/app/screens/revenues/sections/brands-split.js
+++ b/console-frontend/src/app/screens/revenues/sections/brands-split.js
@@ -1,15 +1,22 @@
 import omit from 'lodash.omit'
 import React, { useMemo } from 'react'
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
 import { SimpleList } from 'shared/table-elements'
 
-const columns = [
-  { id: 'logoUrl', label: 'Brand', type: 'image', width: '10%' },
-  { id: 'name', label: '', width: '60%' },
-  { id: 'orders', label: 'Items', width: '15%', align: 'center' },
-  { id: 'revenue', label: 'Revenue', width: '15%', align: 'right', font: 'bold' },
-]
+const BrandsSplit = ({ orders, width }) => {
+  const columns = isWidthUp('sm', width)
+    ? [
+        { id: 'logoUrl', label: 'Brand', type: 'image', width: '10%' },
+        { id: 'name', label: '', width: '60%' },
+        { id: 'orders', label: 'Orders', width: '15%', align: 'right' },
+        { id: 'revenue', label: 'Revenue', width: '15%', align: 'right', font: 'bold' },
+      ]
+    : [
+        { id: 'logoUrl', label: 'Brand', type: 'image', width: '10%', align: 'left' },
+        { id: 'orders', label: 'Orders', width: '40%', align: 'right' },
+        { id: 'revenue', label: 'Revenue', width: '50%', align: 'right', font: 'bold' },
+      ]
 
-const BrandsSplit = ({ orders }) => {
   const brandsSplit = useMemo(
     () =>
       orders
@@ -40,4 +47,4 @@ const BrandsSplit = ({ orders }) => {
   return <SimpleList columns={columns} records={brandsSplit} />
 }
 
-export default BrandsSplit
+export default withWidth()(BrandsSplit)

--- a/console-frontend/src/app/screens/revenues/sections/orders.js
+++ b/console-frontend/src/app/screens/revenues/sections/orders.js
@@ -9,13 +9,13 @@ const Orders = ({ orders, width }) => {
     ? [
         { id: 'logoUrl', label: 'Brand', type: 'image', width: '10%' },
         { id: 'products', label: 'Products', width: '40%' },
-        { id: 'time', label: 'Date', width: '35%', align: 'center' },
+        { id: 'time', label: 'Date', width: '35%', align: 'right' },
         { id: 'revenue', label: 'Revenue', width: '15%', align: 'right', font: 'bold' },
       ]
     : [
         { id: 'logoUrl', label: 'Brand', type: 'image', width: '10%' },
-        { id: 'time', label: 'Date', width: '55%', align: 'center' },
-        { id: 'revenue', label: 'Revenue', width: '25%', align: 'right', font: 'bold' },
+        { id: 'time', label: 'Date', width: '40%', align: 'right' },
+        { id: 'revenue', label: 'Revenue', width: '50%', align: 'right', font: 'bold' },
       ]
 
   const filteredOrders = useMemo(

--- a/console-frontend/src/shared/table-elements/simple-list.js
+++ b/console-frontend/src/shared/table-elements/simple-list.js
@@ -13,13 +13,11 @@ const Wrapper = styled.div`
 const StyledTable = styled(props => <Table {...omit(props, ['sticky'])} />)`
   height: ${({ sticky }) => (sticky ? 'calc(100% - 56px)' : '100%')};
   width: 100%;
-  display: flex;
   flex-direction: column;
   flex: 1;
 `
 
 const StyledTableHead = styled(TableHead)`
-  display: table;
   width: 100%;
 `
 
@@ -37,7 +35,6 @@ const StyledTableCell = styled(TableCell)`
 
 const StyledTableRow = styled(TableRow)`
   width: 100%;
-  display: table;
 `
 
 const TableRowHead = styled(StyledTableRow)`


### PR DESCRIPTION
## Update:
- Fixed columns alignement in revenues page tables.

<img width="1392" alt="desktop" src="https://user-images.githubusercontent.com/35154956/66743113-1a366b80-ee71-11e9-8636-c287cdbcfe29.png">
<img width="283" alt="mobile" src="https://user-images.githubusercontent.com/35154956/66743116-1c98c580-ee71-11e9-973c-b06af981a15b.png">

[Link To Trello Card](https://trello.com/c/LOmqJ3hM/1716-u2u-change-design-of-revenues-tables)