### PR TITLE
Fix auto-login

### DIFF
--- a/backend/app/controllers/api/v1/mes_controller.rb
+++ b/backend/app/controllers/api/v1/mes_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class MesController < RestAdminController
       before_action :authenticate_user!
-      skip_before_action :ensure_terms, only: %i[update]
+      skip_before_action :ensure_terms, only: %i[show update]
 
       def show
         render json: current_user

--- a/backend/app/controllers/api/v1/users/confirmations_controller.rb
+++ b/backend/app/controllers/api/v1/users/confirmations_controller.rb
@@ -12,6 +12,8 @@ module Api
         private
 
         def after_sign_in_path_for(user)
+          # base url should have a scheme in it (http or https) otherwise some browsers / OS won't redirect.
+          # if you have `localhost` in your ENV then change it to `http://localhost`.
           base_url = user.not_affiliate? ? ENV["FRONTEND_BASE_URL"] : ENV["UPTOUS_FRONTEND_BASE_URL"]
           user.errors.empty? ? "#{base_url}/#confirmed" : "#{base_url}/login#error"
         end


### PR DESCRIPTION
### Changes
- Fixed auto-login on confirmation in U2U by skipping a call to `ensure_terms` when calling `mes_controller#show`.