### PR TITLE
U2U: disallow all actions if user didn't agree with terms and conditions

### DIFF
--- a/backend/app/controllers/api/v1/csrf_controller.rb
+++ b/backend/app/controllers/api/v1/csrf_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class CsrfController < RestAdminController
+      skip_before_action :ensure_terms
+
       def csrf_token
         render json: { token: form_authenticity_token, logged_in: current_user.present? }
       end

--- a/backend/app/controllers/api/v1/mes_controller.rb
+++ b/backend/app/controllers/api/v1/mes_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class MesController < RestAdminController
       before_action :authenticate_user!
+      skip_before_action :ensure_terms, only: %i[update]
 
       def show
         render json: current_user

--- a/backend/app/controllers/api/v1/rest_admin_controller.rb
+++ b/backend/app/controllers/api/v1/rest_admin_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class RestAdminController < RestController
       before_action :current_tenant
+      before_action :ensure_terms
       protect_from_forgery with: :exception, prepend: true
 
       private
@@ -9,6 +10,12 @@ module Api
       def current_tenant
         session_account = Account.find_by(slug: request.headers["X-Session-Account"])
         set_current_tenant(session_account)
+      end
+
+      def ensure_terms
+        return unless current_user
+
+        render status: :forbidden unless current_user.not_affiliate? || current_user.accepted_terms_and_conditions_at
       end
 
       def current_user_is_seller?


### PR DESCRIPTION
### Changes
- Made it so that the user will not be able to make requests (except `mes_controller#update` and `csrf_controller#csrf_token`) if `accepted_terms_and_conditions_at` is empty.